### PR TITLE
nocdev-12014: fix: AttributeError exception when using diff() for host with empty generation result

### DIFF
--- a/annet/gen.py
+++ b/annet/gen.py
@@ -704,7 +704,9 @@ def _old_new_get_config_files(ctx: OldNewDeviceContext, device: Device) -> Devic
             return old_files
         if ctx.config == "running":
             old_files_running = ctx.downloaded_files.get(device)
-            if old_files_running and old_files_running.is_empty():
+            if not old_files_running:
+                return old_files
+            if old_files_running.is_empty():
                 exc = (ctx.failed_files.get(device) or
                        Exception("I can't get device files and I don't know why"))
                 get_logger(host=device.hostname).error(str(exc))

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def requirements() -> str:
 if __name__ == "__main__":
     setuptools.setup(
         name="annet",
-        version="0.3",
+        version="0.4",
         description="annet",
         license="MIT",
         url="https://github.com/annetutil/annet",


### PR DESCRIPTION
ctx.downloaded_files will not contain `device` key If host have empty generation result(no files will be downloaded)