### PR TITLE
Return explicit generator API to show if device supported:  gen.supports_device()

### DIFF
--- a/annet/generators/__init__.py
+++ b/annet/generators/__init__.py
@@ -455,7 +455,7 @@ def run_file_generators(
 @tracing.function(min_duration="0.5")
 def _run_entire_generator(gen: "Entire", device: "Device", storage: Storage) -> Optional[GeneratorResult]:
     logger = get_logger(generator=_make_generator_ctx(gen))
-    if not gen.device_supported(device):
+    if not gen.supports_device(device):
         logger.info("generator %s is not supported for device %s", gen, device.hostname)
         return
 
@@ -494,7 +494,7 @@ def _run_json_fragment_generator(
         storage: Storage,
 ) -> Optional[GeneratorResult]:
     logger = get_logger(generator=_make_generator_ctx(gen))
-    if not gen.device_supported(device):
+    if not gen.supports_device(device):
         logger.info("generator %s is not supported for device %s", gen, device.hostname)
 
     path = gen.path(device)
@@ -797,7 +797,7 @@ class Entire(BaseGenerator):
             self.prio = 100
         self.__device = None
 
-    def device_supported(self, device: Device):
+    def supports_device(self, device: Device):
         return bool(self.path(device))
 
     def run(self, device) -> Union[None, str, Iterable[Union[str, tuple]]]:
@@ -917,7 +917,7 @@ class JSONFragment(TreeGenerator):
         if not hasattr(self, "reload_prio"):
             self.reload_prio = 100
 
-    def device_supported(self, device: Device):
+    def supports_device(self, device: Device):
         return bool(self.path(device))
 
     def path(self, device: Device) -> Optional[str]:

--- a/annet/generators/__init__.py
+++ b/annet/generators/__init__.py
@@ -464,7 +464,7 @@ def _run_entire_generator(gen: "Entire", device: "Device", storage: Storage) -> 
         tracing_connector.get().set_device_attributes(span, device)
         tracing_connector.get().set_dimensions_attributes(span, gen, device)
 
-    path = gen.device_supported(device)
+    path = gen.path(device)
     if not path:
         raise RuntimeError("entire generator should return non-empty path")
 


### PR DESCRIPTION
* explicit method for generator to advertise its compatibility with a device gen.supports_device()
* by default is implemented via the old Patrial.run()/Entire.path() semantics
* TODO: DeviceNotSupported should be replaced