### PR TITLE
Multiple storage providers support and storage refactoring

### DIFF
--- a/annet/adapters/netbox/common/models.py
+++ b/annet/adapters/netbox/common/models.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List, Optional, Any
+from typing import List, Optional, Any, Dict
 
 from annet.annlib.netdev.views.hardware import HardwareView
+from annet.storage import Storage
 
 
 @dataclass
@@ -61,6 +62,8 @@ class Interface(Entity):
 
 @dataclass
 class NetboxDevice(Entity):
+    url: str
+    storage: Storage
     neighbours_ids: List[int]
 
     display: str
@@ -79,7 +82,7 @@ class NetboxDevice(Entity):
     primary_ip4: Optional[DeviceIp]
     primary_ip6: Optional[DeviceIp]
     tags: List[Entity]
-    custom_fields: dict[str, Any]
+    custom_fields: Dict[str, Any]
     created: datetime
     last_updated: datetime
 
@@ -91,8 +94,12 @@ class NetboxDevice(Entity):
     interfaces: List[Interface]
 
     # compat
+
     def __hash__(self):
-        return hash(self.id)
+        return hash((self.id, type(self)))
+
+    def __eq__(self, other):
+        return type(self) is type(other) and self.url == other.url
 
     def is_pc(self):
         return self.device_type.manufacturer.name == "Mellanox"

--- a/annet/adapters/netbox/common/status_client.py
+++ b/annet/adapters/netbox/common/status_client.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Dict
 
 from adaptix import Retort, name_mapping, NameStyle
 from dataclass_rest import get
@@ -10,7 +11,7 @@ from .client import BaseNetboxClient
 @dataclass
 class Status:
     netbox_version: str
-    plugins: dict[str, str]
+    plugins: Dict[str, str]
 
 
 class NetboxStatusClient(BaseNetboxClient):

--- a/annet/adapters/netbox/v24/api_models.py
+++ b/annet/adapters/netbox/v24/api_models.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Optional, Any
+from typing import List, Optional, Any, Dict
 
 from annet.adapters.netbox.common.models import Entity, DeviceType
 
@@ -20,6 +20,7 @@ class DeviceIp:
 
 @dataclass
 class Device(Entity):
+    url: str
     display_name: str
     device_type: DeviceType
     device_role: Entity
@@ -36,7 +37,7 @@ class Device(Entity):
     primary_ip4: Optional[DeviceIp]
     primary_ip6: Optional[DeviceIp]
     tags: List[str]
-    custom_fields: dict[str, Any]
+    custom_fields: Dict[str, Any]
     created: datetime
     last_updated: datetime
 
@@ -61,7 +62,7 @@ class IpAddress:
     tenant: Any  # ???
     status: Label
     description: Optional[str]
-    custom_fields: dict[str, Any]
+    custom_fields: Dict[str, Any]
     tags: List[str]
     created: datetime
     last_updated: datetime

--- a/annet/adapters/netbox/v37/api_models.py
+++ b/annet/adapters/netbox/v37/api_models.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Optional, Any
+from typing import List, Optional, Any, Dict
 
 from annet.adapters.netbox.common.models import (
     Entity, Label, DeviceType, DeviceIp,
@@ -16,6 +16,7 @@ class Interface(Entity):
 
 @dataclass
 class Device(Entity):
+    url: str
     display: str  # renamed in 3.x from display_name
     device_type: DeviceType
     device_role: Entity
@@ -32,6 +33,6 @@ class Device(Entity):
     primary_ip4: Optional[DeviceIp]
     primary_ip6: Optional[DeviceIp]
     tags: List[Entity]
-    custom_fields: dict[str, Any]
+    custom_fields: Dict[str, Any]
     created: datetime
     last_updated: datetime

--- a/annet/api/__init__.py
+++ b/annet/api/__init__.py
@@ -655,6 +655,7 @@ def deploy(
     for res in pool.generated_configs(loader.devices):
         # Меняем exit code если хоть один device ловил exception
         if res.err is not None:
+            get_logger(res.device.hostname).error("error generating configs", exc_info=res.err)
             ret |= 2 ** 3
         job = DeployerJob.from_device(res.device, args)
         deployer.parse_result(job, res)

--- a/annet/cli.py
+++ b/annet/cli.py
@@ -4,20 +4,22 @@ import os
 import platform
 import subprocess
 import shutil
-from typing import Generator, Tuple
+from contextlib import ExitStack, contextmanager
+from typing import Tuple, Iterable
 
 import yaml
 from contextlog import get_logger
 from valkit.python import valid_logging_level
 
+from annet.deploy import driver_connector, fetcher_connector
 from annet import api, cli_args, filtering
-from annet.api import collapse_texts
+from annet.api import collapse_texts, Deployer
 from annet.argparse import ArgParser, subcommand
 from annet.diff import gen_sort_diff
 from annet.gen import Loader, old_raw
 from annet.lib import get_context_path, repair_context_file
-from annet.output import output_driver_connector
-from annet.storage import Storage, storage_connector
+from annet.output import output_driver_connector, OutputDriver
+from annet.storage import storage_connector
 
 
 def fill_base_args(parser: ArgParser, pkg_name: str, logging_config: str):
@@ -31,65 +33,91 @@ def list_subcommands():
     return globals().copy()
 
 
+def _gen_current_items(
+        config,
+        stdin,
+        loader: Loader,
+        output_driver: OutputDriver,
+        gen_args: cli_args.GenOptions,
+) -> Iterable[Tuple[str, str, bool]]:
+    for device, result in old_raw(
+        args=gen_args,
+        loader=loader,
+        config=config,
+        stdin=stdin,
+        do_files_download=True,
+        use_mesh=False,
+    ):
+        if device.hw.vendor != "pc":
+            destname = output_driver.cfg_file_names(device)[0]
+            yield (destname, result, False)
+        else:
+            for entire_path, entire_data in sorted(result.items(), key=operator.itemgetter(0)):
+                if entire_data is None:
+                    entire_data = ""
+                destname = output_driver.entire_config_dest_path(device, entire_path)
+                yield (destname, entire_data, False)
+
+
+@contextmanager
+def get_loader(gen_args: cli_args.GenOptions, args: cli_args.QueryOptions):
+    exit_stack = ExitStack()
+    connectors = storage_connector.get_all()
+    storages = []
+    with exit_stack:
+        for connector in connectors:
+            storage_opts = connector.opts().from_cli_opts(args)
+            storages.append(exit_stack.enter_context(connector.storage()(storage_opts)))
+        yield Loader(*storages, args=gen_args)
+
+
 @subcommand(cli_args.QueryOptions, cli_args.opt_config, cli_args.FileOutOptions)
 def show_current(args: cli_args.QueryOptions, config, arg_out: cli_args.FileOutOptions) -> None:
     """ Показать текущий конфиг устройств """
-
-    def _gen_items(storage: Storage) -> Generator[Tuple[str, str, bool], None, None]:
-        for device, result in old_raw(
-            cli_args.GenOptions(args, no_acl=True),
-            storage,
-            config,
-            stdin=args.stdin(storage=storage, config=config),
-            do_files_download=True,
-            use_mesh=False,
-        ):
-            output_driver = output_driver_connector.get()
-            destname = output_driver.cfg_file_names(device)[0]
-            if device.hw.vendor != "pc":
-                yield (destname, result, False)
-            else:
-                for entire_path, entire_data in sorted(result.items(), key=operator.itemgetter(0)):
-                    if entire_data is None:
-                        entire_data = ""
-                    yield (output_driver.entire_config_dest_path(device, entire_path), entire_data, False)
-
-    connector = storage_connector.get()
-    storage_opts = connector.opts().from_cli_opts(args)
-    with connector.storage()(storage_opts) as storage:
-        ids = storage.resolve_object_ids_by_query(args.query)
-        if not ids:
+    gen_args = cli_args.GenOptions(args, no_acl=True)
+    output_driver = output_driver_connector.get()
+    with get_loader(gen_args, args) as loader:
+        if not loader.devices:
             get_logger().error("No devices found for %s", args.query)
-        output_driver_connector.get().write_output(arg_out, _gen_items(storage), len(ids))
+
+        items = _gen_current_items(
+            loader=loader,
+            output_driver=output_driver,
+            gen_args=gen_args,
+            stdin=args.stdin(config=config),
+            config=config,
+        )
+        output_driver.write_output(arg_out, items, len(loader.devices))
 
 
 @subcommand(cli_args.ShowGenOptions)
 def gen(args: cli_args.ShowGenOptions):
     """ Сгенерировать конфиг для устройств """
-    (success, fail) = api.gen(args)
-    out = [item for items in success.values() for item in items]
-    output_driver = output_driver_connector.get()
-    if args.dest is None:
-        text_mapping = {item[0]: item[1] for item in out}
-        out = [(",".join(key), value, False) for key, value in collapse_texts(text_mapping).items()]
-    out.extend(output_driver.format_fails(fail, args))
-    total = len(success) + len(fail)
-    if not total:
-        get_logger().error("No devices found for %s", args.query)
-    output_driver.write_output(args, out, total)
+    with get_loader(args, args) as loader:
+        (success, fail) = api.gen(args, loader)
+
+        out = [item for items in success.values() for item in items]
+        output_driver = output_driver_connector.get()
+        if args.dest is None:
+            text_mapping = {item[0]: item[1] for item in out}
+            out = [(",".join(key), value, False) for key, value in collapse_texts(text_mapping).items()]
+
+        out.extend(output_driver.format_fails(fail, loader.device_fqdns))
+        total = len(success) + len(fail)
+        if not total:
+            get_logger().error("No devices found for %s", args.query)
+        output_driver.write_output(args, out, total)
 
 
 @subcommand(cli_args.ShowDiffOptions)
 def diff(args: cli_args.ShowDiffOptions):
     """ Сгенерировать конфиг для устройств и показать дифф по рулбуку с текущим """
-    connector = storage_connector.get()
-    storage_opts = connector.opts().from_cli_opts(args)
-    with connector.storage()(storage_opts) as storage:
+    with get_loader(args, args) as loader:
         filterer = filtering.filterer_connector.get()
-        loader = Loader(storage, args)
+        device_ids = loader.device_ids
         output_driver_connector.get().write_output(
             args,
-            gen_sort_diff(api.diff(args, loader, filterer), args),
+            gen_sort_diff(api.diff(args, loader, device_ids, filterer), args),
             len(loader.device_ids)
         )
 
@@ -97,20 +125,33 @@ def diff(args: cli_args.ShowDiffOptions):
 @subcommand(cli_args.ShowPatchOptions)
 def patch(args: cli_args.ShowPatchOptions):
     """ Сгенерировать конфиг для устройств и сформировать патч """
-    (success, fail) = api.patch(args)
-    out = [item for items in success.values() for item in items]
-    output_driver = output_driver_connector.get()
-    out.extend(output_driver.format_fails(fail, args))
-    total = len(success) + len(fail)
-    if not total:
-        get_logger().error("No devices found for %s", args.query)
-    output_driver.write_output(args, out, total)
+    with get_loader(args, args) as loader:
+        (success, fail) = api.patch(args, loader)
+
+        out = [item for items in success.values() for item in items]
+        output_driver = output_driver_connector.get()
+        out.extend(output_driver.format_fails(fail, loader.device_fqdns))
+        total = len(success) + len(fail)
+        if not total:
+            get_logger().error("No devices found for %s", args.query)
+        output_driver.write_output(args, out, total)
 
 
 @subcommand(cli_args.DeployOptions)
 def deploy(args: cli_args.DeployOptions):
     """ Сгенерировать конфиг для устройств и задеплоить его """
-    return api.deploy(args)
+
+    deployer = Deployer(args)
+    filterer = filtering.filterer_connector.get()
+    fetcher = fetcher_connector.get()
+    deploy_driver = driver_connector.get()
+
+    with get_loader(args, args) as loader:
+        return api.deploy(
+            args=args, loader=loader, deployer=deployer,
+            deploy_driver=deploy_driver, filterer=filterer,
+            fetcher=fetcher,
+        )
 
 
 @subcommand(cli_args.FileDiffOptions)

--- a/annet/connectors.py
+++ b/annet/connectors.py
@@ -2,8 +2,7 @@ import sys
 from abc import ABC
 from functools import cached_property
 from importlib.metadata import entry_points
-from typing import Generic, Optional, Type, TypeVar
-
+from typing import Generic, Optional, Type, TypeVar, List
 
 T = TypeVar("T")
 
@@ -12,29 +11,46 @@ class Connector(ABC, Generic[T]):
     name: str
     ep_name: str
     ep_group: str = "annet.connectors"
-    _cls: Optional[Type[T]] = None
+    _classes: Optional[List[Type[T]]] = None
 
     def _get_default(self) -> Type[T]:
         raise RuntimeError(f"{self.name} is not set")
 
     @cached_property
-    def _entry_point(self) -> Optional[Type[T]]:
+    def _entry_point(self) -> List[Type[T]]:
         return load_entry_point(self.ep_group, self.ep_name)
 
     def get(self, *args, **kwargs) -> T:
-        if self._cls is not None:
-            res = self._cls
-        else:
-            res = self._entry_point or self._get_default()
+        if self._classes is None:
+            self._classes = self._entry_point or [self._get_default()]
+        if len(self._classes) > 1:
+            raise RuntimeError(
+                f"Multiple classes are registered with the same "
+                f"group={self.ep_group} and name={self.ep_name}: "
+                f"{[cls for cls in self._classes]}",
+            )
+
+        res = self._classes[0]
         return res(*args, **kwargs)
 
+    def get_all(self, *args, **kwargs) -> T:
+        if self._classes is None:
+            self._classes = self._entry_point or [self._get_default()]
+
+        return [cls(*args, **kwargs) for cls in self._classes]
+
     def set(self, cls: Type[T]):
-        if self._cls is not None:
+        if self._classes is not None:
             raise RuntimeError(f"Cannot reinitialize value of {self.name}")
-        self._cls = cls
+        self._classes = [cls]
+
+    def set_all(self, classes: List[Type[T]]):
+        if self._classes is not None:
+            raise RuntimeError(f"Cannot reinitialize value of {self.name}")
+        self._classes = list(classes)
 
     def is_default(self) -> bool:
-        return self._cls is self._entry_point is None
+        return self._classes is self._entry_point is None
 
 
 class CachedConnector(Connector[T], ABC):
@@ -58,7 +74,4 @@ def load_entry_point(group: str, name: str):
         ep = entry_points(group=group, name=name)  # pylint: disable=unexpected-keyword-arg
     if not ep:
         return None
-    if len(ep) > 1:
-        raise RuntimeError(f"Multiple entry points with the same {group=} and {name=}: {[item.value for item in ep]}")
-    for item in ep:
-        return item.load()
+    return [item.load() for item in ep]

--- a/annet/gen.py
+++ b/annet/gen.py
@@ -378,7 +378,7 @@ def old_new(
     do_files_download=False,
     do_print_perf=True,
 ):
-    devices = loader.resolve_devices(device_ids)
+    devices = loader.devices
     gens = loader.resolve_gens(devices)
     running, failed_running = _old_resolve_running(config, devices)
     downloaded_files, failed_files = _old_resolve_files(config, devices, gens, do_files_download)
@@ -857,13 +857,6 @@ class Loader:
         if self._devices_map:
             return list(self._devices_map.values())
         return []
-
-    def resolve_devices(self, device_ids: Iterable[int]) -> List[Device]:
-        devices = []
-        for device_id in device_ids:
-            device = self._devices_map[device_id]
-            devices.append(device)
-        return devices
 
     def resolve_gens(self, devices: Iterable[Device]) -> DeviceGenerators:
         if self._gens is not None:

--- a/annet/gen.py
+++ b/annet/gen.py
@@ -39,6 +39,7 @@ from annet.generators import (
     JSONFragment,
     NotSupportedDevice,
     PartialGenerator,
+    RefGenerator,
 )
 from annet.lib import merge_dicts, percentile
 from annet.output import output_driver_connector
@@ -60,13 +61,16 @@ class DeviceGenerators:
     """Collections of various types of generators found for devices."""
 
     # map device fqdn to found partial generators
-    partial: Dict[str, List[PartialGenerator]] = dataclasses.field(default_factory=dict)
+    partial: Dict[Any, List[PartialGenerator]] = dataclasses.field(default_factory=dict)
+
+    # ref generators
+    ref: Dict[Any, List[RefGenerator]] = dataclasses.field(default_factory=dict)
 
     # map device fqdn to found entire generators
-    entire: Dict[str, List[Entire]] = dataclasses.field(default_factory=dict)
+    entire: Dict[Any, List[Entire]] = dataclasses.field(default_factory=dict)
 
     # map device fqdn to found json fragment generators
-    json_fragment: Dict[str, List[JSONFragment]] = dataclasses.field(default_factory=dict)
+    json_fragment: Dict[Any, List[JSONFragment]] = dataclasses.field(default_factory=dict)
 
     def iter_gens(self) -> Iterator[BaseGenerator]:
         """Iterate over generators."""
@@ -75,19 +79,24 @@ class DeviceGenerators:
                 for gen in gen_list:
                     yield gen
 
-    def file_gens(self, device_fqdn: str) -> Iterator[Union[Entire, JSONFragment]]:
+    def file_gens(self, device: Any) -> Iterator[Union[Entire, JSONFragment]]:
         """Iterate over generators that generate files or file parts."""
         yield from itertools.chain(
-            self.entire.get(device_fqdn, []),
-            self.json_fragment.get(device_fqdn, []),
+            self.entire.get(device, []),
+            self.json_fragment.get(device, []),
         )
+
+    def update(self, other: "DeviceGenerators") -> None:
+        self.partial.update(other.partial)
+        self.ref.update(other.ref)
+        self.entire.update(other.entire)
+        self.json_fragment.update(other.json_fragment)
 
 
 @dataclasses.dataclass
 class OldNewDeviceContext:
     config: str
     args: GenOptions
-    storage: Storage
     downloaded_files: Dict[Device, DeviceDownloadedFiles]
     failed_files: Dict[Device, Exception]
     running: Dict[Device, Dict[str, str]]
@@ -143,21 +152,24 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
                 splitter=tabparser.make_formatter(device.hw).split,
             )
         if not old:
-            res = generators.run_partial_initial(device, ctx.storage)
+            res = generators.run_partial_initial(device)
             old = res.config_tree()
             perf = res.perf_mesures()
             if ctx.args.profile and ctx.do_print_perf:
                 _print_perf("INITIAL", perf)
         run_args = generators.GeneratorPartialRunArgs(
             device=device,
-            storage=ctx.storage,
             use_acl=not ctx.args.no_acl,
             use_acl_safe=ctx.args.acl_safe,
             annotate=ctx.add_annotations,
             generators_context=ctx.args.generators_context,
             no_new=ctx.no_new,
         )
-        res = generators.run_partial_generators(ctx.gens.partial[device.fqdn], run_args)
+        res = generators.run_partial_generators(
+            ctx.gens.partial[device],
+            ctx.gens.ref[device],
+            run_args,
+        )
         partial_results = res.partial_results
         perf = res.perf_mesures()
         if ctx.no_new:
@@ -227,9 +239,8 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
                     get_logger(host=device.hostname).error(error_msg)
                     return OldNewResult(device=device, err=Exception(error_msg))
         res = generators.run_file_generators(
-            ctx.gens.file_gens(device.fqdn),
+            ctx.gens.file_gens(device),
             device,
-            ctx.storage,
         )
 
         entire_results = res.entire_results
@@ -325,7 +336,7 @@ def split_downloaded_files(
     """Split downloaded files per generator type: entire/json_fragment."""
     ret = DeviceDownloadedFiles()
 
-    for gen in gens.file_gens(device.fqdn):
+    for gen in gens.file_gens(device):
         filepath = gen.path(device)
         if filepath in device_flat_files:
             if isinstance(gen, Entire):
@@ -356,7 +367,6 @@ def split_downloaded_files_multi_device(
 @tracing.function
 def old_new(
     args: GenOptions,
-    storage: Storage,
     config: str,
     loader: "Loader",
     filterer: Filterer,
@@ -368,13 +378,13 @@ def old_new(
     do_files_download=False,
     do_print_perf=True,
 ):
-    devices = loader.resolve_devices(storage, device_ids)
-    gens = loader.resolve_gens(storage, devices)
+    devices = loader.resolve_devices(device_ids)
+    gens = loader.resolve_gens(devices)
     running, failed_running = _old_resolve_running(config, devices)
     downloaded_files, failed_files = _old_resolve_files(config, devices, gens, do_files_download)
 
     if stdin is None:
-        stdin = args.stdin(storage=storage, filter_acl=args.filter_acl, config=config)
+        stdin = args.stdin(filter_acl=args.filter_acl, config=config)
 
     fetched_packages, failed_packages = {}, {}
     if do_files_download and config == "running":
@@ -386,7 +396,6 @@ def old_new(
     ctx = OldNewDeviceContext(
         config=config,
         args=args,
-        storage=storage,
         downloaded_files=split_downloaded_files_multi_device(downloaded_files, gens, devices),
         failed_files=failed_files,
         running=running,
@@ -414,26 +423,25 @@ def old_new(
 
 
 @tracing.function
-def old_raw(args: GenOptions, storage, config, stdin=None,
-            do_files_download=False, use_mesh=True,
-            ) -> Iterable[Tuple[Device, Union[str, Dict[str, str]]]]:
-    devices = storage.make_devices(args.query, preload_neighbors=True, use_mesh=use_mesh)
-    device_gens = _old_resolve_gens(args, storage, devices)
-    running, failed_running = _old_resolve_running(config, devices)
-    downloaded_files, failed_files = _old_resolve_files(config, devices, device_gens, do_files_download)
+def old_raw(
+        args: GenOptions, loader: Loader, config, stdin=None,
+        do_files_download=False, use_mesh=True,
+) -> Iterable[Tuple[Device, Union[str, Dict[str, str]]]]:
+    device_gens = loader.resolve_gens(loader.devices)
+    running, failed_running = _old_resolve_running(config, loader.devices)
+    downloaded_files, failed_files = _old_resolve_files(config, loader.devices, device_gens, do_files_download)
     if stdin is None:
-        stdin = args.stdin(storage=storage, filter_acl=args.filter_acl, config=config)
+        stdin = args.stdin(filter_acl=args.filter_acl, config=config)
     ctx = OldNewDeviceContext(
         config=config,
         args=args,
-        storage=storage,
-        downloaded_files=split_downloaded_files_multi_device(downloaded_files, device_gens, devices),
+        downloaded_files=split_downloaded_files_multi_device(downloaded_files, device_gens, loader.devices),
         failed_files=failed_files,
         running=running,
         failed_running=failed_running,
         stdin=stdin,
         do_files_download=do_files_download,
-        device_count=len(devices),
+        device_count=len(loader.devices),
         no_new=True,
         add_annotations=False,
         add_implicit=False,
@@ -442,7 +450,7 @@ def old_raw(args: GenOptions, storage, config, stdin=None,
         failed_packages={},
         do_print_perf=True,
     )
-    for device in devices:
+    for device in loader.devices:
         if not device.is_pc():
             config = _old_new_get_config_cli(ctx, device)
             config = scrub_config(config, device.breed)
@@ -464,68 +472,59 @@ def worker(device_id, args: ShowGenOptions, stdin, loader: "Loader", filterer: F
     if span:
         span.set_attribute("device.id", device_id)
 
-    connector = storage_connector.get()
-    storage_opts = connector.opts().from_cli_opts(args)
-    with connector.storage()(storage_opts) as storage:
-        for res in old_new(
-            args,
-            storage,
-            config="/dev/null",
-            loader=loader,
-            filterer=filterer,
-            add_implicit=False,
-            add_annotations=args.annotate,
-            stdin=stdin,
-            device_ids=[device_id],
-        ):
-            new = res.get_new(args.acl_safe)
-            new_files = res.get_new_files(args.acl_safe)
-            new_file_fragments = res.get_new_file_fragments(args.acl_safe)
-            output_driver = output_driver_connector.get()
-            device = res.device
-            if new is None:
-                continue
-            for (entire_path, (entire_data, _)) in sorted(new_files.items(), key=itemgetter(0)):
-                yield (output_driver.entire_config_dest_path(device, entire_path), entire_data, False)
+    for res in old_new(
+        args,
+        config="/dev/null",
+        loader=loader,
+        filterer=filterer,
+        add_implicit=False,
+        add_annotations=args.annotate,
+        stdin=stdin,
+        device_ids=[device_id],
+    ):
+        new = res.get_new(args.acl_safe)
+        new_files = res.get_new_files(args.acl_safe)
+        new_file_fragments = res.get_new_file_fragments(args.acl_safe)
+        output_driver = output_driver_connector.get()
+        device = res.device
+        if new is None:
+            continue
+        for (entire_path, (entire_data, _)) in sorted(new_files.items(), key=itemgetter(0)):
+            yield (output_driver.entire_config_dest_path(device, entire_path), entire_data, False)
 
-            for (path, (data, _)) in sorted(new_file_fragments.items(), key=itemgetter(0)):
-                dumped_data = json.dumps(data, indent=4, sort_keys=True, ensure_ascii=False)
-                yield (output_driver.entire_config_dest_path(device, path), dumped_data, False)
+        for (path, (data, _)) in sorted(new_file_fragments.items(), key=itemgetter(0)):
+            dumped_data = json.dumps(data, indent=4, sort_keys=True, ensure_ascii=False)
+            yield (output_driver.entire_config_dest_path(device, path), dumped_data, False)
 
-            has_file_result = new_files or new_file_fragments
-            has_partial_result = new or not has_file_result
-            if device.hw.vendor in platform.VENDOR_REVERSES and has_partial_result:
-                orderer = patching.Orderer.from_hw(device.hw)
-                yield (output_driver.cfg_file_names(device)[0],
-                       format_config_blocks(
-                           orderer.order_config(new),
-                           device.hw,
-                           args.indent
-                       ),
-                       False)
+        has_file_result = new_files or new_file_fragments
+        has_partial_result = new or not has_file_result
+        if device.hw.vendor in platform.VENDOR_REVERSES and has_partial_result:
+            orderer = patching.Orderer.from_hw(device.hw)
+            yield (output_driver.cfg_file_names(device)[0],
+                   format_config_blocks(
+                       orderer.order_config(new),
+                       device.hw,
+                       args.indent
+                   ),
+                   False)
 
 
 def old_new_worker(device_id, args: DeployOptions, config, stdin, loader: "Loader", filterer: Filterer):
-    connector = storage_connector.get()
-    storage_opts = connector.opts().from_cli_opts(args)
-    with connector.storage()(storage_opts) as storage:
-        yield from old_new(
-            args,
-            storage,
-            config=config,
-            loader=loader,
-            filterer=filterer,
-            stdin=stdin,
-            device_ids=[device_id],
-            no_new=args.clear,
-            do_files_download=True,
-        )
+    yield from old_new(
+        args,
+        config=config,
+        loader=loader,
+        filterer=filterer,
+        stdin=stdin,
+        device_ids=[device_id],
+        no_new=args.clear,
+        do_files_download=True,
+    )
 
 
 class OldNewParallel(Parallel):
-    def __init__(self, storage: Storage, args: DeployOptions, loader: "Loader", filterer: Filterer):
-        self.storage = storage
-        stdin = args.stdin(storage=storage, filter_acl=args.filter_acl, config=args.config)
+    def __init__(self, args: DeployOptions, loader: "Loader", filterer: Filterer):
+        stdin = args.stdin(filter_acl=args.filter_acl, config=args.config)
         super().__init__(
             old_new_worker,
             args,
@@ -536,20 +535,19 @@ class OldNewParallel(Parallel):
         )
         self.tune_args(args)
 
-    def generated_configs(self, device_ids: List[int]) -> Generator[OldNewResult, None, None]:
-        skipped = set(device_ids)
+    def generated_configs(self, devices: List[Device]) -> Generator[OldNewResult, None, None]:
+        devices_by_id = {device.id: device for device in devices}
+        device_ids = list(devices_by_id)
 
         for task_result in self.irun(device_ids):
             if task_result.exc is not None:
-                device = self.storage.get_device(task_result.device_id, use_mesh=False, preload_neighbors=False)
+                device = devices_by_id.pop(task_result.device_id)
                 yield OldNewResult(device=device, err=task_result.exc)
-                skipped.discard(task_result.device_id)
             elif task_result.result is not None:
                 yield from task_result.result
-                skipped.discard(task_result.device_id)
+                devices_by_id.pop(task_result.device_id)
 
-        for device_id in skipped:
-            device = self.storage.get_device(device_id, use_mesh=False, preload_neighbors=False)
+        for device in devices_by_id.values():
             yield OldNewResult(device=device, err=Exception(f"No config returned for {device.hostname}"))
 
 
@@ -565,7 +563,7 @@ def _get_files_to_download(devices: List[Device], gens: DeviceGenerators) -> Dic
     for device in devices:
         paths = set()
         try:
-            for generator in gens.file_gens(device.fqdn):
+            for generator in gens.file_gens(device):
                 try:
                     path = generator.path(device)
                     if path:
@@ -714,6 +712,8 @@ def _old_new_get_config_cli(ctx: OldNewDeviceContext, device: Device) -> str:
             raise exc
     elif ctx.config == "-":
         text = ctx.stdin["config"]
+        if ctx.device_count > 1:
+            raise ValueError("stdin config can not be used with multiple devices")
     else:
         if os.path.isdir(ctx.config):
             filename = _existing_cfg_file_name(ctx.config, device)
@@ -767,13 +767,15 @@ def _old_new_get_config_files(ctx: OldNewDeviceContext, device: Device) -> Devic
 
 
 @tracing.function
-def _old_resolve_gens(args: GenOptions, storage: Storage, devices: List[Device]) -> DeviceGenerators:
+def _old_resolve_gens(args: GenOptions, storage: Storage, devices: Iterable[Device]) -> DeviceGenerators:
     per_device_gens = DeviceGenerators()
+    devices = devices or [None]  # get all generators if no devices provided
     for device in devices:
         gens = generators.build_generators(storage, gens=args, device=device)
-        per_device_gens.partial[device.fqdn] = gens.partial
-        per_device_gens.entire[device.fqdn] = gens.entire
-        per_device_gens.json_fragment[device.fqdn] = gens.json_fragment
+        per_device_gens.partial[device] = gens.partial
+        per_device_gens.entire[device] = gens.entire
+        per_device_gens.json_fragment[device] = gens.json_fragment
+        per_device_gens.ref[device] = gens.ref
     return per_device_gens
 
 
@@ -809,37 +811,46 @@ def _old_resolve_files(config: str,
 
 
 class Loader:
-    def __init__(self, storage: Storage, args: GenOptions, no_empty_warning: bool = False) -> None:
+    def __init__(
+            self, *storages: Storage,
+            args: GenOptions,
+            no_empty_warning: bool = False,
+    ) -> None:
         self._args = args
-        self._storage = storage
+        self._storages = storages
         self._no_empty_warning = no_empty_warning
-        self._devices_map: Optional[Dict[int, Device]] = None
-        self._gens: Optional[DeviceGenerators] = None
+        self._devices_map: Dict[int, Device] = {}
+        self._gens: DeviceGenerators = DeviceGenerators()
+        self._counter = itertools.count()
 
         self._preload()
 
     def _preload(self) -> None:
         with tracing_connector.get().start_as_current_span("Resolve devices"):
-            devices = self._storage.make_devices(
-                self._args.query,
-                preload_neighbors=True,
-                use_mesh=not self._args.no_mesh,
-                preload_extra_fields=True,
-            )
+            for storage in self._storages:
+                devices = storage.make_devices(
+                    self._args.query,
+                    preload_neighbors=True,
+                    use_mesh=not self._args.no_mesh,
+                    preload_extra_fields=True,
+                )
+                for device in devices:
+                    self._devices_map[next(self._counter)] = device
+                self._gens.update(_old_resolve_gens(self._args, storage, devices))
         if not devices and not self._no_empty_warning:
             get_logger().error("No devices found for %s", self._args.query)
             return
 
-        self._devices_map = {d.id: d for d in devices}
-        self._gens = _old_resolve_gens(self._args, self._storage, devices)
-
     @property
     def device_fqdns(self):
-        return {d.id: d.fqdn for d in self._devices_map.values()} if self._devices_map else {}
+        return {
+            device_id: d.fqdn
+            for device_id, d in self._devices_map.items()
+        }
 
     @property
     def device_ids(self):
-        return list(self.device_fqdns)
+        return list(self._devices_map)
 
     @property
     def devices(self) -> List[Device]:
@@ -847,23 +858,16 @@ class Loader:
             return list(self._devices_map.values())
         return []
 
-    def resolve_devices(self, storage: Storage, device_ids: Iterable[int]) -> List[Device]:
+    def resolve_devices(self, device_ids: Iterable[int]) -> List[Device]:
         devices = []
         for device_id in device_ids:
             device = self._devices_map[device_id]
-
-            # can not use self._storage here, we can be in another process
-            device.storage = storage
-
             devices.append(device)
         return devices
 
-    def resolve_gens(self, storage: Storage, devices: Iterable[Device]) -> DeviceGenerators:
+    def resolve_gens(self, devices: Iterable[Device]) -> DeviceGenerators:
         if self._gens is not None:
-            for gen in self._gens.iter_gens():
-                # can not use self._storage here, we can be in another process
-                gen.storage = storage
             return self._gens
 
         with tracing_connector.get().start_as_current_span("Resolve gens"):
-            return _old_resolve_gens(self._args, storage, devices)
+            return _old_resolve_gens(self._args, self._storage, devices)

--- a/annet/generators/__init__.py
+++ b/annet/generators/__init__.py
@@ -1,219 +1,51 @@
 from __future__ import annotations
 
-import abc
-import contextlib
 import dataclasses
 import importlib
 import os
-import pkgutil
-import re
 import textwrap
-import time
-import types
 from collections import OrderedDict as odict
 from typing import (
-    Any,
-    Callable,
-    Dict,
     FrozenSet,
     Iterable,
     List,
     Optional,
-    Set,
-    Tuple,
     Union,
 )
 
-from annet.annlib import jsontools
 from annet.annlib.rbparser.acl import compile_acl_text
 from contextlog import get_logger
 
-from annet.storage import Device, Storage
+from annet.storage import Device
 
 from annet import patching, tabparser, tracing
 from annet.cli_args import GenSelectOptions, ShowGeneratorsOptions
 from annet.lib import (
-    add_annotation,
-    flatten,
     get_context,
-    jinja_render,
-    mako_render,
-    merge_dicts,
 )
-from annet.reference import RefMatcher, RefTracker
 from annet.tracing import tracing_connector
 from annet.types import (
     GeneratorEntireResult,
     GeneratorJSONFragmentResult,
     GeneratorPartialResult,
     GeneratorPartialRunArgs,
-    GeneratorPerf,
     GeneratorResult,
 )
-
+from .base import (
+    BaseGenerator,
+    TextGenerator as TextGenerator,
+    ParamsList as ParamsList,
+)
+from .exceptions import NotSupportedDevice, GeneratorError
+from .jsonfragment import JSONFragment
+from .partial import PartialGenerator
+from .entire import Entire
+from .ref import RefGenerator
+from .perf import GeneratorPerfMesurer
+from .result import RunGeneratorResult
 
 # =====
 DISABLED_TAG = "disable"
-
-
-# =====
-class GeneratorError(Exception):
-    pass
-
-
-class NotSupportedDevice(GeneratorError):
-    pass
-
-
-class DefaultBlockIfCondition:
-    pass
-
-
-class GeneratorPerfMesurer:
-    def __init__(
-        self,
-        gen: Union["PartialGenerator", "Entire"],
-        storage: Storage,
-        run_args: Optional[GeneratorPartialRunArgs] = None,
-        trace_min_duration: tracing.MinDurationT = None
-    ):
-        self._gen = gen
-        self._storage = storage
-        self._run_args = run_args
-
-        self._start_time: float = 0.0
-        self._span_ctx = None
-        self._span = None
-        self._trace_min_duration = trace_min_duration
-
-        self.last_result: Optional[GeneratorPerf] = None
-
-    def start(self) -> None:
-        self.last_result = None
-
-        self._storage.flush_perf()
-
-        self._span_ctx = tracing_connector.get().start_as_current_span(
-            "gen:call",
-            tracer_name=self._gen.__class__.__module__,
-            min_duration=self._trace_min_duration,
-        )
-        self._span = self._span_ctx.__enter__()  # pylint: disable=unnecessary-dunder-call
-
-        if self._span:
-            self._span.set_attributes({"generator.class": self._gen.__class__.__name__})
-            if self._run_args:
-                tracing_connector.get().set_device_attributes(self._span, self._run_args.device)
-
-        self._start_time = time.monotonic()
-
-    def finish(self, exc_type=None, exc_val=None, exc_tb=None) -> GeneratorPerf:
-        total = time.monotonic() - self._start_time
-        rt = self._storage.flush_perf()
-        self._span_ctx.__exit__(exc_type, exc_val, exc_tb)
-
-        meta = {}
-        if tracing_connector.get().enabled:
-            span_context = self._span.get_span_context()
-            meta = {
-                "span": {
-                    "trace_id": str(span_context.trace_id),
-                    "span_id": str(span_context.span_id),
-                }
-            }
-
-        self.last_result = GeneratorPerf(total=total, rt=rt, meta=meta)
-        return self.last_result
-
-    def __enter__(self):
-        self.start()
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.finish(exc_type, exc_val, exc_tb)
-
-
-class RunGeneratorResult:
-    """
-    Результат запуска run_partial_generators/run_file_generators
-    """
-
-    def __init__(self):
-        self.partial_results: Dict[str, GeneratorPartialResult] = {}
-        self.entire_results: Dict[str, GeneratorEntireResult] = {}
-        self.json_fragment_results: Dict[str, GeneratorJSONFragmentResult] = {}
-        self.ref_track: RefTracker = RefTracker()
-        self.ref_matcher: RefMatcher = RefMatcher()
-
-    def add_partial(self, result: GeneratorPartialResult):
-        self.partial_results[result.name] = result
-
-    def add_entire(self, result: GeneratorEntireResult) -> None:
-        # Если есть несколько генераторов на один файл, выбрать тот, что с большим приоритетом
-        if result.path:
-            if result.path not in self.entire_results or result.prio > self.entire_results[result.path].prio:
-                self.entire_results[result.path] = result
-
-    def add_json_fragment(self, result: GeneratorJSONFragmentResult) -> None:
-        self.json_fragment_results[result.name] = result
-
-    def config_tree(self, safe: bool = False) -> Dict[str, Any]:  # OrderedDict
-        tree = odict()
-        for gr in self.partial_results.values():
-            config = gr.safe_config if safe else gr.config
-            tree = merge_dicts(tree, config)
-        return tree
-
-    def new_files(self, safe: bool = False) -> Dict[str, Tuple[str, str]]:
-        files = {}
-        for gr in self.entire_results.values():
-            if not safe or gr.is_safe:
-                files[gr.path] = (gr.output, gr.reload)
-        return files
-
-    def acl_text(self) -> str:
-        return _combine_acl_text(self.partial_results, lambda gr: gr.acl)
-
-    def acl_safe_text(self) -> str:
-        return _combine_acl_text(self.partial_results, lambda gr: gr.acl_safe)
-
-    def new_json_fragment_files(
-            self,
-            old_files: Dict[str, Optional[str]],
-            safe: bool = False,
-    ) -> Dict[str, Tuple[Any, Optional[str]]]:
-        files: Dict[str, Tuple[Any, Optional[str]]] = {}
-        reload_prios: Dict[str, int] = {}
-        for generator_result in self.json_fragment_results.values():
-            filepath = generator_result.path
-            if filepath not in files:
-                if old_files.get(filepath) is not None:
-                    files[filepath] = (old_files[filepath], None)
-                else:
-                    files[filepath] = ({}, None)
-            previous_config: Dict[str, Any] = files[filepath][0]
-            new_fragment = generator_result.config
-
-            if safe:
-                new_config = jsontools.apply_json_fragment(previous_config, new_fragment, generator_result.acl_safe)
-            else:
-                new_config = jsontools.apply_json_fragment(previous_config, new_fragment, generator_result.acl)
-
-            if filepath in reload_prios and reload_prios[filepath] > generator_result.reload_prio:
-                _, reload_cmd = files[filepath]
-            else:
-                reload_cmd = generator_result.reload
-                reload_prios[filepath] = generator_result.reload_prio
-            files[filepath] = (new_config, reload_cmd)
-        return files
-
-    def perf_mesures(self) -> Dict[str, Dict[str, int]]:
-        mesures = {}
-        for gr in self.partial_results.values():
-            mesures[gr.name] = {"total": gr.perf.total, "rt": gr.perf.rt, "meta": gr.perf.meta}
-        for gr in self.entire_results.values():
-            mesures[gr.name] = {"total": gr.perf.total, "rt": gr.perf.rt, "meta": gr.perf.meta}
-        return mesures
 
 
 # =====
@@ -257,6 +89,7 @@ class Generators:
 
     partial: List[PartialGenerator] = dataclasses.field(default_factory=list)
     entire: List[Entire] = dataclasses.field(default_factory=list)
+    ref: List[RefGenerator] = dataclasses.field(default_factory=list)
     json_fragment: List[JSONFragment] = dataclasses.field(default_factory=list)
 
 
@@ -265,35 +98,46 @@ def build_generators(storage, gens: GenSelectOptions, device: Optional[Device] =
     if gens.generators_context is not None:
         os.environ["ANN_GENERATORS_CONTEXT"] = gens.generators_context
     all_generators = _get_generators(get_context()["generators"], storage, device)
+    ref_generators = _get_ref_generators(get_context()["generators"], storage, device)
     validate_genselect(gens, all_generators)
     classes = list(select_generators(gens, all_generators))
     partial = [obj for obj in classes if obj.TYPE == "PARTIAL"]
     entire = [obj for obj in classes if obj.TYPE == "ENTIRE"]
     entire = list(sorted(entire, key=lambda x: x.prio, reverse=True))
     json_fragment = [obj for obj in classes if obj.TYPE == "JSON_FRAGMENT"]
-    return Generators(partial=partial, entire=entire, json_fragment=json_fragment)
+    return Generators(
+        partial=partial,
+        entire=entire,
+        json_fragment=json_fragment,
+        ref=ref_generators,
+    )
 
 
 @tracing.function
-def run_partial_initial(device, storage):
+def run_partial_initial(device):
     from .common.initial import InitialConfig
 
     tracing_connector.get().set_device_attributes(tracing_connector.get().get_current_span(), device)
 
-    run_args = GeneratorPartialRunArgs(device, storage)
-    return run_partial_generators([InitialConfig()], run_args)
+    run_args = GeneratorPartialRunArgs(device)
+    return run_partial_generators([InitialConfig(storage=device.storage)], [], run_args)
 
 
 @tracing.function
-def run_partial_generators(gens: List["PartialGenerator"], run_args: GeneratorPartialRunArgs):
+def run_partial_generators(
+        gens: List["PartialGenerator"],
+        ref_gens: List["RefGenerator"],
+        run_args: GeneratorPartialRunArgs,
+):
     logger = get_logger(host=run_args.device.hostname)
     tracing_connector.get().set_device_attributes(tracing_connector.get().get_current_span(), run_args.device)
 
     ret = RunGeneratorResult()
     if run_args.generators_context is not None:
         os.environ["ANN_GENERATORS_CONTEXT"] = run_args.generators_context
-    for gen in _get_ref_generators(get_context()["generators"], run_args.storage):
-        ret.ref_matcher.add(gen.ref(run_args.device), gen.__class__)
+
+    for gen in ref_gens:
+        ret.ref_matcher.add(gen.ref(run_args.device), gen)
 
     logger.debug("Generating selected PARTIALs ...")
 
@@ -310,9 +154,9 @@ def run_partial_generators(gens: List["PartialGenerator"], run_args: GeneratorPa
         config = result.safe_config if run_args.use_acl_safe else result.config
 
         ref_match = ret.ref_matcher.match(config)
-        for gen_cls, groups in ref_match:
-            gens.append(gen_cls(run_args.storage, groups))
-            ret.ref_track.add(gen.__class__, gen_cls)
+        for ref_gen, groups in ref_match:
+            gens.append(ref_gen.with_groups(groups))
+            ret.ref_track.add(gen.__class__, ref_gen.__class__)
 
         ret.ref_track.config(gen.__class__, config)
         ret.add_partial(result)
@@ -342,7 +186,7 @@ def _run_partial_generator(gen: "PartialGenerator", run_args: GeneratorPartialRu
             "generators_context": str(run_args.generators_context),
         })
 
-    with GeneratorPerfMesurer(gen, run_args.storage, run_args=run_args) as pm:
+    with GeneratorPerfMesurer(gen, run_args=run_args) as pm:
         if not run_args.no_new:
             if gen.get_user_runner(device):
                 logger.info("Generating PARTIAL ...")
@@ -430,7 +274,6 @@ def check_entire_generators_required_packages(gens, device_packages: FrozenSet[s
 def run_file_generators(
         gens: Iterable[Union["JSONFragment", "Entire"]],
         device: "Device",
-        storage: Storage,
 ) -> RunGeneratorResult:
     """Run generators that generate files or file parts."""
     ret = RunGeneratorResult()
@@ -446,7 +289,7 @@ def run_file_generators(
         else:
             raise RuntimeError(f"Unknown generator class type: cls={gen.__class__} TYPE={gen.__class__.TYPE}")
         try:
-            result = run_generator_fn(gen, device, storage)
+            result = run_generator_fn(gen, device)
         except NotSupportedDevice as exc:
             logger.info("generator %s raised unsupported error: %r", gen, exc)
             continue
@@ -457,7 +300,7 @@ def run_file_generators(
 
 
 @tracing.function(min_duration="0.5")
-def _run_entire_generator(gen: "Entire", device: "Device", storage: Storage) -> Optional[GeneratorResult]:
+def _run_entire_generator(gen: "Entire", device: "Device") -> Optional[GeneratorResult]:
     logger = get_logger(generator=_make_generator_ctx(gen))
     if not gen.supports_device(device):
         logger.info("generator %s is not supported for device %s", gen, device.hostname)
@@ -473,7 +316,7 @@ def _run_entire_generator(gen: "Entire", device: "Device", storage: Storage) -> 
         raise RuntimeError("entire generator should return non-empty path")
 
     logger.info("Generating ENTIRE ...")
-    with GeneratorPerfMesurer(gen, storage, trace_min_duration="0.5") as pm:
+    with GeneratorPerfMesurer(gen, trace_min_duration="0.5") as pm:
         output = gen(device)
 
     return GeneratorEntireResult(
@@ -495,7 +338,6 @@ def _make_generator_ctx(gen):
 def _run_json_fragment_generator(
         gen: "JSONFragment",
         device: "Device",
-        storage: Storage,
 ) -> Optional[GeneratorResult]:
     logger = get_logger(generator=_make_generator_ctx(gen))
     if not gen.supports_device(device):
@@ -520,7 +362,7 @@ def _run_json_fragment_generator(
         acl_safe = [safe_acl_item_or_list_of_items]
 
     logger.info("Generating JSON_FRAGMENT ...")
-    with GeneratorPerfMesurer(gen, storage) as pm:
+    with GeneratorPerfMesurer(gen) as pm:
         config = gen(device)
     reload_cmds = gen.get_reload_cmds(device)
     return GeneratorJSONFragmentResult(
@@ -559,7 +401,7 @@ def _get_generators(module_paths: Union[List[str], dict], storage, device=None):
     return res_generators
 
 
-def _get_ref_generators(module_paths: List[str], storage):
+def _get_ref_generators(module_paths: List[str], storage, device):
     if isinstance(module_paths, dict):
         module_paths = module_paths.get("default")
     res_generators = []
@@ -568,302 +410,6 @@ def _get_ref_generators(module_paths: List[str], storage):
         if hasattr(module, "get_ref_generators"):
             res_generators += module.get_ref_generators(storage)
     return res_generators
-
-
-class InvalidValueFromGenerator(ValueError):
-    pass
-
-
-class GenStringable(abc.ABC):
-    @abc.abstractmethod
-    def gen_str(self) -> str:
-        pass
-
-
-ParamsList = tabparser.JuniperList
-
-
-def _filter_str(value: Union[str, int, float, tabparser.JuniperList, ParamsList, GenStringable]):
-    if isinstance(value, (
-        str,
-        int,
-        float,
-        tabparser.JuniperList,
-        ParamsList,
-    )):
-        return str(value)
-
-    if hasattr(value, "gen_str") and callable(value.gen_str):
-        return value.gen_str()
-
-    raise InvalidValueFromGenerator("Invalid yield type: %s(%s)" % (type(value).__name__, value))
-
-
-# =====
-class BaseGenerator:
-    TYPE: str
-    TAGS: list[str]
-
-    def supports_device(self, device: Device) -> bool:  # pylint: disable=unused-argument
-        return True
-
-
-class TreeGenerator(BaseGenerator):
-    def __init__(self, indent="  "):
-        self._indents = []
-        self._rows = []
-        self._block_path = []
-        self._indent = indent
-
-    @tracing.contextmanager(min_duration="0.1")
-    @contextlib.contextmanager
-    def block(self, *tokens, indent=None):
-        span = tracing_connector.get().get_current_span()
-        if span:
-            span.set_attribute("tokens", " ".join(map(str, tokens)))
-
-        indent = self._indent if indent is None else indent
-        block = " ".join(map(_filter_str, tokens))
-        self._block_path.append(block)
-        self._append_text(block)
-        self._indents.append(indent)
-        yield
-        self._indents.pop(-1)
-        self._block_path.pop(-1)
-
-    @contextlib.contextmanager
-    def block_if(self, *tokens, condition=DefaultBlockIfCondition):
-        if condition is DefaultBlockIfCondition:
-            condition = (None not in tokens and "" not in tokens)
-        if condition:
-            with self.block(*tokens):
-                yield
-                return
-        yield
-
-    @contextlib.contextmanager
-    def multiblock(self, *blocks):
-        if blocks:
-            blk = blocks[0]
-            tokens = blk if isinstance(blk, (list, tuple)) else [blk]
-            with self.block(*tokens):
-                with self.multiblock(*blocks[1:]):
-                    yield
-                    return
-        yield
-
-    @contextlib.contextmanager
-    def multiblock_if(self, *blocks, condition=DefaultBlockIfCondition):
-        if condition is DefaultBlockIfCondition:
-            condition = (None not in blocks)
-            if condition:
-                if blocks:
-                    blk = blocks[0]
-                    tokens = blk if isinstance(blk, (list, tuple)) else [blk]
-                    with self.block(*tokens):
-                        with self.multiblock(*blocks[1:]):
-                            yield
-                            return
-        yield
-
-    # ===
-    def _append_text(self, text):
-        self._append_text_cb(text)
-
-    def _append_text_cb(self, text, row_cb=None):
-        for row in _split_and_strip(text):
-            if row_cb:
-                row = row_cb(row)
-            self._rows.append("".join(self._indents) + row)
-
-
-class TextGenerator(TreeGenerator):
-    def __add__(self, line):
-        self._append_text(line)
-        return self
-
-    def __iter__(self):
-        yield from self._rows
-
-
-class PartialGenerator(TreeGenerator):
-    TYPE = "PARTIAL"
-    TAGS: List[str] = []
-
-    def __init__(self, storage):
-        super().__init__()
-        self.storage = storage
-        self._annotate = False
-        self._running_gen = None
-        self._annotations = []
-        self._annotation_module = self.__class__.__module__ or ""
-
-    def supports_device(self, device: Device) -> bool:
-        if self.__class__.run is PartialGenerator.run:
-            return bool(self._get_vendor_func(device.hw.vendor, "run"))
-        else:
-            return True
-
-    def acl(self, device):
-        acl_func = self._get_vendor_func(device.hw.vendor, "acl")
-        if acl_func:
-            return acl_func(device)
-
-    def acl_safe(self, device):
-        acl_func = self._get_vendor_func(device.hw.vendor, "acl_safe")
-        if acl_func:
-            return acl_func(device)
-
-    def run(self, device) -> Iterable[Union[str, tuple]]:
-        run_func = self._get_vendor_func(device.hw.vendor, "run")
-        if run_func:
-            return run_func(device)
-
-    def get_user_runner(self, device):
-        if self.__class__.run is not PartialGenerator.run:
-            return self.run
-        return self._get_vendor_func(device.hw.vendor, "run")
-
-    def _get_vendor_func(self, vendor: str, func_name: str):
-        attr_name = f"{func_name}_{vendor}"
-        if hasattr(self, attr_name):
-            return getattr(self, attr_name)
-        return None
-
-    # =====
-
-    @classmethod
-    def get_aliases(cls) -> Set[str]:
-        return {cls.__name__, *cls.TAGS}
-
-    def __call__(self, device, annotate=False):
-        self._indents = []
-        self._rows = []
-        self._running_gen = self.run(device)
-        self._annotate = annotate
-
-        if annotate and self.__class__.__module__:
-            self._annotation_module = ".".join(self.__class__.__module__.split(".")[-2:])
-
-        for text in self._running_gen:
-            if isinstance(text, tuple):
-                text = " ".join(map(_filter_str, flatten(text)))
-            else:
-                text = _filter_str(text)
-            self._append_text(text)
-
-        for row in self._rows:
-            assert re.search(r"\bNone\b", row) is None, "Found 'None' in yield result: %s" % (row)
-        if annotate:
-            generated_rows = (add_annotation(x, y) for (x, y) in zip(self._rows, self._annotations))
-        else:
-            generated_rows = self._rows
-        return "\n".join(generated_rows) + "\n"
-
-    def _append_text(self, text):
-        def annotation_cb(row):
-            annotation = "%s:%d" % self.get_running_line()
-            self._annotations.append(annotation)
-            return row
-
-        self._append_text_cb(
-            text,
-            annotation_cb if self._annotate else None
-        )
-
-    def get_running_line(self):
-        if not self._running_gen or not self._running_gen.gi_frame:
-            return (repr(self._running_gen), -1)
-        return self._annotation_module, self._running_gen.gi_frame.f_lineno
-
-    @classmethod
-    def literal(cls, item):
-        return '"{}"'.format(item)
-
-    def __repr__(self):
-        return "<%s>" % self.__class__.__name__
-
-
-class RefGenerator(PartialGenerator):
-    def __init__(self, storage, groups=None):
-        super().__init__(storage)
-        self.groups = groups
-
-    def ref(self, device):
-        if hasattr(self, "ref_" + device.hw.vendor):
-            return getattr(self, "ref_" + device.hw.vendor)(device)
-        return ""
-
-
-class Entire(BaseGenerator):
-    TYPE = "ENTIRE"
-    TAGS: List[str] = []
-    REQUIRED_PACKAGES: FrozenSet[str] = frozenset()
-
-    def __init__(self, storage):
-        self.storage = storage
-        # между генераторами для одного и того же path - выбирается тот что больше
-        if not hasattr(self, "prio"):
-            self.prio = 100
-        self.__device = None
-
-    def supports_device(self, device: Device):
-        return bool(self.path(device))
-
-    def run(self, device) -> Union[None, str, Iterable[Union[str, tuple]]]:
-        raise NotImplementedError
-
-    def reload(self, device) -> Optional[str]:  # pylint: disable=unused-argument
-        return
-
-    def get_reload_cmds(self, device) -> str:
-        ret = self.reload(device) or ""
-        path = self.path(device)
-        if path and device.hw.PC and device.hw.soft.startswith(("Cumulus", "SwitchDev", "SONiC")):
-            parts = []
-            if ret:
-                parts.append(ret)
-            parts.append("/usr/bin/etckeeper commitreload %s" % path)
-            return "\n".join(parts)
-        return ret
-
-    def path(self, device) -> Optional[str]:
-        raise NotImplementedError("Required PATH for ENTIRE generator")
-
-    # pylint: disable=unused-argument
-    def is_safe(self, device) -> bool:
-        """Output gen results when --acl-safe flag is used"""
-        return False
-
-    def read(self, path) -> str:
-        return pkgutil.get_data(__name__, path).decode()
-
-    def mako(self, text, **kwargs) -> str:
-        return mako_render(text, dedent=True, device=self.__device, **kwargs)
-
-    def jinja(self, text, **kwargs) -> str:
-        return jinja_render(text, dedent=True, device=self.__device, **kwargs)
-
-    # =====
-
-    @classmethod
-    def get_aliases(cls) -> Set[str]:
-        return {cls.__name__, *cls.TAGS}
-
-    def __call__(self, device):
-        self.__device = device
-        parts = []
-        run_res = self.run(device)
-        if isinstance(run_res, str):
-            run_res = (run_res,)
-        if run_res is None or not isinstance(run_res, (tuple, types.GeneratorType)):
-            raise Exception("generator %s returns %s" % (self.__class__.__name__, type(run_res)))
-        for text in run_res:
-            if isinstance(text, tuple):
-                text = " ".join(map(_filter_str, flatten(text)))
-            assert re.search(r"\bNone\b", text) is None, "Found 'None' in yield result: %s" % text
-            parts.append(text)
-        return "\n".join(parts)
 
 
 def select_generators(gens: GenSelectOptions, classes: Iterable[BaseGenerator]):
@@ -887,135 +433,3 @@ def select_generators(gens: GenSelectOptions, classes: Iterable[BaseGenerator]):
         flts.append(lambda c: not contains(c, gens.excluded_gens))
 
     return filter(lambda x: all(f(x) for f in flts), classes)
-
-
-def _split_and_strip(text):
-    if "\n" in text:
-        rows = textwrap.dedent(text).strip().split("\n")
-    else:
-        rows = [text]
-    return rows
-
-
-def _combine_acl_text(
-    partial_results: Dict[str, GeneratorPartialResult],
-    acl_getter: Callable[[GeneratorPartialResult], str]
-) -> str:
-    acl_text = ""
-    for gr in partial_results.values():
-        for line in textwrap.dedent(acl_getter(gr)).split("\n"):
-            if line and not line.isspace():
-                acl_text += line.rstrip()
-                acl_text += fr"  %generator_names={gr.name}"
-                acl_text += "\n"
-    return acl_text
-
-
-class JSONFragment(TreeGenerator):
-    """Generates parts of JSON config file."""
-
-    TYPE = "JSON_FRAGMENT"
-    TAGS: List[str] = []
-
-    def __init__(self, storage: Storage):
-        super().__init__()
-        self.storage = storage
-        self._json_config: Dict[str, Any] = {}
-        self._config_pointer: List[str] = []
-
-        # if two generators edit same file, commands from generator with greater `reload_prio` will be used
-        if not hasattr(self, "reload_prio"):
-            self.reload_prio = 100
-
-    def supports_device(self, device: Device):
-        return bool(self.path(device))
-
-    def path(self, device: Device) -> Optional[str]:
-        raise NotImplementedError("Required PATH for JSON_FRAGMENT generator")
-
-    @classmethod
-    def get_aliases(cls) -> Set[str]:
-        return {cls.__name__, *cls.TAGS}
-
-    def acl(self, device: Device) -> Union[str, List[str]]:
-        """
-        Restrict the generator to a specified ACL using JSON Pointer syntax.
-
-        Expected ACL to be a list of strings, but a single string is also allowed.
-        """
-        raise NotImplementedError("Required ACL for JSON_FRAGMENT generator")
-
-    def acl_safe(self, device: Device) -> Union[str, List[str]]:
-        """
-        Restrict the generator to a specified safe ACL using JSON Pointer syntax.
-
-        Expected ACL to be a list of strings, but a single string is also allowed.
-        """
-        raise NotImplementedError("Required ACL for JSON_FRAGMENT generator")
-
-    def run(self, device: Device):
-        raise NotImplementedError
-
-    def get_reload_cmds(self, device: Device) -> str:
-        ret = self.reload(device) or ""
-        return ret
-
-    def reload(self, device) -> Optional[str]:
-        raise NotImplementedError
-
-    @contextlib.contextmanager
-    def block(self, *tokens, indent=None):  # pylint: disable=unused-argument
-        block_str = "".join(map(_filter_str, tokens))
-        self._config_pointer.append(block_str)
-        try:
-            yield
-        finally:
-            self._config_pointer.pop()
-
-    @contextlib.contextmanager
-    def block_piped(self, *tokens, indent=None):  # pylint: disable=unused-argument
-        block_str = "|".join(map(_filter_str, tokens))
-        self._config_pointer.append(block_str)
-        try:
-            yield
-        finally:
-            self._config_pointer.pop()
-
-    def __call__(self, device: Device, annotate: bool = False):
-        for cfg_fragment in self.run(device):
-            self._set_or_replace_dict(self._config_pointer, cfg_fragment)
-        return self._json_config
-
-    def _set_or_replace_dict(self, pointer, value):
-        if not pointer:
-            if self._json_config == {}:
-                self._json_config = value
-            else:
-                self._json_config = [self._json_config, value]
-        else:
-            self._set_dict(self._json_config, pointer, value)
-
-    @classmethod
-    def _to_str(cls, value: Any) -> str:
-        if isinstance(value, str):
-            return value
-        elif isinstance(value, list):
-            return [cls._to_str(x) for x in value]
-        elif isinstance(value, dict):
-            for k, v in value.items():
-                value[k] = cls._to_str(v)
-            return value
-        return str(value)
-
-    @classmethod
-    def _set_dict(cls, cfg, pointer, value):
-        # pointer has at least one key
-        if len(pointer) == 1:
-            if pointer[0] in cfg:
-                cfg[pointer[0]] = [cfg[pointer[0]], cls._to_str(value)]
-            else:
-                cfg[pointer[0]] = cls._to_str(value)
-        else:
-            if pointer[0] not in cfg:
-                cfg[pointer[0]] = {}
-            cls._set_dict(cfg[pointer[0]], pointer[1:], cls._to_str(value))

--- a/annet/generators/base.py
+++ b/annet/generators/base.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import abc
+import contextlib
+import textwrap
+from typing import Union, List
+
+from annet import tabparser, tracing
+from annet.tracing import tracing_connector
+from .exceptions import InvalidValueFromGenerator
+
+
+class DefaultBlockIfCondition:
+    pass
+
+
+ParamsList = tabparser.JuniperList
+
+
+class GenStringable(abc.ABC):
+    @abc.abstractmethod
+    def gen_str(self) -> str:
+        pass
+
+
+def _filter_str(value: Union[
+    str, int, float, tabparser.JuniperList, ParamsList, GenStringable]):
+    if isinstance(value, (
+            str,
+            int,
+            float,
+            tabparser.JuniperList,
+            ParamsList,
+    )):
+        return str(value)
+
+    if hasattr(value, "gen_str") and callable(value.gen_str):
+        return value.gen_str()
+
+    raise InvalidValueFromGenerator(
+        "Invalid yield type: %s(%s)" % (type(value).__name__, value))
+
+
+def _split_and_strip(text):
+    if "\n" in text:
+        rows = textwrap.dedent(text).strip().split("\n")
+    else:
+        rows = [text]
+    return rows
+
+
+# =====
+class BaseGenerator:
+    TYPE: str
+    TAGS: List[str]
+
+    def supports_device(self, device) -> bool:  # pylint: disable=unused-argument
+        return True
+
+
+class TreeGenerator(BaseGenerator):
+    def __init__(self, indent="  "):
+        self._indents = []
+        self._rows = []
+        self._block_path = []
+        self._indent = indent
+
+    @tracing.contextmanager(min_duration="0.1")
+    @contextlib.contextmanager
+    def block(self, *tokens, indent=None):
+        span = tracing_connector.get().get_current_span()
+        if span:
+            span.set_attribute("tokens", " ".join(map(str, tokens)))
+
+        indent = self._indent if indent is None else indent
+        block = " ".join(map(_filter_str, tokens))
+        self._block_path.append(block)
+        self._append_text(block)
+        self._indents.append(indent)
+        yield
+        self._indents.pop(-1)
+        self._block_path.pop(-1)
+
+    @contextlib.contextmanager
+    def block_if(self, *tokens, condition=DefaultBlockIfCondition):
+        if condition is DefaultBlockIfCondition:
+            condition = (None not in tokens and "" not in tokens)
+        if condition:
+            with self.block(*tokens):
+                yield
+                return
+        yield
+
+    @contextlib.contextmanager
+    def multiblock(self, *blocks):
+        if blocks:
+            blk = blocks[0]
+            tokens = blk if isinstance(blk, (list, tuple)) else [blk]
+            with self.block(*tokens):
+                with self.multiblock(*blocks[1:]):
+                    yield
+                    return
+        yield
+
+    @contextlib.contextmanager
+    def multiblock_if(self, *blocks, condition=DefaultBlockIfCondition):
+        if condition is DefaultBlockIfCondition:
+            condition = (None not in blocks)
+            if condition:
+                if blocks:
+                    blk = blocks[0]
+                    tokens = blk if isinstance(blk, (list, tuple)) else [blk]
+                    with self.block(*tokens):
+                        with self.multiblock(*blocks[1:]):
+                            yield
+                            return
+        yield
+
+    # ===
+    def _append_text(self, text):
+        self._append_text_cb(text)
+
+    def _append_text_cb(self, text, row_cb=None):
+        for row in _split_and_strip(text):
+            if row_cb:
+                row = row_cb(row)
+            self._rows.append("".join(self._indents) + row)
+
+
+class TextGenerator(TreeGenerator):
+    def __add__(self, line):
+        self._append_text(line)
+        return self
+
+    def __iter__(self):
+        yield from self._rows

--- a/annet/generators/common/initial.py
+++ b/annet/generators/common/initial.py
@@ -14,7 +14,7 @@ class InitialConfig(PartialGenerator):
     """
     def __init__(self, storage=None):
         self._do_run = not storage
-        super().__init__(storage=None)
+        super().__init__(storage=storage)
 
     def run_huawei(self, device):
         if not self._do_run:

--- a/annet/generators/entire.py
+++ b/annet/generators/entire.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import pkgutil
+import re
+import types
+from typing import (
+    FrozenSet,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    Union,
+)
+
+from annet.lib import (
+    flatten,
+    jinja_render,
+    mako_render,
+)
+from .base import BaseGenerator, _filter_str
+from .exceptions import NotSupportedDevice
+
+
+class Entire(BaseGenerator):
+    TYPE = "ENTIRE"
+    TAGS: List[str] = []
+    REQUIRED_PACKAGES: FrozenSet[str] = frozenset()
+
+    def __init__(self, storage):
+        self.storage = storage
+        # между генераторами для одного и того же path - выбирается тот что больше
+        if not hasattr(self, "prio"):
+            self.prio = 100
+        self.__device = None
+
+    def supports_device(self, device):
+        return bool(self.path(device))
+
+    def run(self, device) -> Union[None, str, Iterable[Union[str, tuple]]]:
+        raise NotImplementedError
+
+    def reload(self, device) -> Optional[
+        str]:  # pylint: disable=unused-argument
+        return
+
+    def get_reload_cmds(self, device) -> str:
+        ret = self.reload(device) or ""
+        path = self.path(device)
+        if path and device.hw.PC and device.hw.soft.startswith(
+            ("Cumulus", "SwitchDev", "SONiC"),
+        ):
+            parts = []
+            if ret:
+                parts.append(ret)
+            parts.append("/usr/bin/etckeeper commitreload %s" % path)
+            return "\n".join(parts)
+        return ret
+
+    def path(self, device) -> Optional[str]:
+        raise NotImplementedError("Required PATH for ENTIRE generator")
+
+    # pylint: disable=unused-argument
+    def is_safe(self, device) -> bool:
+        """Output gen results when --acl-safe flag is used"""
+        return False
+
+    def read(self, path) -> str:
+        return pkgutil.get_data(__name__, path).decode()
+
+    def mako(self, text, **kwargs) -> str:
+        return mako_render(text, dedent=True, device=self.__device, **kwargs)
+
+    def jinja(self, text, **kwargs) -> str:
+        return jinja_render(text, dedent=True, device=self.__device, **kwargs)
+
+    # =====
+
+    @classmethod
+    def get_aliases(cls) -> Set[str]:
+        return {cls.__name__, *cls.TAGS}
+
+    def __call__(self, device):
+        self.__device = device
+        parts = []
+        run_res = self.run(device)
+        if isinstance(run_res, str):
+            run_res = (run_res,)
+        if run_res is None or not isinstance(run_res, (tuple, types.GeneratorType)):
+            raise Exception("generator %s returns %s" % (
+                self.__class__.__name__, type(run_res)))
+        for text in run_res:
+            if isinstance(text, tuple):
+                text = " ".join(map(_filter_str, flatten(text)))
+            assert re.search(r"\bNone\b", text) is None, \
+                "Found 'None' in yield result: %s" % text
+            parts.append(text)
+        return "\n".join(parts)

--- a/annet/generators/exceptions.py
+++ b/annet/generators/exceptions.py
@@ -1,0 +1,10 @@
+class GeneratorError(Exception):
+    pass
+
+
+class InvalidValueFromGenerator(ValueError):
+    pass
+
+
+class NotSupportedDevice(GeneratorError):
+    pass

--- a/annet/generators/jsonfragment.py
+++ b/annet/generators/jsonfragment.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import contextlib
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Union,
+)
+
+from annet.storage import Device, Storage
+from .base import TreeGenerator, _filter_str
+from .exceptions import NotSupportedDevice
+
+
+class JSONFragment(TreeGenerator):
+    """Generates parts of JSON config file."""
+
+    TYPE = "JSON_FRAGMENT"
+    TAGS: List[str] = []
+
+    def __init__(self, storage: Storage):
+        super().__init__()
+        self.storage = storage
+        self._json_config: Dict[str, Any] = {}
+        self._config_pointer: List[str] = []
+
+        # if two generators edit same file, commands from generator with greater `reload_prio` will be used
+        if not hasattr(self, "reload_prio"):
+            self.reload_prio = 100
+
+    def supports_device(self, device: Device):
+        return bool(self.path(device))
+
+    def path(self, device: Device) -> Optional[str]:
+        raise NotImplementedError("Required PATH for JSON_FRAGMENT generator")
+
+    @classmethod
+    def get_aliases(cls) -> Set[str]:
+        return {cls.__name__, *cls.TAGS}
+
+    def acl(self, device: Device) -> Union[str, List[str]]:
+        """
+        Restrict the generator to a specified ACL using JSON Pointer syntax.
+
+        Expected ACL to be a list of strings, but a single string is also allowed.
+        """
+        raise NotImplementedError("Required ACL for JSON_FRAGMENT generator")
+
+    def acl_safe(self, device: Device) -> Union[str, List[str]]:
+        """
+        Restrict the generator to a specified safe ACL using JSON Pointer syntax.
+
+        Expected ACL to be a list of strings, but a single string is also allowed.
+        """
+        raise NotImplementedError("Required ACL for JSON_FRAGMENT generator")
+
+    def run(self, device: Device):
+        raise NotImplementedError
+
+    def get_reload_cmds(self, device: Device) -> str:
+        ret = self.reload(device) or ""
+        return ret
+
+    def reload(self, device) -> Optional[str]:
+        raise NotImplementedError
+
+    @contextlib.contextmanager
+    def block(self, *tokens, indent=None):  # pylint: disable=unused-argument
+        block_str = "".join(map(_filter_str, tokens))
+        self._config_pointer.append(block_str)
+        try:
+            yield
+        finally:
+            self._config_pointer.pop()
+
+    @contextlib.contextmanager
+    def block_piped(self, *tokens, indent=None):  # pylint: disable=unused-argument
+        block_str = "|".join(map(_filter_str, tokens))
+        self._config_pointer.append(block_str)
+        try:
+            yield
+        finally:
+            self._config_pointer.pop()
+
+    def __call__(self, device: Device, annotate: bool = False):
+        for cfg_fragment in self.run(device):
+            self._set_or_replace_dict(self._config_pointer, cfg_fragment)
+        return self._json_config
+
+    def _set_or_replace_dict(self, pointer, value):
+        if not pointer:
+            if self._json_config == {}:
+                self._json_config = value
+            else:
+                self._json_config = [self._json_config, value]
+        else:
+            self._set_dict(self._json_config, pointer, value)
+
+    @classmethod
+    def _to_str(cls, value: Any) -> str:
+        if isinstance(value, str):
+            return value
+        elif isinstance(value, list):
+            return [cls._to_str(x) for x in value]
+        elif isinstance(value, dict):
+            for k, v in value.items():
+                value[k] = cls._to_str(v)
+            return value
+        return str(value)
+
+    @classmethod
+    def _set_dict(cls, cfg, pointer, value):
+        # pointer has at least one key
+        if len(pointer) == 1:
+            if pointer[0] in cfg:
+                cfg[pointer[0]] = [cfg[pointer[0]], cls._to_str(value)]
+            else:
+                cfg[pointer[0]] = cls._to_str(value)
+        else:
+            if pointer[0] not in cfg:
+                cfg[pointer[0]] = {}
+            cls._set_dict(cfg[pointer[0]], pointer[1:], cls._to_str(value))

--- a/annet/generators/partial.py
+++ b/annet/generators/partial.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import re
+from typing import (
+    Iterable,
+    List,
+    Set,
+    Union,
+)
+
+from annet.lib import (
+    add_annotation,
+    flatten,
+)
+from .base import TreeGenerator, _filter_str
+from .exceptions import NotSupportedDevice
+
+
+class PartialGenerator(TreeGenerator):
+    TYPE = "PARTIAL"
+    TAGS: List[str] = []
+
+    def __init__(self, storage):
+        super().__init__()
+        self.storage = storage
+        self._annotate = False
+        self._running_gen = None
+        self._annotations = []
+        self._annotation_module = self.__class__.__module__ or ""
+
+    def supports_device(self, device) -> bool:
+        if self.__class__.run is PartialGenerator.run:
+            return bool(self._get_vendor_func(device.hw.vendor, "run"))
+        else:
+            return True
+
+    def acl(self, device):
+        acl_func = self._get_vendor_func(device.hw.vendor, "acl")
+        if acl_func:
+            return acl_func(device)
+
+    def acl_safe(self, device):
+        acl_func = self._get_vendor_func(device.hw.vendor, "acl_safe")
+        if acl_func:
+            return acl_func(device)
+
+    def run(self, device) -> Iterable[Union[str, tuple]]:
+        run_func = self._get_vendor_func(device.hw.vendor, "run")
+        if run_func:
+            return run_func(device)
+
+    def get_user_runner(self, device):
+        if self.__class__.run is not PartialGenerator.run:
+            return self.run
+        return self._get_vendor_func(device.hw.vendor, "run")
+
+    def _get_vendor_func(self, vendor: str, func_name: str):
+        attr_name = f"{func_name}_{vendor}"
+        if hasattr(self, attr_name):
+            return getattr(self, attr_name)
+        return None
+
+    # =====
+
+    @classmethod
+    def get_aliases(cls) -> Set[str]:
+        return {cls.__name__, *cls.TAGS}
+
+    def __call__(self, device, annotate=False):
+        self._indents = []
+        self._rows = []
+        self._running_gen = self.run(device)
+        self._annotate = annotate
+
+        if annotate and self.__class__.__module__:
+            self._annotation_module = ".".join(
+                self.__class__.__module__.split(".")[-2:])
+
+        for text in self._running_gen:
+            if isinstance(text, tuple):
+                text = " ".join(map(_filter_str, flatten(text)))
+            else:
+                text = _filter_str(text)
+            self._append_text(text)
+
+        for row in self._rows:
+            assert re.search(r"\bNone\b", row) is None, \
+                "Found 'None' in yield result: %s" % (row)
+        if annotate:
+            generated_rows = (
+                add_annotation(x, y)
+                for (x, y) in zip(self._rows, self._annotations)
+            )
+        else:
+            generated_rows = self._rows
+        return "\n".join(generated_rows) + "\n"
+
+    def _append_text(self, text):
+        def annotation_cb(row):
+            annotation = "%s:%d" % self.get_running_line()
+            self._annotations.append(annotation)
+            return row
+
+        self._append_text_cb(
+            text,
+            annotation_cb if self._annotate else None
+        )
+
+    def get_running_line(self):
+        if not self._running_gen or not self._running_gen.gi_frame:
+            return (repr(self._running_gen), -1)
+        return self._annotation_module, self._running_gen.gi_frame.f_lineno
+
+    @classmethod
+    def literal(cls, item):
+        return '"{}"'.format(item)
+
+    def __repr__(self):
+        return "<%s>" % self.__class__.__name__

--- a/annet/generators/perf.py
+++ b/annet/generators/perf.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import time
+from typing import (
+    Optional,
+    Union,
+)
+
+from annet import tracing
+from annet.tracing import tracing_connector
+from annet.types import (
+    GeneratorPartialRunArgs,
+    GeneratorPerf,
+)
+from .entire import Entire
+from .partial import PartialGenerator
+
+# =====
+DISABLED_TAG = "disable"
+
+
+class GeneratorPerfMesurer:
+    def __init__(
+            self,
+            gen: Union[PartialGenerator, Entire],
+            run_args: Optional[GeneratorPartialRunArgs] = None,
+            trace_min_duration: tracing.MinDurationT = None
+    ):
+        self._gen = gen
+        self._run_args = run_args
+
+        self._start_time: float = 0.0
+        self._span_ctx = None
+        self._span = None
+        self._trace_min_duration = trace_min_duration
+
+        self.last_result: Optional[GeneratorPerf] = None
+
+    def start(self) -> None:
+        self.last_result = None
+
+        self._span_ctx = tracing_connector.get().start_as_current_span(
+            "gen:call",
+            tracer_name=self._gen.__class__.__module__,
+            min_duration=self._trace_min_duration,
+        )
+        self._span = self._span_ctx.__enter__()  # pylint: disable=unnecessary-dunder-call
+
+        if self._span:
+            self._span.set_attributes(
+                {"generator.class": self._gen.__class__.__name__})
+            if self._run_args:
+                tracing_connector.get().set_device_attributes(
+                    self._span, self._run_args.device,
+                )
+
+        self._start_time = time.monotonic()
+
+    def finish(self, exc_type=None, exc_val=None,
+               exc_tb=None) -> GeneratorPerf:
+        total = time.monotonic() - self._start_time
+        self._span_ctx.__exit__(exc_type, exc_val, exc_tb)
+
+        meta = {}
+        if tracing_connector.get().enabled:
+            span_context = self._span.get_span_context()
+            meta = {
+                "span": {
+                    "trace_id": str(span_context.trace_id),
+                    "span_id": str(span_context.span_id),
+                },
+            }
+
+        self.last_result = GeneratorPerf(total=total, rt=total, meta=meta)
+        return self.last_result
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.finish(exc_type, exc_val, exc_tb)

--- a/annet/generators/perf.py
+++ b/annet/generators/perf.py
@@ -15,9 +15,6 @@ from annet.types import (
 from .entire import Entire
 from .partial import PartialGenerator
 
-# =====
-DISABLED_TAG = "disable"
-
 
 class GeneratorPerfMesurer:
     def __init__(

--- a/annet/generators/ref.py
+++ b/annet/generators/ref.py
@@ -1,0 +1,15 @@
+from .partial import PartialGenerator
+
+
+class RefGenerator(PartialGenerator):
+    def __init__(self, storage, groups=None):
+        super().__init__(storage)
+        self.groups = groups
+
+    def ref(self, device):
+        if hasattr(self, "ref_" + device.hw.vendor):
+            return getattr(self, "ref_" + device.hw.vendor)(device)
+        return ""
+
+    def with_groups(self, groups):
+        return type(self)(self.storage, groups)

--- a/annet/generators/result.py
+++ b/annet/generators/result.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import textwrap
+from collections import OrderedDict as odict
+from typing import (
+    Any,
+    Dict,
+    Optional,
+    Tuple, Callable,
+)
+
+from annet.annlib import jsontools
+from annet.lib import (
+    merge_dicts,
+)
+from annet.reference import RefMatcher, RefTracker
+from annet.types import (
+    GeneratorEntireResult,
+    GeneratorJSONFragmentResult,
+    GeneratorPartialResult,
+)
+
+
+def _combine_acl_text(
+        partial_results: Dict[str, GeneratorPartialResult],
+        acl_getter: Callable[[GeneratorPartialResult], str]
+) -> str:
+    acl_text = ""
+    for gr in partial_results.values():
+        for line in textwrap.dedent(acl_getter(gr)).split("\n"):
+            if line and not line.isspace():
+                acl_text += line.rstrip()
+                acl_text += fr"  %generator_names={gr.name}"
+                acl_text += "\n"
+    return acl_text
+
+
+class RunGeneratorResult:
+    """
+    Результат запуска run_partial_generators/run_file_generators
+    """
+
+    def __init__(self):
+        self.partial_results: Dict[str, GeneratorPartialResult] = {}
+        self.entire_results: Dict[str, GeneratorEntireResult] = {}
+        self.json_fragment_results: Dict[str, GeneratorJSONFragmentResult] = {}
+        self.ref_track: RefTracker = RefTracker()
+        self.ref_matcher: RefMatcher = RefMatcher()
+
+    def add_partial(self, result: GeneratorPartialResult):
+        self.partial_results[result.name] = result
+
+    def add_entire(self, result: GeneratorEntireResult) -> None:
+        # Если есть несколько генераторов на один файл, выбрать тот, что с большим приоритетом
+        if result.path:
+            if result.path not in self.entire_results or \
+                    result.prio > self.entire_results[result.path].prio:
+                self.entire_results[result.path] = result
+
+    def add_json_fragment(self, result: GeneratorJSONFragmentResult) -> None:
+        self.json_fragment_results[result.name] = result
+
+    def config_tree(self, safe: bool = False) -> Dict[str, Any]:  # OrderedDict
+        tree = odict()
+        for gr in self.partial_results.values():
+            config = gr.safe_config if safe else gr.config
+            tree = merge_dicts(tree, config)
+        return tree
+
+    def new_files(self, safe: bool = False) -> Dict[str, Tuple[str, str]]:
+        files = {}
+        for gr in self.entire_results.values():
+            if not safe or gr.is_safe:
+                files[gr.path] = (gr.output, gr.reload)
+        return files
+
+    def acl_text(self) -> str:
+        return _combine_acl_text(self.partial_results, lambda gr: gr.acl)
+
+    def acl_safe_text(self) -> str:
+        return _combine_acl_text(self.partial_results, lambda gr: gr.acl_safe)
+
+    def new_json_fragment_files(
+            self,
+            old_files: Dict[str, Optional[str]],
+            safe: bool = False,
+    ) -> Dict[str, Tuple[Any, Optional[str]]]:
+        # TODO: safe
+        files: Dict[str, Tuple[Any, Optional[str]]] = {}
+        reload_prios: Dict[str, int] = {}
+        for generator_result in self.json_fragment_results.values():
+            filepath = generator_result.path
+            if filepath not in files:
+                if old_files.get(filepath) is not None:
+                    files[filepath] = (old_files[filepath], None)
+                else:
+                    files[filepath] = ({}, None)
+            result_acl = generator_result.acl
+            if safe:
+                result_acl = generator_result.acl_safe
+            previous_config: Dict[str, Any] = files[filepath][0]
+            new_fragment = generator_result.config
+            new_config = jsontools.apply_json_fragment(
+                previous_config,
+                new_fragment,
+                result_acl,
+            )
+            if filepath in reload_prios and \
+                    reload_prios[filepath] > generator_result.reload_prio:
+                _, reload_cmd = files[filepath]
+            else:
+                reload_cmd = generator_result.reload
+                reload_prios[filepath] = generator_result.reload_prio
+            files[filepath] = (new_config, reload_cmd)
+        return files
+
+    def perf_mesures(self) -> Dict[str, Dict[str, int]]:
+        mesures = {}
+        for gr in self.partial_results.values():
+            mesures[gr.name] = {"total": gr.perf.total,
+                                "rt": gr.perf.rt,
+                                "meta": gr.perf.meta}
+        for gr in self.entire_results.values():
+            mesures[gr.name] = {"total": gr.perf.total,
+                                "rt": gr.perf.rt,
+                                "meta": gr.perf.meta}
+        return mesures

--- a/annet/output.py
+++ b/annet/output.py
@@ -2,7 +2,7 @@ import abc
 import os
 import posixpath
 import sys
-from typing import List, Optional, Tuple, Type
+from typing import List, Optional, Tuple, Type, Dict
 
 import colorama
 from annet.annlib.output import (  # pylint: disable=unused-import
@@ -41,7 +41,7 @@ class OutputDriver(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def format_fails(self, fail, args: Optional[QueryOptions] = None) -> Tuple[str, str]:
+    def format_fails(self, fail, fqdns: Optional[Dict[int, str]] = None) -> Tuple[str, str]:
         pass
 
     @abc.abstractmethod
@@ -129,14 +129,9 @@ class OutputDriverBasic(OutputDriver):
                 with open(dest, "w") as file:
                     writer.write(file)
 
-    def format_fails(self, fail, args: Optional[QueryOptions] = None):
+    def format_fails(self, fail, fqdns: Optional[Dict[int, str]] = None):
         ret = []
-        fqdns = {}
-        if args:
-            connector = storage_connector.get()
-            storage_opts = connector.opts().from_cli_opts(args)
-            with connector.storage()(storage_opts) as storage:
-                fqdns = storage.resolve_fdnds_by_query(args.query)
+        fqdns = fqdns or {}
         for (assignment, exc) in fail.items():
             label = assignment
             if assignment in fqdns:

--- a/annet/storage.py
+++ b/annet/storage.py
@@ -1,6 +1,5 @@
 import abc
-from typing import Any, Iterable, Optional, Type, Union
-
+from typing import Any, Iterable, Optional, Type, Union, Protocol
 
 try:
     from annet.connectors import Connector
@@ -81,7 +80,12 @@ class Query(abc.ABC):
         pass
 
 
-class Device(abc.ABC):
+class Device(Protocol):
+    @property
+    @abc.abstractmethod
+    def storage(self) -> Storage:
+        pass
+
     @abc.abstractmethod
     def __hash__(self):
         pass

--- a/annet/types.py
+++ b/annet/types.py
@@ -43,7 +43,6 @@ class GeneratorPartialRunArgs:
     def __init__(
         self,
         device: Device,
-        storage: Storage,
         use_acl: bool = False,
         use_acl_safe: bool = False,
         annotate: bool = False,
@@ -51,7 +50,6 @@ class GeneratorPartialRunArgs:
         no_new: bool = False,
     ):
         self.device = device
-        self.storage = storage
         self.use_acl = use_acl  # фильтруем по acl ввыод генератора (--no-acl для дебага)
         self.use_acl_safe = use_acl_safe  # [NOCDEV-6190] используем более строгий генераторный acl
         self.annotate = annotate  # добавляем в каждую строку вывода информацию откуда она была заyield'ена


### PR DESCRIPTION
This PR is combined effort to support multiple storage providers. It is helpful when you are migrating from one inventory storage to another.

The general gist is:

* we setup multiple storage inventories by passing `annet.storage.storage_connector.set_all([ProviderA, ProviderB])`
* use `Loader()` instead of calling `Storage()` directly to lookup device representation in multiple inventories
* every device found in different inventory is treated as separate device and is passed to selected generators
* use `gen.supports_device(device)` API to check if storage.Device instance should be passed to the generator

Since the generator is supposed to advertise by itself it's own suitability for a specific storage inventory device object, important usage note:

* base `Generator.supports_device()` returns true for any device object
* its necessary to keep backward compatibility with old generator/inventory semantic
* if multiple storages are enabled all existing generators should be provided with correct `supports_device()`
* otherwise the generator will fail or conflict with itself (if two device objects have compatible API) 

Since the Storage() was a heavily used API the big chunk of changes are consist of refactoring, 

* refactor:  split `annet/generators/__init__.py` into separate types
* refactor:  do not create storage manually and use the one provided by device
* fix: netbox storage - support multiple storage providers and fixes for API
* fix: generator-level errors when deploying
