### PR TITLE
Add acl_safe processing to JSONFragment

### DIFF
--- a/annet/annlib/jsontools.py
+++ b/annet/annlib/jsontools.py
@@ -106,7 +106,7 @@ def apply_acl_filters(content: Dict[str, Any], filters: List[str]) -> Dict[str, 
             patch = jsonpatch.JsonPatch([{"op": "add", "path": f, "value": part}])
             result = patch.apply(result)
         except jsonpointer.JsonPointerException:
-            # no value found in new_fragment by the pointer, skip the ACL item
+            # no value found in content by the pointer, skip the ACL item
             continue
 
     return result

--- a/annet/gen.py
+++ b/annet/gen.py
@@ -216,6 +216,7 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
 
     new_files = {}
     safe_new_files = {}
+    safe_new_json_fragment_files = {}
     if not ctx.no_new:
         if device in ctx.fetched_packages:
             if ctx.args.required_packages_check:
@@ -238,9 +239,6 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
         new_files = res.new_files()
         new_json_fragment_files = res.new_json_fragment_files(old_json_fragment_files)
 
-        if ctx.args.acl_safe:
-            safe_new_files = res.new_files(safe=True)
-
         filters = build_filter_text(filterer, device, ctx.stdin, ctx.args, ctx.config).split("\n")
 
         for file_name in new_json_fragment_files:
@@ -255,6 +253,16 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
                 file_name,
                 jsontools.apply_acl_filters(old_json_fragment_files[file_name][0], filters)
             )
+
+        if ctx.args.acl_safe:
+            safe_new_files = res.new_files(safe=True)
+            safe_new_json_fragment_files = res.new_json_fragment_files(old_json_fragment_files, safe=True)
+            for file_name in safe_new_json_fragment_files:
+                safe_new_json_fragment_files = _update_json_config(
+                    safe_new_json_fragment_files,
+                    file_name,
+                    jsontools.apply_acl_filters(safe_new_json_fragment_files[file_name][0], filters)
+                )
 
     if ctx.args.profile:
         perf = res.perf_mesures()
@@ -281,6 +289,7 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
         safe_old=safe_old,
         safe_new=safe_new,
         safe_new_files=safe_new_files,
+        safe_new_json_fragment_files=safe_new_json_fragment_files,
         filter_acl_rules=filter_acl_rules,
     )
 

--- a/annet/gen.py
+++ b/annet/gen.py
@@ -239,7 +239,7 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
         new_files = res.new_files()
         new_json_fragment_files = res.new_json_fragment_files(old_json_fragment_files)
 
-        filters = None
+        filters: List[str] = []
         filters_text = build_filter_text(filterer, device, ctx.stdin, ctx.args, ctx.config)
         if filters_text:
             filters = filters_text.split("\n")
@@ -260,7 +260,7 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
         if ctx.args.acl_safe:
             safe_new_files = res.new_files(safe=True)
             safe_new_json_fragment_files = res.new_json_fragment_files(old_json_fragment_files, safe=True)
-            if filters:
+            if len(filters):
                 for file_name in safe_new_json_fragment_files:
                     safe_new_json_fragment_files = _update_json_config(
                         safe_new_json_fragment_files,

--- a/annet/gen.py
+++ b/annet/gen.py
@@ -260,7 +260,7 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
         if ctx.args.acl_safe:
             safe_new_files = res.new_files(safe=True)
             safe_new_json_fragment_files = res.new_json_fragment_files(old_json_fragment_files, safe=True)
-            if len(filters):
+            if filters:
                 for file_name in safe_new_json_fragment_files:
                     safe_new_json_fragment_files = _update_json_config(
                         safe_new_json_fragment_files,

--- a/annet/gen.py
+++ b/annet/gen.py
@@ -239,6 +239,7 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
         new_files = res.new_files()
         new_json_fragment_files = res.new_json_fragment_files(old_json_fragment_files)
 
+        filters = None
         filters_text = build_filter_text(filterer, device, ctx.stdin, ctx.args, ctx.config)
         if filters_text:
             filters = filters_text.split("\n")
@@ -259,12 +260,13 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
         if ctx.args.acl_safe:
             safe_new_files = res.new_files(safe=True)
             safe_new_json_fragment_files = res.new_json_fragment_files(old_json_fragment_files, safe=True)
-            for file_name in safe_new_json_fragment_files:
-                safe_new_json_fragment_files = _update_json_config(
-                    safe_new_json_fragment_files,
-                    file_name,
-                    jsontools.apply_acl_filters(safe_new_json_fragment_files[file_name][0], filters)
-                )
+            if filters:
+                for file_name in safe_new_json_fragment_files:
+                    safe_new_json_fragment_files = _update_json_config(
+                        safe_new_json_fragment_files,
+                        file_name,
+                        jsontools.apply_acl_filters(safe_new_json_fragment_files[file_name][0], filters)
+                    )
 
     if ctx.args.profile:
         perf = res.perf_mesures()

--- a/annet/gen.py
+++ b/annet/gen.py
@@ -239,20 +239,22 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
         new_files = res.new_files()
         new_json_fragment_files = res.new_json_fragment_files(old_json_fragment_files)
 
-        filters = build_filter_text(filterer, device, ctx.stdin, ctx.args, ctx.config).split("\n")
+        filters_text = build_filter_text(filterer, device, ctx.stdin, ctx.args, ctx.config)
+        if filters_text:
+            filters = filters_text.split("\n")
 
-        for file_name in new_json_fragment_files:
-            new_json_fragment_files = _update_json_config(
-                new_json_fragment_files,
-                file_name,
-                jsontools.apply_acl_filters(new_json_fragment_files[file_name][0], filters)
-            )
-        for file_name in old_json_fragment_files:
-            old_json_fragment_files = _update_json_config(
-                old_json_fragment_files,
-                file_name,
-                jsontools.apply_acl_filters(old_json_fragment_files[file_name][0], filters)
-            )
+            for file_name in new_json_fragment_files:
+                new_json_fragment_files = _update_json_config(
+                    new_json_fragment_files,
+                    file_name,
+                    jsontools.apply_acl_filters(new_json_fragment_files[file_name][0], filters)
+                )
+            for file_name in old_json_fragment_files:
+                old_json_fragment_files = _update_json_config(
+                    old_json_fragment_files,
+                    file_name,
+                    jsontools.apply_acl_filters(old_json_fragment_files[file_name][0], filters)
+                )
 
         if ctx.args.acl_safe:
             safe_new_files = res.new_files(safe=True)

--- a/annet/generators/__init__.py
+++ b/annet/generators/__init__.py
@@ -180,9 +180,8 @@ class RunGeneratorResult:
     def new_json_fragment_files(
             self,
             old_files: Dict[str, Optional[str]],
-            safe: bool = False,  # pylint: disable=unused-argument
+            safe: bool = False,
     ) -> Dict[str, Tuple[Any, Optional[str]]]:
-        # TODO: safe
         files: Dict[str, Tuple[Any, Optional[str]]] = {}
         reload_prios: Dict[str, int] = {}
         for generator_result in self.json_fragment_results.values():
@@ -194,7 +193,12 @@ class RunGeneratorResult:
                     files[filepath] = ({}, None)
             previous_config: Dict[str, Any] = files[filepath][0]
             new_fragment = generator_result.config
-            new_config = jsontools.apply_json_fragment(previous_config, new_fragment, generator_result.acl)
+
+            if safe:
+                new_config = jsontools.apply_json_fragment(previous_config, new_fragment, generator_result.acl_safe)
+            else:
+                new_config = jsontools.apply_json_fragment(previous_config, new_fragment, generator_result.acl)
+
             if filepath in reload_prios and reload_prios[filepath] > generator_result.reload_prio:
                 _, reload_cmd = files[filepath]
             else:
@@ -502,12 +506,17 @@ def _run_json_fragment_generator(
         raise RuntimeError("json fragment generator should return non-empty path")
 
     acl_item_or_list_of_items = gen.acl(device)
+    safe_acl_item_or_list_of_items = gen.acl_safe(device)
     if not acl_item_or_list_of_items:
         raise RuntimeError("json fragment generator should return non-empty acl")
     if isinstance(acl_item_or_list_of_items, list):
         acl = acl_item_or_list_of_items
     else:
         acl = [acl_item_or_list_of_items]
+    if isinstance(safe_acl_item_or_list_of_items, list):
+        acl_safe = safe_acl_item_or_list_of_items
+    else:
+        acl_safe = [safe_acl_item_or_list_of_items]
 
     logger.info("Generating JSON_FRAGMENT ...")
     with GeneratorPerfMesurer(gen, storage) as pm:
@@ -518,6 +527,7 @@ def _run_json_fragment_generator(
         tags=gen.TAGS,
         path=path,
         acl=acl,
+        acl_safe=acl_safe,
         config=config,
         reload=reload_cmds,
         perf=pm.last_result,
@@ -930,6 +940,14 @@ class JSONFragment(TreeGenerator):
     def acl(self, device: Device) -> Union[str, List[str]]:
         """
         Restrict the generator to a specified ACL using JSON Pointer syntax.
+
+        Expected ACL to be a list of strings, but a single string is also allowed.
+        """
+        raise NotImplementedError("Required ACL for JSON_FRAGMENT generator")
+
+    def acl_safe(self, device: Device) -> Union[str, List[str]]:
+        """
+        Restrict the generator to a specified safe ACL using JSON Pointer syntax.
 
         Expected ACL to be a list of strings, but a single string is also allowed.
         """

--- a/annet/generators/__init__.py
+++ b/annet/generators/__init__.py
@@ -531,7 +531,6 @@ def _run_json_fragment_generator(
         config=config,
         reload=reload_cmds,
         perf=pm.last_result,
-        is_safe=gen.is_safe(device),
         reload_prio=gen.reload_prio,
     )
 
@@ -955,11 +954,6 @@ class JSONFragment(TreeGenerator):
 
     def run(self, device: Device):
         raise NotImplementedError
-
-    # pylint: disable=unused-argument
-    def is_safe(self, device: Device) -> bool:
-        """Output gen results when --acl-safe flag is used"""
-        return False
 
     def get_reload_cmds(self, device: Device) -> str:
         ret = self.reload(device) or ""

--- a/annet/types.py
+++ b/annet/types.py
@@ -126,6 +126,7 @@ class GeneratorJSONFragmentResult:
         tags: List[str],
         path: str,
         acl: List[str],
+        acl_safe: List[str],
         config: Dict[str, Any],
         reload: str,
         perf: GeneratorPerf,
@@ -136,6 +137,7 @@ class GeneratorJSONFragmentResult:
         self.tags = tags
         self.path = path
         self.acl = acl
+        self.acl_safe = acl_safe
         self.config = config
         self.reload = reload
         self.perf = perf
@@ -171,6 +173,7 @@ class OldNewResult:
         safe_old=None,
         safe_new=None,
         safe_new_files=None,
+        safe_new_json_fragment_files=None,
         filter_acl_rules=None
     ):
         self.device: Device = device
@@ -193,6 +196,7 @@ class OldNewResult:
         self.safe_old: MutableMapping = safe_old if safe_old else OrderedDict()
         self.safe_new: MutableMapping = safe_new if safe_new else OrderedDict()
         self.safe_new_files: MutableMapping = safe_new_files if safe_new_files else {}
+        self.safe_new_json_fragment_files: MutableMapping = safe_new_json_fragment_files or {}
 
         self.filter_acl_rules: Optional[MutableMapping] = filter_acl_rules
 
@@ -221,5 +225,7 @@ class OldNewResult:
         return self.new_files
 
     def get_new_file_fragments(self, safe: bool = False) -> Dict[str, Tuple[Any, Optional[str]]]:  # pylint: disable=unused-argument
-        # TODO: safe
+        if safe:
+            return self.safe_new_json_fragment_files
+
         return self.new_json_fragment_files

--- a/annet/types.py
+++ b/annet/types.py
@@ -130,7 +130,6 @@ class GeneratorJSONFragmentResult:
         config: Dict[str, Any],
         reload: str,
         perf: GeneratorPerf,
-        is_safe: bool,
         reload_prio: int,
     ):
         self.name = name
@@ -141,7 +140,6 @@ class GeneratorJSONFragmentResult:
         self.config = config
         self.reload = reload
         self.perf = perf
-        self.is_safe = is_safe
         self.reload_prio = reload_prio
 
 


### PR DESCRIPTION
Added processing of `acl_safe` flag with JSONFragment. The process is similar to partial generators. JSONFragment generators has `acl_safe` method now. It returns ACL rules as JSON Pointer. While generating configuration generator either `acl()` or `acl_safe()`.