### PR TITLE
Fix device support check in JSONFragment generators

### DIFF
--- a/annet/generators/__init__.py
+++ b/annet/generators/__init__.py
@@ -500,6 +500,7 @@ def _run_json_fragment_generator(
     logger = get_logger(generator=_make_generator_ctx(gen))
     if not gen.supports_device(device):
         logger.info("generator %s is not supported for device %s", gen, device.hostname)
+        return
 
     path = gen.path(device)
     if not path:


### PR DESCRIPTION
@azryve, there was a commit between `v7` and `v8` where all generators were changed. I assume that there was a little mistake inside.

Because of that mistake both `v8` and `v9` don't work properly for equipment that has no `JSONFragment` config.