### PR TITLE
Fix empty old json config with acl filters

### DIFF
--- a/annet/annlib/jsontools.py
+++ b/annet/annlib/jsontools.py
@@ -92,7 +92,11 @@ def apply_patch(content: Optional[bytes], patch_bytes: bytes) -> bytes:
 def apply_acl_filters(content: Dict[str, Any], filters: List[str]) -> Dict[str, Any]:
     result = {}
     for f in filters:
-        pointer = jsonpointer.JsonPointer(f)
+        filter_text = f.strip()
+        if not filter_text:
+            continue
+
+        pointer = jsonpointer.JsonPointer(filter_text)
 
         try:
             part = pointer.get(copy.deepcopy(content))
@@ -103,7 +107,7 @@ def apply_acl_filters(content: Dict[str, Any], filters: List[str]) -> Dict[str, 
                     sub_tree[i] = {}
                 sub_tree = sub_tree[i]
 
-            patch = jsonpatch.JsonPatch([{"op": "add", "path": f, "value": part}])
+            patch = jsonpatch.JsonPatch([{"op": "add", "path": filter_text, "value": part}])
             result = patch.apply(result)
         except jsonpointer.JsonPointerException:
             # no value found in content by the pointer, skip the ACL item

--- a/annet/gen.py
+++ b/annet/gen.py
@@ -245,28 +245,31 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
             filters = filters_text.split("\n")
 
             for file_name in new_json_fragment_files:
-                new_json_fragment_files = _update_json_config(
-                    new_json_fragment_files,
-                    file_name,
-                    jsontools.apply_acl_filters(new_json_fragment_files[file_name][0], filters)
-                )
+                if new_json_fragment_files.get(file_name) is not None:
+                    new_json_fragment_files = _update_json_config(
+                        new_json_fragment_files,
+                        file_name,
+                        jsontools.apply_acl_filters(new_json_fragment_files[file_name][0], filters)
+                    )
             for file_name in old_json_fragment_files:
-                old_json_fragment_files = _update_json_config(
-                    old_json_fragment_files,
-                    file_name,
-                    jsontools.apply_acl_filters(old_json_fragment_files[file_name][0], filters)
-                )
+                if old_json_fragment_files.get(file_name) is not None:
+                    old_json_fragment_files = _update_json_config(
+                        old_json_fragment_files,
+                        file_name,
+                        jsontools.apply_acl_filters(old_json_fragment_files[file_name][0], filters)
+                    )
 
         if ctx.args.acl_safe:
             safe_new_files = res.new_files(safe=True)
             safe_new_json_fragment_files = res.new_json_fragment_files(old_json_fragment_files, safe=True)
             if filters:
                 for file_name in safe_new_json_fragment_files:
-                    safe_new_json_fragment_files = _update_json_config(
-                        safe_new_json_fragment_files,
-                        file_name,
-                        jsontools.apply_acl_filters(safe_new_json_fragment_files[file_name][0], filters)
-                    )
+                    if safe_new_json_fragment_files.get(file_name):
+                        safe_new_json_fragment_files = _update_json_config(
+                            safe_new_json_fragment_files,
+                            file_name,
+                            jsontools.apply_acl_filters(safe_new_json_fragment_files[file_name][0], filters)
+                        )
 
     if ctx.args.profile:
         perf = res.perf_mesures()

--- a/annet/gen.py
+++ b/annet/gen.py
@@ -253,11 +253,7 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
                     )
             for file_name in old_json_fragment_files:
                 if old_json_fragment_files.get(file_name) is not None:
-                    old_json_fragment_files = _update_json_config(
-                        old_json_fragment_files,
-                        file_name,
-                        jsontools.apply_acl_filters(old_json_fragment_files[file_name][0], filters)
-                    )
+                    old_json_fragment_files[file_name] = jsontools.apply_acl_filters(old_json_fragment_files[file_name], filters)
 
         if ctx.args.acl_safe:
             safe_new_files = res.new_files(safe=True)

--- a/tests/annet/test_jsonfragments.py
+++ b/tests/annet/test_jsonfragments.py
@@ -286,7 +286,7 @@ def test_acl_filter_empty_line(edgecore_json_config, acl_filter2):
     filters = acl_filter2.split("\n")
     result = jsontools.apply_acl_filters(edgecore_json_config, filters)
 
-    assert result == edgecore_json_config
+    assert result == {}
 
 
 def test_acl_filter_wrong_filters_skip(edgecore_json_config, acl_filter3, filter3_result):


### PR DESCRIPTION
We found that old json configs can be empty ([from here](https://github.com/annetutil/annet/blob/58a336f80680e7e11f6e2284913ea4ffebefacf6/annet/gen.py#L337)). It brakes some code with acl filters.

Added here:
* some checks looking if there is no config inside json files;
* all filters filtering. Empty line now not recognising as *.