### PR TITLE
Fix broken no_new option execution in helper old_new_per_device

### DIFF
--- a/annet/gen.py
+++ b/annet/gen.py
@@ -130,6 +130,7 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
     entire_results = []
     implicit_rules: Optional[Dict[str, Any]] = None
     filter_acl_rules: Optional[Dict[str, Any]] = None
+    old_json_fragment_files: Dict[str, Dict[str, Any]] = {}
     new_json_fragment_files: Dict[str, Dict[str, Any]] = {}
     json_fragment_results: Dict[str, generators.GeneratorJSONFragmentResult] = {}
 


### PR DESCRIPTION
It is used in not widely known but useful option {diff,patch,deploy} --clear.
Now since 2389034656dc9d87279b56c240e5b52c8098d65e it results in error:

```
UnboundLocalError: cannot access local variable 'old_json_fragment_files' where it is not associated with a value
```