### PR TITLE
NOCDEV-13298: fix exception handling when failed to get running config

### DIFF
--- a/annet/gen.py
+++ b/annet/gen.py
@@ -709,8 +709,7 @@ def _old_new_get_config_cli(ctx: OldNewDeviceContext, device: Device) -> str:
     elif ctx.config == "running":
         text = ctx.running.get(device)
         if text is None:
-            exc = (ctx.failed_running.get(device.fqdn) or
-                   ctx.failed_running.get(device.hostname) or
+            exc = (ctx.failed_running.get(device) or
                    Exception("I can't get device config and I don't know why"))
             get_logger(host=device.hostname).error("config error %s", exc)
             raise exc


### PR DESCRIPTION
Currently we are trying to get config fetch exception by hostname or fqdn, which is incorrect. [Correct way](https://github.com/annetutil/annet/blob/6133cd188fb976e135f9d768ed0897918ab6cfc5/annet/gen.py#L103) is to get by device.