### PR TITLE
Do not create empty dest config file if no generators has been matched

### DIFF
--- a/annet/gen.py
+++ b/annet/gen.py
@@ -513,9 +513,11 @@ def worker(device_id, args: ShowGenOptions, stdin, loader: "Loader", filterer: F
             dumped_data = json.dumps(data, indent=4, sort_keys=True, ensure_ascii=False)
             yield (output_driver.entire_config_dest_path(device, path), dumped_data, False)
 
-        has_file_result = new_files or new_file_fragments
-        has_partial_result = new or not has_file_result
-        if device.hw.vendor in platform.VENDOR_REVERSES and has_partial_result:
+        # Consider result of partial run empty and create an empty dest file
+        # only if there are some acl rules that has been matched.
+        # Otherwise treat it as if no supported generators have been found.
+        acl_rules = res.get_acl_rules(args.acl_safe)
+        if device.hw.vendor in platform.VENDOR_REVERSES and acl_rules:
             orderer = patching.Orderer.from_hw(device.hw)
             yield (output_driver.cfg_file_names(device)[0],
                    format_config_blocks(


### PR DESCRIPTION
Currently if there is no generators that has matched provided selector the run of ann gen --dest ./output/ will result in empty ./output/<devicename>.cfg file being created.

 This is due to current logic which essentially considers that empty file generation result is a signal of partial generators being run: `has_partial_result = new or not has_file_result`.

A more proper way (besides explicitly adding the partial_generators field to OldNewResult) of distinguishing between two cases is to check whether there is any partial acls rules are provided in generation result.

This edge case has occured when I tried to enable new storage without enabling any generators for it.