### PR TITLE
adapter/netbox: add device neighbors, interface type and prefixes

### DIFF
--- a/annet/adapters/netbox/common/models.py
+++ b/annet/adapters/netbox/common/models.py
@@ -40,6 +40,22 @@ class DeviceIp:
 
 
 @dataclass
+class Prefix:
+    id: int
+    prefix: str
+    site: Entity | None
+    vrf: Entity | None
+    tenant: Entity | None
+    vlan: Entity | None
+    role: Entity | None
+    status: Label
+    is_pool: bool
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+
+
+@dataclass
 class IpAddress:
     id: int
     assigned_object_id: int
@@ -50,12 +66,27 @@ class IpAddress:
     tags: List[Entity]
     created: datetime
     last_updated: datetime
+    prefix: Optional[Prefix] = None
+
+
+@dataclass
+class InterfaceConnectedEndpoint(Entity):
+    device: Entity
+
+
+@dataclass
+class InterfaceType:
+    value: str
+    label: str
 
 
 @dataclass
 class Interface(Entity):
     device: Entity
     enabled: bool
+    description: str
+    type: InterfaceType
+    connected_endpoints: Optional[list[InterfaceConnectedEndpoint]]
     display: str = ""
     ip_addresses: List[IpAddress] = field(default_factory=list)
 
@@ -64,7 +95,6 @@ class Interface(Entity):
 class NetboxDevice(Entity):
     url: str
     storage: Storage
-    neighbours_ids: List[int]
 
     display: str
     device_type: DeviceType
@@ -92,6 +122,7 @@ class NetboxDevice(Entity):
     breed: str
 
     interfaces: List[Interface]
+    neighbours: Optional[List["NetboxDevice"]]
 
     # compat
 

--- a/annet/adapters/netbox/v37/storage.py
+++ b/annet/adapters/netbox/v37/storage.py
@@ -152,7 +152,7 @@ class NetboxStorageV37(Storage):
 
         ips = self.netbox.ipam_all_ip_addresses(interface_id=list(extended_ifaces))
         ip_to_cidrs: Dict[str, str] = {ip.address: str(ip_interface(ip.address).network) for ip in ips.results}
-        prefixes = self.netbox.ipam_all_prefixes(prefix=[x for x in ip_to_cidrs.values()])
+        prefixes = self.netbox.ipam_all_prefixes(prefix=list(ip_to_cidrs.values()))
         cidr_to_prefix: Dict[str, models.Prefix] = {x.prefix: x for x in prefixes.results}
 
         for ip in ips.results:

--- a/annet/adapters/netbox/v37/storage.py
+++ b/annet/adapters/netbox/v37/storage.py
@@ -1,5 +1,7 @@
 from logging import getLogger
-from typing import Optional, List, Union
+from typing import Optional, List, Union, Dict
+from ipaddress import ip_interface
+from collections import defaultdict
 
 from adaptix import P
 from adaptix.conversion import impl_converter, link
@@ -28,18 +30,21 @@ def extend_device_base(
         interfaces: List[models.Interface],
         hw: Optional[HardwareView],
         breed: str,
+        neighbours: Optional[List[models.NetboxDevice]],
         storage: Storage,
-        neighbours_ids: List[int],
 ) -> models.NetboxDevice:
     ...
 
 
 def extend_device(
-        device: api_models.Device, storage: Storage,
+        device: api_models.Device,
+        interfaces: List[models.Interface],
+        neighbours: Optional[List[models.NetboxDevice]],
+        storage: Storage,
 ) -> models.NetboxDevice:
     return extend_device_base(
         device=device,
-        interfaces=[],
+        interfaces=interfaces,
         breed=get_breed(
             device.device_type.manufacturer.name,
             device.device_type.model,
@@ -48,7 +53,7 @@ def extend_device(
             device.device_type.manufacturer.name,
             device.device_type.model,
         ),
-        neighbours_ids=[],
+        neighbours=neighbours,
         storage=storage,
     )
 
@@ -58,6 +63,13 @@ def extend_interface(
         interface: api_models.Interface,
         ip_addresses: List[models.IpAddress],
 ) -> models.Interface:
+    ...
+
+
+@impl_converter
+def extend_ip_address(
+        ip_address: models.IpAddress, prefix: Optional[models.Prefix],
+) -> models.IpAddress:
     ...
 
 
@@ -95,15 +107,29 @@ class NetboxStorageV37(Storage):
         if isinstance(query, list):
             query = NetboxQuery.new(query)
         device_ids = {
-            device.id: extend_device(device=device, storage=self)
+            device.id: extend_device(
+                device=device,
+                interfaces=[],
+                neighbours=[],
+                storage=self,
+            )
             for device in self._load_devices(query)
         }
         if not device_ids:
             return []
 
         interfaces = self._load_interfaces(list(device_ids))
+        neighbours = {x.id: x for x in self._load_neighbours(interfaces)}
+        neighbours_seen = defaultdict(set)
+
         for interface in interfaces:
             device_ids[interface.device.id].interfaces.append(interface)
+            for e in interface.connected_endpoints or []:
+                neighbour = neighbours[e.device.id]
+                if neighbour.id not in neighbours_seen[interface.device.id]:
+                    neighbours_seen[interface.device.id].add(neighbour.id)
+                    device_ids[interface.device.id].neighbours.append(neighbour)
+
         return list(device_ids.values())
 
     def _load_devices(self, query: NetboxQuery) -> List[api_models.Device]:
@@ -118,26 +144,65 @@ class NetboxStorageV37(Storage):
             if is_supported(device.device_type.manufacturer.name)
         ]
 
-    def _load_interfaces(self, device_ids: List[int]) -> List[
-        models.Interface]:
-        interfaces = self.netbox.dcim_all_interfaces(device_id=device_ids)
+    def _extend_interfaces(self, interfaces: List[models.Interface]) -> List[models.Interface]:
         extended_ifaces = {
             interface.id: extend_interface(interface, [])
-            for interface in interfaces.results
+            for interface in interfaces
         }
 
         ips = self.netbox.ipam_all_ip_addresses(interface_id=list(extended_ifaces))
+        ip_to_cidrs: Dict[str, str] = {ip.address: str(ip_interface(ip.address).network) for ip in ips.results}
+        prefixes = self.netbox.ipam_all_prefixes(prefix=[x for x in ip_to_cidrs.values()])
+        cidr_to_prefix: Dict[str, models.Prefix] = {x.prefix: x for x in prefixes.results}
+
         for ip in ips.results:
+            cidr = ip_to_cidrs[ip.address]
+            ip = extend_ip_address(ip, prefix=cidr_to_prefix.get(cidr))
             extended_ifaces[ip.assigned_object_id].ip_addresses.append(ip)
         return list(extended_ifaces.values())
+
+    def _load_interfaces(self, device_ids: List[int]) -> List[
+        models.Interface]:
+        interfaces = self.netbox.dcim_all_interfaces(device_id=device_ids)
+        return self._extend_interfaces(interfaces.results)
+
+    def _load_interfaces_by_id(self, ids: List[int]) -> List[models.Interface]:
+        interfaces = self.netbox.dcim_all_interfaces_by_id(id=ids)
+        return self._extend_interfaces(interfaces.results)
+
+    def _load_neighbours(self, interfaces: List[models.Interface]) -> List[models.NetboxDevice]:
+        endpoints = [e for i in interfaces for e in i.connected_endpoints or []]
+        remote_interfaces_ids = [e.id for e in endpoints]
+        neighbours_ids = [e.device.id for e in endpoints]
+        neighbours_ifaces_dics = defaultdict(list)
+        # load only the connected interface to speed things up
+        for iface in self._load_interfaces_by_id(remote_interfaces_ids):
+            neighbours_ifaces_dics[iface.device.id].append(iface)
+        neighbours = []
+        for neighbour in self.netbox.dcim_all_devices_by_id(id=neighbours_ids).results:
+            extended_neighbour = extend_device(
+                device=neighbour,
+                storage=self,
+                interfaces=neighbours_ifaces_dics[neighbour.id],
+                neighbours=None,  # do not load recursively
+            )
+            neighbours.append(extended_neighbour)
+        return neighbours
 
     def get_device(
             self, obj_id, preload_neighbors=False, use_mesh=None,
             **kwargs,
     ) -> models.NetboxDevice:
         device = self.netbox.dcim_device(obj_id)
-        res = extend_device(device=device, storage=self)
-        res.interfaces = self._load_interfaces([device.id])
+        interfaces = self._load_interfaces([device.id])
+        neighbours = self._load_neighbours(interfaces)
+
+        res = extend_device(
+            device=device,
+            storage=self,
+            interfaces=interfaces[device.id],
+            neighbours=neighbours,
+        )
         return res
 
     def flush_perf(self):

--- a/annet/annlib/netdev/views/hardware.py
+++ b/annet/annlib/netdev/views/hardware.py
@@ -61,6 +61,10 @@ class HardwareView(HardwareLeaf):
     def vendor(self) -> Optional[str]:
         return hw_to_vendor(self)
 
+    @property
+    def soft(self) -> str:
+        return self._soft
+
     def __hash__(self):
         return hash(self.model)
 


### PR DESCRIPTION
Additional data for netbox device:

* interface.type: just added field to the model
* interface.ip_addresses[].prefix: load prefix assosiated with specific ip address
* device.neighbours: load lightweight representation of neighbouring devices (with only a subset of directly connected interfaces)