### PR TITLE
netbox: pass software version from platform name

### DIFF
--- a/annet/adapters/netbox/common/manufacturer.py
+++ b/annet/adapters/netbox/common/manufacturer.py
@@ -19,15 +19,12 @@ _VENDORS = {
 }
 
 
-def _vendor_to_hw(vendor):
-    return HardwareView(_VENDORS.get(vendor.lower(), vendor), None)
-
-
-def get_hw(manufacturer: str, model: str):
+def get_hw(manufacturer: str, model: str, platform_name: str):
     # by some reason Netbox calls Mellanox SN as MSN, so we fix them here
     if manufacturer == "Mellanox" and model.startswith("MSN"):
         model = model.replace("MSN", "SN", 1)
-    hw = _vendor_to_hw(manufacturer + " " + model)
+    vendor = manufacturer + " " + model
+    hw = HardwareView(_VENDORS.get(vendor.lower(), vendor), platform_name)
     if not hw:
         raise ValueError(f"unsupported manufacturer {manufacturer}")
     return hw

--- a/annet/adapters/netbox/v24/storage.py
+++ b/annet/adapters/netbox/v24/storage.py
@@ -44,6 +44,9 @@ def extend_device(
 ) -> models.NetboxDevice:
     manufacturer = device.device_type.manufacturer.name
     model = device.device_type.model
+    platform_name = ""
+    if device.platform:
+        platform_name = device.platform.name
 
     return models.NetboxDevice(
         url=device.url,
@@ -71,7 +74,7 @@ def extend_device(
 
         fqdn=device.name,
         hostname=device.name,
-        hw=get_hw(manufacturer, model),
+        hw=get_hw(manufacturer, model, platform_name),
         breed=get_breed(manufacturer, model),
         interfaces=[],
         neighbours_ids=[],

--- a/annet/adapters/netbox/v37/storage.py
+++ b/annet/adapters/netbox/v37/storage.py
@@ -42,6 +42,9 @@ def extend_device(
         neighbours: Optional[List[models.NetboxDevice]],
         storage: Storage,
 ) -> models.NetboxDevice:
+    platform_name: str = ""
+    if device.platform:
+        platform_name = device.platform.name
     return extend_device_base(
         device=device,
         interfaces=interfaces,
@@ -52,6 +55,7 @@ def extend_device(
         hw=get_hw(
             device.device_type.manufacturer.name,
             device.device_type.model,
+            platform_name,
         ),
         neighbours=neighbours,
         storage=storage,


### PR DESCRIPTION
Pass the platform name to hw.sw_version. The platform is a netbox enitity used to desribe software running on a network appliance and associate that with the device manufacturer:

https://demo.netbox.dev/static/docs/models/dcim/platform/