### PR TITLE
adapters/netbox: fix get_device for netboxv37

### DIFF
--- a/annet/adapters/netbox/v37/storage.py
+++ b/annet/adapters/netbox/v37/storage.py
@@ -204,7 +204,7 @@ class NetboxStorageV37(Storage):
         res = extend_device(
             device=device,
             storage=self,
-            interfaces=interfaces[device.id],
+            interfaces=interfaces,
             neighbours=neighbours,
         )
         return res


### PR DESCRIPTION
NetboxStorageV37.get_device is broken in previous intration when I was adding fetching device neighbors.

It has not been noticed right aways since the most of the core logic is using more flexible `make_devices` which allows to fetch multiple devices at once.