### PR TITLE
NOCDEV-14336: fix deleting keys from json fragment configs

### DIFF
--- a/annet/annlib/jsontools.py
+++ b/annet/annlib/jsontools.py
@@ -28,7 +28,11 @@ def apply_json_fragment(
         try:
             new_value = pointer.get(new_fragment)
         except jsonpointer.JsonPointerException:
-            # no value found in new_fragment by the pointer, skip the ACL item
+            # no value found in new_fragment by the pointer,
+            # try to delete it from the new config
+            doc, part = pointer.to_last(full_new_config)
+            if isinstance(doc, dict) and isinstance(part, str):
+                doc.pop(part, None)
             continue
 
         _ensure_pointer_exists(full_new_config, pointer)


### PR DESCRIPTION
Currently we can not delete top level keys from json fragment configs, because we can not match acl pointer to empty dict. Fixed by deleting mathing part from the old config