### PR TITLE
adapters/netbox: allow unknown manufacturers

### DIFF
--- a/annet/adapters/netbox/common/manufacturer.py
+++ b/annet/adapters/netbox/common/manufacturer.py
@@ -25,8 +25,6 @@ def get_hw(manufacturer: str, model: str, platform_name: str):
         model = model.replace("MSN", "SN", 1)
     vendor = manufacturer + " " + model
     hw = HardwareView(_VENDORS.get(vendor.lower(), vendor), platform_name)
-    if not hw:
-        raise ValueError(f"unsupported manufacturer {manufacturer}")
     return hw
 
 
@@ -47,13 +45,4 @@ def get_breed(manufacturer: str, model: str):
         return "adva8"
     elif manufacturer == "Arista":
         return "eos4"
-    raise ValueError(f"unsupported manufacturer {manufacturer}")
-
-
-def is_supported(manufacturer: str) -> bool:
-    if manufacturer not in (
-            "Huawei", "Mellanox", "Juniper", "Cisco", "Adva", "Arista",
-    ):
-        logger.warning("Unsupported manufacturer `%s`", manufacturer)
-        return False
-    return True
+    return ""

--- a/annet/adapters/netbox/v24/storage.py
+++ b/annet/adapters/netbox/v24/storage.py
@@ -6,10 +6,11 @@ from annetbox.v24.client_sync import NetboxV24
 
 from annet.adapters.netbox.common import models
 from annet.adapters.netbox.common.manufacturer import (
-    is_supported, get_hw, get_breed,
+   get_hw, get_breed,
 )
 from annet.adapters.netbox.common.query import NetboxQuery
 from annet.adapters.netbox.common.storage_opts import NetboxStorageOpts
+from annet.annlib.netdev.views.hardware import HardwareView
 from annet.storage import Storage
 
 logger = getLogger(__name__)
@@ -162,7 +163,6 @@ class NetboxStorageV24(Storage):
             device
             for device in self.netbox.dcim_all_devices().results
             if _match_query(query, device)
-            if is_supported(device.device_type.manufacturer.name)
         ]
 
     def _load_interfaces(self, device_ids: List[int]) -> List[


### PR DESCRIPTION
adapter/netbox enforced a list of supported manufacturers. this limits its usability for no particular reason, so i think its better to get rid of it.

* adapters/netbox: remove is_supported helper from adapter netbox
* adapters/netbox: allow unknown manufacturers and breeds

