### PR TITLE
Fix acl regexp parser

### DIFF
--- a/annet/annlib/rbparser/syntax.py
+++ b/annet/annlib/rbparser/syntax.py
@@ -31,7 +31,7 @@ def compile_row_regexp(row, flags=0):
         row = row[:-3]
     elif "~/" in row:
         # ~/{regex}/ -> {regex}, () не нужны поскольку уже (?:) - non-captured
-        row = re.sub(r"~/([^/]+)/", r"\1", row)
+        row = re.sub(r"~/(((?!~/).)+)/", r"\1", row)
     else:
         row += r"(?:\s|$)"
     row = re.sub(r"\s+", r"\\s+", row)


### PR DESCRIPTION
Now in ACL not available using regexp with `/`: 

```
interface ~/(GE1/0/17|GE1/0/18|GE1/0/48)/
interface ~/(GE1\/0\/17|GE1\/0\/18|GE1\/0\/48)/
interface ~/(GE1\/0\/17|GE1\/0\/18|GE1\/0\/48)/ %cant_delete
interface ~/(GE1\/0\/17|GE1\/0\/18|GE1\/0\/48)/ test ~/asd/
```

Fix it: https://regexr.com/857qd