### PR TITLE
adapter/netbox: breed as cuml2 for NVIDIA same as for Mellanox

### DIFF
--- a/annet/adapters/netbox/common/manufacturer.py
+++ b/annet/adapters/netbox/common/manufacturer.py
@@ -35,7 +35,7 @@ def get_breed(manufacturer: str, model: str):
         return "vrp85"
     elif manufacturer == "Huawei":
         return "vrp55"
-    elif manufacturer == "Mellanox":
+    elif manufacturer in ("Mellanox", "NVIDIA"):
         return "cuml2"
     elif manufacturer == "Juniper":
         return "jun10"


### PR DESCRIPTION
We need to use same breed cuml2 for NVIDIA (ex Mellanox) devices. Both run Cumulus OS.