### PR TITLE
NOCDEV-15403: fix Ufispace in devdb.json

### DIFF
--- a/annet/annlib/netdev/devdb/data/devdb.json
+++ b/annet/annlib/netdev/devdb/data/devdb.json
@@ -119,7 +119,8 @@
     "PC.Whitebox.Asterfusion.CX.CX500.CX532P-N": " CX532P-N",
     "PC.Whitebox.Ufispace": "[Uu]fi[Ss]pace",
     "PC.Whitebox.Ufispace.S": " S",
-    "PC.Whitebox.Ufispace.S.S9110-32X": " S9110-32X",
+    "PC.Whitebox.Ufispace.S.S9100": " S91\\d\\d",
+    "PC.Whitebox.Ufispace.S.S9100.S9110_32X": " S9110-32X",
 
     "RouterOS": "^([Rr]outer[Oo][Ss]|[Mm]ikro[Tt]ik)",
 


### PR DESCRIPTION
- Add S9100 series (100G models)
- Get rid of `-` in `S9100-32X`