### PR TITLE
NEBIUSNOC-2416: change default --log-dest from curdir to ~/.annet/deploy

### DIFF
--- a/annet/argparse.py
+++ b/annet/argparse.py
@@ -107,6 +107,8 @@ class Arg:
         default = self.kwargs.get("default", None)
         if isinstance(default, ConvertibleDefault) and "type" in self.kwargs:
             default = self.kwargs["default"] = default.convert(self.kwargs["type"])
+        elif isinstance(default, Callable):
+            default = self.kwargs["default"] = default()
         elif default is False and "action" not in self.kwargs:
             self.kwargs["action"] = "store_true"
         self.default = default

--- a/annet/cli.py
+++ b/annet/cli.py
@@ -273,7 +273,7 @@ def file_patch(args: cli_args.FilePatchOptions):
 def context():
     """ A group of commands for manipulating context.
 
-    By default, the context file is located in '~/.annushka/context.yml',
+    By default, the context file is located in '~/.annet/context.yml',
     but it can be set with the ANN_CONTEXT_CONFIG_PATH environment variable.
     """
     context_touch()

--- a/annet/cli_args.py
+++ b/annet/cli_args.py
@@ -8,6 +8,7 @@ import os
 
 from valkit.common import valid_string_list
 
+import annet.lib
 from annet.argparse import Arg, ArgGroup, DefaultFromEnv
 from annet.hardware import hardware_connector
 from annet.storage import Query, get_storage
@@ -228,7 +229,7 @@ opt_log_json = Arg(
 )
 
 opt_log_dest = Arg(
-    "--log-dest", default="deploy/",
+    "--log-dest", default=annet.lib.get_default_log_dest,
     help="Log to a specified file, directory, or '-' (stdout)"
 )
 

--- a/annet/lib.py
+++ b/annet/lib.py
@@ -37,8 +37,20 @@ from annet.annlib.lib import (  # pylint: disable=unused-import
 from contextlog import get_logger
 
 
-_TEMPLATE_CONTEXT_PATH: Optional[str] = None
-_DEFAULT_CONTEXT_PATH: Optional[str] = None
+_HOMEDIR_PATH: Optional[str] = None           # defaults to ~/.annet
+_TEMPLATE_CONTEXT_PATH: Optional[str] = None  # defaults to annet/configs/context.yml
+_DEFAULT_CONTEXT_PATH: Optional[str] = None   # defaults to ~/.annet/context.yml
+
+
+def get_homedir_path() -> str:
+    if _HOMEDIR_PATH is None:
+        set_homedir_path("~/.annet/")
+    return _HOMEDIR_PATH
+
+
+def set_homedir_path(path: str) -> None:
+    global _HOMEDIR_PATH  # pylint: disable=global-statement
+    _HOMEDIR_PATH = path
 
 
 def get_template_context_path() -> str:
@@ -61,6 +73,11 @@ def get_default_context_path() -> str:
 def set_default_context_path(path: str) -> None:
     global _DEFAULT_CONTEXT_PATH  # pylint: disable=global-statement
     _DEFAULT_CONTEXT_PATH = path
+
+
+def get_default_log_dest() -> str:
+    homedir = get_homedir_path()
+    return os.path.join(homedir, "deploy/")
 
 
 @lru_cache(maxsize=1)


### PR DESCRIPTION
Currently deploy logs are saved into curdir. I got tired of it and decided to move it into `~/.annet/deploy`.
To keep the old behaviour you can either:
* override `annet.cli.opt_log_dest`
* set curdir in main(): `annet.lib.set_homedir_path(os.curdir)`

Changelog:
* annet/argparse: support no-arg callable as default value
* annet/lib: add ability to set/get_homedir_conf
* annet/cli: replace forgotten ~/.annushka with ~/.annet
