### PR TITLE
NEBIUSNOC-2468: fix netbox hostname query matching multiple fqdn

### DIFF
--- a/annet/adapters/netbox/common/query.py
+++ b/annet/adapters/netbox/common/query.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, List, Union, Iterable, Optional
+from typing import List, Union, Iterable, Optional
 
 from annet.storage import Query
 
@@ -15,9 +15,7 @@ class NetboxQuery(Query):
     ) -> "NetboxQuery":
         if hosts_range is not None:
             raise ValueError("host_range is not supported")
-        query = cls(query=list(query))
-        query = hostname_dot_hack(query)
-        return query
+        return cls(query=list(query))
 
     @property
     def globs(self):
@@ -26,23 +24,3 @@ class NetboxQuery(Query):
 
     def is_empty(self) -> bool:
         return len(self.query) == 0
-
-
-def hostname_dot_hack(netbox_query: NetboxQuery) -> NetboxQuery:
-    # there is no proper way to lookup host by its hostname
-    # ie find "host" with fqdn "host.example.com"
-    # besides using name__ic (ie startswith)
-    # since there is no direct analogue for this field in netbox
-    # so we need to add a dot to hostnames (top-level fqdn part)
-    # so we would not receive devices with a common name prefix
-    def add_dot(raw_query: Any) -> Any:
-        if isinstance(raw_query, str) and "." not in raw_query:
-            raw_query = raw_query + "."
-        return raw_query
-
-    raw_query = netbox_query.query
-    if isinstance(raw_query, list):
-        for i, name in enumerate(raw_query):
-            raw_query[i] = add_dot(name)
-
-    return NetboxQuery(raw_query)

--- a/annet/adapters/netbox/common/query.py
+++ b/annet/adapters/netbox/common/query.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Union, Iterable, Optional
+from typing import Any, List, Union, Iterable, Optional
 
 from annet.storage import Query
 
@@ -15,7 +15,9 @@ class NetboxQuery(Query):
     ) -> "NetboxQuery":
         if hosts_range is not None:
             raise ValueError("host_range is not supported")
-        return cls(query=list(query))
+        query = cls(query=list(query))
+        query = hostname_dot_hack(query)
+        return query
 
     @property
     def globs(self):
@@ -24,3 +26,23 @@ class NetboxQuery(Query):
 
     def is_empty(self) -> bool:
         return len(self.query) == 0
+
+
+def hostname_dot_hack(netbox_query: NetboxQuery) -> NetboxQuery:
+    # there is no proper way to lookup host by its hostname
+    # ie find "host" with fqdn "host.example.com"
+    # besides using name__ic (ie startswith)
+    # since there is no direct analogue for this field in netbox
+    # so we need to add a dot to hostnames (top-level fqdn part)
+    # so we would not receive devices with a common name prefix
+    def add_dot(raw_query: Any) -> Any:
+        if isinstance(raw_query, str) and "." not in raw_query:
+            raw_query = raw_query + "."
+        return raw_query
+
+    raw_query = netbox_query.query
+    if isinstance(raw_query, list):
+        for i, name in enumerate(raw_query):
+            raw_query[i] = add_dot(name)
+
+    return NetboxQuery(raw_query)

--- a/annet/adapters/netbox/v37/storage.py
+++ b/annet/adapters/netbox/v37/storage.py
@@ -97,13 +97,11 @@ class NetboxStorageV37(Storage):
         pass
 
     def resolve_object_ids_by_query(self, query: NetboxQuery):
-        query = _hostname_dot_hack(query)
         return [
             d.id for d in self._load_devices(query)
         ]
 
     def resolve_fdnds_by_query(self, query: NetboxQuery):
-        query = _hostname_dot_hack(query)
         return [
             d.name for d in self._load_devices(query)
         ]
@@ -118,7 +116,6 @@ class NetboxStorageV37(Storage):
     ) -> List[models.NetboxDevice]:
         if isinstance(query, list):
             query = NetboxQuery.new(query)
-        query = _hostname_dot_hack(query)
         device_ids = {
             device.id: extend_device(
                 device=device,

--- a/annet/adapters/netbox/v37/storage.py
+++ b/annet/adapters/netbox/v37/storage.py
@@ -1,5 +1,5 @@
 from logging import getLogger
-from typing import Optional, List, Union, Dict
+from typing import Any, Optional, List, Union, Dict
 from ipaddress import ip_interface
 from collections import defaultdict
 
@@ -97,11 +97,13 @@ class NetboxStorageV37(Storage):
         pass
 
     def resolve_object_ids_by_query(self, query: NetboxQuery):
+        query = _hostname_dot_hack(query)
         return [
             d.id for d in self._load_devices(query)
         ]
 
     def resolve_fdnds_by_query(self, query: NetboxQuery):
+        query = _hostname_dot_hack(query)
         return [
             d.name for d in self._load_devices(query)
         ]
@@ -116,6 +118,7 @@ class NetboxStorageV37(Storage):
     ) -> List[models.NetboxDevice]:
         if isinstance(query, list):
             query = NetboxQuery.new(query)
+        query = _hostname_dot_hack(query)
         device_ids = {
             device.id: extend_device(
                 device=device,
@@ -145,6 +148,7 @@ class NetboxStorageV37(Storage):
     def _load_devices(self, query: NetboxQuery) -> List[api_models.Device]:
         if not query.globs:
             return []
+        query = _hostname_dot_hack(query)
         return [
             device
             for device in self.netbox.dcim_all_devices(
@@ -223,3 +227,23 @@ def _match_query(query: NetboxQuery, device_data: api_models.Device) -> bool:
         if subquery.strip() in device_data.name:
             return True
     return False
+
+
+def _hostname_dot_hack(netbox_query: NetboxQuery) -> NetboxQuery:
+    # there is no proper way to lookup host by its hostname
+    # ie find "host" with fqdn "host.example.com"
+    # besides using name__ic (ie startswith)
+    # since there is no direct analogue for this field in netbox
+    # so we need to add a dot to hostnames (top-level fqdn part)
+    # so we would not receive devices with a common name prefix
+    def add_dot(raw_query: Any) -> Any:
+        if isinstance(raw_query, str) and "." not in raw_query:
+            raw_query = raw_query + "."
+        return raw_query
+
+    raw_query = netbox_query.query
+    if isinstance(raw_query, list):
+        for i, name in enumerate(raw_query):
+            raw_query[i] = add_dot(name)
+
+    return NetboxQuery(raw_query)


### PR DESCRIPTION
There is no proper way to lookup host by its hostname ie find "host" with fqdn "host.example.com" besides using name__ic (ie startswith).
Since there is no direct analogue for this field in netbox, we need to add a dot to hostnames (top-level fqdn part) so we would not receive all devices with a common name prefix.