### PR TITLE
NOCDEV-14656: option for create output dir even for blackboxes

### DIFF
--- a/annet/cli_args.py
+++ b/annet/cli_args.py
@@ -75,11 +75,6 @@ opt_dest_force_create_dir = Arg(
     help="Output generated data to dir, even for blackboxes"
 )
 
-opt_blackbox_config_filename = Arg(
-    "--blackbox-config-filename", default="config.cfg",
-    help="Filename for blackbox config (applicable only with --dest-force-create-dir)"
-)
-
 opt_old = Arg(
     "old",
     help="A path to a file (or a directory with a batch of files) that contains the old config"
@@ -437,7 +432,6 @@ class FileOutOptions(ArgGroup):
     no_label = opt_no_label
     no_color = opt_no_color
     dest_force_create_dir = opt_dest_force_create_dir
-    blackbox_config_filename = opt_blackbox_config_filename
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/annet/cli_args.py
+++ b/annet/cli_args.py
@@ -70,6 +70,16 @@ opt_expand_path = Arg(
     help="Use full paths of Entire-generators and no just names when writing them to the file system"
 )
 
+opt_dest_force_create_dir = Arg(
+    "--dest-force-create-dir", default=False,
+    help="Output generated data to dir, even for blackboxes"
+)
+
+opt_blackbox_config_filename = Arg(
+    "--blackbox-config-filename", default="config.cfg",
+    help="Filename for blackbox config (applicable only with --dest-force-create-dir)"
+)
+
 opt_old = Arg(
     "old",
     help="A path to a file (or a directory with a batch of files) that contains the old config"
@@ -426,6 +436,8 @@ class FileOutOptions(ArgGroup):
     expand_path = opt_expand_path
     no_label = opt_no_label
     no_color = opt_no_color
+    dest_force_create_dir = opt_dest_force_create_dir
+    blackbox_config_filename = opt_blackbox_config_filename
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/annet/output.py
+++ b/annet/output.py
@@ -24,6 +24,9 @@ from annet.connectors import Connector
 from annet.storage import Device, storage_connector
 
 
+BLACKBOX_FILENAME = "config.cfg"
+
+
 class _DriverConnector(Connector["OutputDriver"]):
     name = "OutputDriver"
     ep_name = "output"
@@ -101,7 +104,7 @@ class OutputDriverBasic(OutputDriver):
                     writer.write(sys.stdout)
             elif dir_mode:
                 if arg_out.dest_force_create_dir and os.sep not in label:
-                    label = os.path.join(label, arg_out.blackbox_config_filename)
+                    label = os.path.join(label, BLACKBOX_FILENAME)
 
                 if label.startswith(LABEL_NEW_PREFIX):
                     label = label[len(LABEL_NEW_PREFIX):]

--- a/annet/output.py
+++ b/annet/output.py
@@ -77,7 +77,8 @@ class OutputDriverBasic(OutputDriver):
             yield from items_iter
 
         dest = arg_out.dest
-        dir_mode = dir_or_file_output(dest, query_result_count, suggest_dir=(os.sep in first_result[0]))
+        suggest_dir = arg_out.dest_force_create_dir or os.sep in first_result[0]
+        dir_mode = dir_or_file_output(dest, query_result_count, suggest_dir=suggest_dir)
         _reassembled_items = list(_reassemble_items())
 
         for output_no, (label, output, is_fail) in enumerate(_reassembled_items):
@@ -99,6 +100,9 @@ class OutputDriverBasic(OutputDriver):
                         print_label(label, back_color=label_color)
                     writer.write(sys.stdout)
             elif dir_mode:
+                if arg_out.dest_force_create_dir and os.sep not in label:
+                    label = os.path.join(label, arg_out.blackbox_config_filename)
+
                 if label.startswith(LABEL_NEW_PREFIX):
                     label = label[len(LABEL_NEW_PREFIX):]
                 if label.startswith(os.sep):
@@ -114,7 +118,7 @@ class OutputDriverBasic(OutputDriver):
                     label = os.sep.join(parts[1:])
                     if not arg_out.expand_path:
                         label = os.path.basename(label)
-                    if query_result_count > 1:
+                    if query_result_count > 1 or arg_out.dest_force_create_dir:
                         label = os.path.join(hostname, label)
                 file_dest = os.path.join(dest, "errors") if is_fail else dest
                 out_file = os.path.normpath(os.path.join(file_dest, label))


### PR DESCRIPTION
Currently whitebox configs are written to a directory named `<devname>.cfg`, and blackbox configs are written to a file with the same name. In this PR a flag is added allowing writing blackbox config to a directory `<devname>.cfg`