### PR TITLE
feat: detect EP by group name only

### DIFF
--- a/annet/adapters/file/provider.py
+++ b/annet/adapters/file/provider.py
@@ -3,6 +3,7 @@ from annet.storage import Query
 from dataclasses import dataclass, fields
 from typing import List, Iterable, Any
 from annet.storage import StorageProvider, Storage
+from annet.connectors import AdapterWithName
 from annet.storage import Device as DeviceCls
 from annet.annlib.netdev.views.hardware import vendor_to_hw
 import yaml
@@ -108,7 +109,7 @@ class Devices:
             self.devices = devices
 
 
-class Provider(StorageProvider):
+class Provider(StorageProvider, AdapterWithName):
     def storage(self):
         return storage_factory
 

--- a/annet/adapters/netbox/provider.py
+++ b/annet/adapters/netbox/provider.py
@@ -27,7 +27,7 @@ def storage_factory(opts: NetboxStorageOpts) -> Storage:
 
 
 class NetboxProvider(StorageProvider, AdapterWithName, AdapterWithConfig):
-    def __init__(self, url:Optional[str] = None, token: Optional[str] = None):
+    def __init__(self, url: Optional[str] = None, token: Optional[str] = None):
         self.url = url
         self.token = token
 

--- a/annet/adapters/netbox/provider.py
+++ b/annet/adapters/netbox/provider.py
@@ -27,7 +27,7 @@ def storage_factory(opts: NetboxStorageOpts) -> Storage:
 
 
 class NetboxProvider(StorageProvider, AdapterWithName, AdapterWithConfig):
-    def __init__(self, url:Optional[str]=None,token:Optional[str]=None):
+    def __init__(self, url:Optional[str] = None, token: Optional[str] = None):
         self.url = url
         self.token = token
 

--- a/annet/adapters/netbox/provider.py
+++ b/annet/adapters/netbox/provider.py
@@ -1,6 +1,9 @@
+from typing import Dict, Any, Optional
+
 from dataclass_rest.exceptions import ClientError
 
 from annet.storage import StorageProvider, Storage
+from annet.connectors import AdapterWithName, AdapterWithConfig, T
 from .common.status_client import NetboxStatusClient
 from .common.storage_opts import NetboxStorageOpts
 from .common.query import NetboxQuery
@@ -23,7 +26,14 @@ def storage_factory(opts: NetboxStorageOpts) -> Storage:
         raise ValueError(f"Unsupported version: {status.netbox_version}")
 
 
-class NetboxProvider(StorageProvider):
+class NetboxProvider(StorageProvider, AdapterWithName, AdapterWithConfig):
+    def __init__(self, url:Optional[str]=None,token:Optional[str]=None):
+        self.url = url
+        self.token = token
+
+    def with_config(self, **kwargs: Dict[str, Any]) -> T:
+        return NetboxProvider(**kwargs)
+
     def storage(self):
         return storage_factory
 

--- a/annet/api/__init__.py
+++ b/annet/api/__init__.py
@@ -218,8 +218,8 @@ def log_host_progress_cb(pool: Parallel, task_result: TaskResult):
         stacklevel=2,
     )
     args = cast(cli_args.QueryOptions, pool.args[0])
-    connector, connector_opts = get_storage()
-    storage_opts = connector.opts().parse_params(connector_opts, args)
+    connector = get_storage()
+    storage_opts = connector.opts().parse_params({}, args)
     with connector.storage()(storage_opts) as storage:
         fqdns = storage.resolve_fdnds_by_query(args.query)
     PoolProgressLogger(device_fqdns=fqdns)(pool, task_result)

--- a/annet/cli.py
+++ b/annet/cli.py
@@ -68,8 +68,8 @@ def get_loader(gen_args: cli_args.GenOptions, args: cli_args.QueryOptionsBase):
     exit_stack = ExitStack()
     storages = []
     with exit_stack:
-        connector, connector_opts = get_storage()
-        storage_opts = connector.opts().parse_params(connector_opts, args)
+        connector, conf_params = get_storage()
+        storage_opts = connector.opts().parse_params(conf_params, args)
         storages.append(exit_stack.enter_context(connector.storage()(storage_opts)))
         yield Loader(*storages, args=gen_args, no_empty_warning=args.query.is_empty())
 

--- a/annet/connectors.py
+++ b/annet/connectors.py
@@ -1,8 +1,9 @@
 import sys
-from abc import ABC
+from abc import ABC, abstractmethod
 from functools import cached_property
 from importlib.metadata import entry_points
-from typing import Generic, Optional, Type, TypeVar, List
+from typing import Generic, Optional, Type, TypeVar, List, Dict, Any, Tuple
+import warnings
 from annet.lib import get_context
 
 T = TypeVar("T")
@@ -28,15 +29,16 @@ class Connector(ABC, Generic[T]):
         return ep
 
     def get(self, *args, **kwargs) -> T:
+        """
+        Returns connector. If more than one is registered returns random and throw warning
+        """
         if self._classes is None:
             self._classes = self._entry_point or [self._get_default()]
+        if not self._classes:
+            raise Exception(f"Not found registered class for group={self.ep_group}")
         if len(self._classes) > 1:
-            raise RuntimeError(
-                f"Multiple classes are registered with the same "
-                f"group={self.ep_group} and name={self.ep_name}: "
-                f"{[cls for cls in self._classes]}",
-            )
-
+            warnings.warn(f"Multiple classes are registered with the group={self.ep_group} but "
+                          f"{[cls for cls in self._classes]}", UserWarning)
         res = self._classes[0]
         return res(*args, **kwargs)
 
@@ -92,3 +94,50 @@ def load_entry_point_new(group: str) -> List:
     if not ep:
         return []
     return [item.load() for item in ep]
+
+
+class AdapterWithConfig(ABC, Generic[T]):
+    @abstractmethod
+    def with_config(self, **kwargs: Dict[str, Any]) -> T:
+        pass
+
+
+class AdapterWithName(ABC):
+    @abstractmethod
+    def name(self) -> str:
+        pass
+
+
+def get_connector_from_config(config_key: str, connectors: List[Connector]) -> Tuple[Connector, Dict[str, Any]]:
+    seen: list[str] = []
+    if not connectors:
+        raise Exception("empty connectors")
+    connector = connectors[0]  # default
+    connector_params: Dict[str, Any] = {}
+    if context_storage := get_context().get(config_key):
+        adapter_name = context_storage.get("adapter", None)
+        connector_params = context_storage.get("params", {})
+        if adapter_name:
+            for con in connectors:
+                con_name = connector.__class__.__name__
+                if isinstance(con, AdapterWithName):
+                    con_name = con.name()
+                seen.append(con_name)
+                if adapter_name == con_name:
+                    connector = con
+                    break
+            else:
+                raise Exception("unknown %s %s: seen %s" % (config_key, adapter_name, seen))
+        else:
+            connector = connectors[0]
+            if len(connectors) > 1:
+                warnings.warn(f"Please specify adapter for '{config_key}'. Found more than one classes {connectors}", UserWarning)
+    else:
+        connector = connectors[0]
+        if len(connectors) > 1:
+            warnings.warn(f"Please specify '{config_key}'. Found more than one classes {connectors}", UserWarning)
+    if isinstance(connector, AdapterWithConfig):
+        connector = connector.with_config(**connector_params)
+    # return connector_params only for storage
+    # TODO: switch storage interface to AdapterWithConfig
+    return connector, connector_params

--- a/annet/deploy.py
+++ b/annet/deploy.py
@@ -40,11 +40,13 @@ class DeployResult(_DeployResultBase):  # noqa: E302
 class _FetcherConnector(Connector["Fetcher"]):
     name = "Fetcher"
     ep_name = "deploy_fetcher"
+    ep_by_group_only = "annet.connectors.fetcher"
 
 
 class _DriverConnector(Connector["DeployDriver"]):
     name = "DeployDriver"
     ep_name = "deploy_driver"
+    ep_by_group_only = "annet.connectors.deployer"
 
 
 fetcher_connector = _FetcherConnector()

--- a/annet/deploy.py
+++ b/annet/deploy.py
@@ -6,7 +6,7 @@ import itertools
 import re
 from collections import namedtuple
 from contextlib import contextmanager
-from typing import Dict, List, Optional, Any, OrderedDict, Tuple
+from typing import Dict, List, Optional, Any, OrderedDict, Tuple, Type
 
 from contextlog import get_logger
 
@@ -14,9 +14,8 @@ from annet import text_term_format
 from annet.annlib.command import Command, Question, CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.annlib.rbparser.deploying import MakeMessageMatcher, Answer
-from annet.lib import get_context
 from annet.cli_args import DeployOptions
-from annet.connectors import Connector
+from annet.connectors import Connector, get_connector_from_config
 from annet.output import TextArgs
 from annet.rulebook import get_rulebook, deploying
 from annet.storage import Device
@@ -42,11 +41,21 @@ class _FetcherConnector(Connector["Fetcher"]):
     ep_name = "deploy_fetcher"
     ep_by_group_only = "annet.connectors.fetcher"
 
+    def _get_default(self) -> Type["Fetcher"]:
+        # if entry points are broken, try to use direct import
+        import annet.adapters.fetchers.stub.fetcher as stub_fetcher
+        return stub_fetcher.StubFetcher
+
 
 class _DriverConnector(Connector["DeployDriver"]):
     name = "DeployDriver"
     ep_name = "deploy_driver"
     ep_by_group_only = "annet.connectors.deployer"
+
+    def _get_default(self) -> Type["DeployDriver"]:
+        # if entry points are broken, try to use direct import
+        import annet.adapters.deployers.stub.deployer as stub_deployer
+        return stub_deployer.StubDeployDriver
 
 
 fetcher_connector = _FetcherConnector()
@@ -66,42 +75,10 @@ class Fetcher(abc.ABC):
         pass
 
 
-class AdapterWithConfig(abc.ABC):
-    @abc.abstractmethod
-    def with_config(self, **kwargs: Dict[str, Any]) -> Fetcher:
-        pass
-
-
-class AdapterWithName(abc.ABC):
-    @abc.abstractmethod
-    def name(self) -> str:
-        pass
-
-
 def get_fetcher() -> Fetcher:
     connectors = fetcher_connector.get_all()
-    seen: list[str] = []
-    connector = connectors[0]
-    connector_params: Any = {}
-    if context_storage := get_context().get("fetcher"):
-        for con in connectors:
-            con_name = connector.__class__.__name__
-            if isinstance(con, AdapterWithName):
-                con_name = con.name()
-            seen.append(con_name)
-            if not (adapter := context_storage):
-                raise Exception("adapter is not set in %s" % context_storage)
-            if adapter["adapter"] == con_name:
-                connector = con
-                connector_params = adapter.get("params", {})
-                break
-        else:
-            raise Exception("unknown fetcher %s: seen %s" % (context_storage["adapter"], seen))
-    else:
-        connector = connectors[0]
-    if isinstance(connector, AdapterWithConfig):
-        connector = connector.with_config(**connector_params)
-    return connector
+    fetcher, _ = get_connector_from_config("fetcher", connectors)
+    return fetcher
 
 
 class DeployDriver(abc.ABC):
@@ -123,29 +100,9 @@ class DeployDriver(abc.ABC):
 
 
 def get_deployer() -> DeployDriver:
-    connectors = driver_connector.get_all()
-    seen: list[str] = []
-    connector = connectors[0]
-    connector_params: Any = {}
-    if context_storage := get_context().get("deployer"):
-        for con in connectors:
-            con_name = connector.__class__.__name__
-            if isinstance(con, AdapterWithName):
-                con_name = con.name()
-            seen.append(con_name)
-            if not (adapter := context_storage):
-                raise Exception("adapter is not set in %s" % context_storage)
-            if adapter["adapter"] == con_name:
-                connector = con
-                connector_params = adapter.get("params", {})
-                break
-        else:
-            raise Exception("unknown deployer %s: seen %s" % (context_storage["adapter"], seen))
-    else:
-        connector = connectors[0]
-    if isinstance(connector, AdapterWithConfig):
-        connector = connector.with_config(**connector_params)
-    return connector
+    connectors = fetcher_connector.get_all()
+    deployer, _ = get_connector_from_config("deployer", connectors)
+    return deployer
 
 
 # ===

--- a/annet/filtering.py
+++ b/annet/filtering.py
@@ -7,6 +7,7 @@ from annet.connectors import Connector
 class _FiltererConnector(Connector["Filterer"]):
     name = "Filterer"
     ep_name = "filterer"
+    ep_by_group_only = "annet.connectors.filterer"
 
     def _get_default(self) -> Type["Filterer"]:
         return NopFilterer

--- a/annet/hardware.py
+++ b/annet/hardware.py
@@ -15,6 +15,7 @@ except ImportError:
 class _HardwareConnector(Connector["HarwareProvider"]):
     name = "Hardware"
     ep_name = "hardware"
+    ep_by_group_only = "annet.connectors.hardware"
 
 
 hardware_connector = _HardwareConnector()

--- a/annet/output.py
+++ b/annet/output.py
@@ -30,6 +30,7 @@ BLACKBOX_FILENAME = "config.cfg"
 class _DriverConnector(Connector["OutputDriver"]):
     name = "OutputDriver"
     ep_name = "output"
+    ep_by_group_only = "annet.connectors.output"
 
     def _get_default(self) -> Type["OutputDriver"]:
         return OutputDriverBasic

--- a/annet/storage.py
+++ b/annet/storage.py
@@ -1,6 +1,6 @@
 import abc
 from typing import Any, Iterable, Optional, Type, Union, Protocol, Dict
-from annet.connectors import Connector, get_context
+from annet.connectors import Connector, get_connector_from_config
 
 
 class _StorageConnector(Connector["StorageProvider"]):
@@ -129,18 +129,6 @@ class Device(Protocol):
         pass
 
 
-def get_storage() -> (Storage, Dict[str, Any]):
+def get_storage() -> tuple[StorageProvider, Dict[str, Any]]:
     connectors = storage_connector.get_all()
-    seen: list[str] = []
-    if context_storage := get_context().get("storage"):
-        for connector in connectors:
-            con_name = connector.name()
-            seen.append(con_name)
-            if "adapter" not in context_storage:
-                raise Exception("adapter is not set in %s" % context_storage)
-            if context_storage["adapter"] == con_name:
-                return connector, context_storage.get("params", {})
-        else:
-            raise Exception("unknown storage %s: seen %s" % (context_storage["adapter"], seen))
-    else:
-        return connectors[0], {}
+    return get_connector_from_config("storage", connectors)

--- a/annet/storage.py
+++ b/annet/storage.py
@@ -4,8 +4,9 @@ from annet.connectors import Connector, get_context
 
 
 class _StorageConnector(Connector["StorageProvider"]):
-    name = "Storage"
-    ep_name = "storage"
+    name = "Storage"  # legacy
+    ep_name = "storage"  # legacy
+    ep_by_group_only = "annet.connectors.storage"
 
 
 storage_connector = _StorageConnector()

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ if __name__ == "__main__":
           "annet.connectors": [
             "storage = annet.adapters.netbox.provider:NetboxProvider",
           ],
+          "annet.connectors.storage": [
+            "file = annet.adapters.file.provider:Provider",
+          ],
         },
         python_requires=">=3.8",
         install_requires=requirements(),


### PR DESCRIPTION
Annet filters entry points by group and name, but name is just an identifier of exact entry point, not qualifier.
Official documentation states:
"The group that an entry point belongs to indicates what sort of object it provides."
...
"The name identifies this entry point within its group. The precise meaning of this is up to the consumer. For console scripts, the name of the entry point is the command that will be used to launch it. Within a distribution, entry point names should be unique."
Moreover, with current approach it is impossible to add more than one EP by a package.
This request adds additional lookup using only EP group.