### PR TITLE
fix is_default method

### DIFF
--- a/annet/connectors.py
+++ b/annet/connectors.py
@@ -59,7 +59,7 @@ class Connector(ABC, Generic[T]):
         self._classes = list(classes)
 
     def is_default(self) -> bool:
-        return self._classes is self._entry_point is None
+        return self._classes is None and not self._entry_point
 
 
 class CachedConnector(Connector[T], ABC):


### PR DESCRIPTION
Prior to [this commit](https://github.com/annetutil/annet/commit/fe4352a4fd07431960ac4f7b6fc0d99848d190f0#diff-c6cd579423588fb0b93f6c6c95e7cd1c81227200586c9f8a94d1395ea4bdfd38L77) empty `self._entry_point` was `None`, but now it is empty list. Fix `is_default` accordingly.