### PR TITLE
fix: RuntimeError

### DIFF
--- a/annet/lib.py
+++ b/annet/lib.py
@@ -141,6 +141,4 @@ def repair_context_file() -> None:
 
 
 def do_async(coro: Awaitable):
-    loop = asyncio.get_event_loop()
-    res = loop.run_until_complete(coro)
-    return res
+    return asyncio.run(coro)


### PR DESCRIPTION
Fix
```
  File "/annet/annet/api/__init__.py", line 669, in deploy
    result = annet.lib.do_async(deploy_driver.bulk_deploy(deploy_cmds, args))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/annet/annet/lib.py", line 144, in do_async
    loop = asyncio.get_event_loop()
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.9/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/events.py", line 681, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
RuntimeError: There is no current event loop in thread 'MainThread'.
```