### PR TITLE
chore: use 3.9 compatible syntax

### DIFF
--- a/annet/adapters/file/provider.py
+++ b/annet/adapters/file/provider.py
@@ -1,7 +1,7 @@
 from annet.annlib.netdev.views.dump import DumpableView
 from annet.storage import Query
 from dataclasses import dataclass, fields
-from typing import List, Iterable, Any
+from typing import List, Iterable, Optional, Any
 from annet.storage import StorageProvider, Storage
 from annet.connectors import AdapterWithName
 from annet.storage import Device as DeviceCls
@@ -24,11 +24,11 @@ class Interface(DumpableView):
 class DeviceStorage:
     fqdn: str
     vendor: str
-    hostname: str | None = None
-    serial: str | None = None
-    id: str | None = None
-    interfaces: list[Interface] | None = None
-    storage: Storage | None = None
+    hostname: Optional[str] = None
+    serial: Optional[str] = None
+    id: Optional[str] = None
+    interfaces: Optional[list[Interface]] = None
+    storage: Optional[Storage] = None
 
     def __post_init__(self):
         if not self.id:
@@ -128,7 +128,7 @@ class Query(Query):
     query: List[str]
 
     @classmethod
-    def new(cls, query: str | Iterable[str], hosts_range: slice | None = None) -> "Query":
+    def new(cls, query: str | Iterable[str], hosts_range: Optional[slice] = None) -> "Query":
         if hosts_range is not None:
             raise ValueError("host_range is not supported")
         return cls(query=list(query))
@@ -146,7 +146,7 @@ class StorageOpts:
         self.path = path
 
     @classmethod
-    def parse_params(cls, conf_params: dict[str, str] | None, cli_opts: Any):
+    def parse_params(cls, conf_params: Optional[dict[str, str]], cli_opts: Any):
         path = conf_params.get("path")
         if not path:
             raise Exception("empty path")

--- a/annet/adapters/netbox/common/models.py
+++ b/annet/adapters/netbox/common/models.py
@@ -52,17 +52,17 @@ class DeviceIp(DumpableView):
 class Prefix(DumpableView):
     id: int
     prefix: str
-    site: Entity | None
-    vrf: Entity | None
-    tenant: Entity | None
-    vlan: Entity | None
-    role: Entity | None
+    site: Optional[Entity]
+    vrf: Optional[Entity]
+    tenant: Optional[Entity]
+    vlan: Optional[Entity]
+    role: Optional[Entity]
     status: Label
     is_pool: bool
     custom_fields: dict[str, Any]
     created: datetime
     last_updated: datetime
-    description: str | None = ""
+    description: Optional[str] = ""
 
     @property
     def _dump__list_key(self):

--- a/annet/adapters/netbox/common/storage_opts.py
+++ b/annet/adapters/netbox/common/storage_opts.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any
+from typing import Any, Optional
 
 DEFAULT_URL = "http://localhost"
 
@@ -10,7 +10,7 @@ class NetboxStorageOpts:
         self.token = token
 
     @classmethod
-    def parse_params(cls, conf_params: dict[str, str] | None, cli_opts: Any):
+    def parse_params(cls, conf_params: Optional[dict[str, str]], cli_opts: Any):
         url = os.getenv("NETBOX_URL") or conf_params.get("url") or DEFAULT_URL
         token = os.getenv("NETBOX_TOKEN", "").strip() or conf_params.get("token") or ""
         return cls(url=url, token=token)

--- a/annet/cli.py
+++ b/annet/cli.py
@@ -8,7 +8,7 @@ import subprocess
 import shutil
 import sys
 from contextlib import ExitStack, contextmanager
-from typing import Tuple, Iterable
+from typing import Optional, Tuple, Iterable
 
 import tabulate
 import yaml
@@ -129,7 +129,7 @@ def show_generators(args: cli_args.ShowGeneratorsOptions):
     """ List applicable generators (for a device if query is set) """
     arg_gens = cli_args.GenOptions(args)
     with get_loader(arg_gens, args) as loader:
-        device: Device | None = None
+        device: Optional[Device] = None
         devices = loader.devices
         if len(devices) == 1:
             device = devices[0]

--- a/annet/deploy.py
+++ b/annet/deploy.py
@@ -481,7 +481,7 @@ def make_cmd_params(rule: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def make_apply_commands(rule: dict, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str | None = None):
+def make_apply_commands(rule: dict, hw: HardwareView, do_commit: bool, do_finalize: bool, path: Optional[str] = None):
     apply_logic = rule["attrs"]["apply_logic"]
     before, after = apply_logic(hw, do_commit=do_commit, do_finalize=do_finalize, path=path)
     return before, after


### PR DESCRIPTION
We are still supporting 3.9 and union type syntax was [introduced](https://peps.python.org/pep-0604/) in 3.10. Using `Optional` instead.