### PR TITLE
NOCDEV-15813: do not sort diff lines alphanumerically

### DIFF
--- a/annet/annlib/diff.py
+++ b/annet/annlib/diff.py
@@ -59,9 +59,8 @@ def diff_cmp(diff_l, diff_r):
     (op_l, line_l, _, _) = diff_l
     (op_r, line_r, _, _) = diff_r
 
-    cmp_line = (line_l > line_r) - (line_l < line_r)
     cmp_op = ops_order[op_l] - ops_order[op_r]
-    if cmp_line == 0:
+    if line_l == line_r:
         # При равенстве строк порядок определяется операцией
         return cmp_op
 
@@ -101,9 +100,7 @@ def diff_cmp(diff_l, diff_r):
             else:
                 continue
             break
-    if res != 0:
-        return res
-    return cmp_line
+    return res
 
 
 def resort_diff(diff: Diff) -> Diff:

--- a/tests/annet/test_diff.py
+++ b/tests/annet/test_diff.py
@@ -223,7 +223,7 @@ def str2diff(raw_diff: str) -> Diff:
 def test_sort():
     l1 = (diff_ops["-"], "peer FE80::11:11 bfd min-tx-interval 250 min-rx-interval 250", [], {})
     l2 = (diff_ops["+"], "peer RR_11 advertise-community", [], {})
-    assert diff_cmp(l1, l2) < 0
+    assert diff_cmp(l1, l2) == 0
     l1 = (diff_ops["-"], "peer FE80::11:12 advertise-community", [], {})
     l2 = (diff_ops["-"], "peer FE80::11:11 bfd min-tx-interval 250 min-rx-interval 250", [], {})
     assert diff_cmp(l1, l2) == 0


### PR DESCRIPTION
Preserve the order of the lines in the generated config