### PR TITLE
NOCDEV-16007: fix acl rules selection with global children

### DIFF
--- a/annet/annlib/patching.py
+++ b/annet/annlib/patching.py
@@ -500,18 +500,20 @@ def _select_match(matches, rules):
 
     # Мерджим всех потомков которые заматчились
     local_children = odict()
+    global_children = odict()
     if is_f_cr_allowed:
         for (rule, is_cr_allowed) in map(operator.itemgetter(0), matches):
             if is_cr_allowed:
                 local_children = merge_dicts(local_children, rule["children"]["local"])
             # optional break on is_cr_allowed==False?
 
+                global_children = merge_dicts(global_children, rule["children"]["global"])
+
+    global_children = merge_dicts(global_children, rules["global"])
+
     children_rules = {
         "local": local_children,
-        "global": odict(
-            (list(f_rule["children"]["global"].items()) if is_f_cr_allowed else [])
-            + list(rules["global"].items()),
-        ),
+        "global": global_children,
     }
 
     match = {"attrs": f_rule["attrs"]}

--- a/tests/annet/test_acl/juniper-two-rules-with-global-children.yaml
+++ b/tests/annet/test_acl/juniper-two-rules-with-global-children.yaml
@@ -1,0 +1,26 @@
+- vendor: juniper
+  acl: |
+    routing-options  %cant_delete=1
+      rib *
+        ~  %global=1
+    routing-options  %cant_delete=1
+      rib inet6.0  %cant_delete=1
+        static  %cant_delete=1
+          route 127.0.0.1
+            ~
+  input: |
+    routing-options {
+        rib inet6.0 {
+            static {
+                route ::1/128 discard;
+            }
+        }
+    }
+  output: |
+    routing-options {
+        rib inet6.0 {
+            static {
+                route ::1/128 discard;
+            }
+        }
+    }


### PR DESCRIPTION
Consider following situation. We have generator 1 with the acl:
```
routing-options  %cant_delete=1
  rib *
    ~  %global=1
```
And we also have generator 2 with the acl:
```
routing-options  %cant_delete=1
  rib inet6.0  %cant_delete=1
    static  %cant_delete=1
      route 127.0.0.1
        ~
```
Our generators emit the following configuration:
```
routing-options {
    rib inet6.0 {
        static {
            route ::1/128 discard;
        }
    }
}
```
This configuration is allowed by the first acl, so it will remain unchanged after applying the combined acl. Right? Actually, wrong. After applying the acl we will get
```
routing-options {
    rib inet6.0 {
        static;
    }
}
```
What happened? Two acl rules are matched by the line `rib inet6.0`: `rib *` from the first generator and `rib inet6.0` from the second. If more than one rule [matched](https://github.com/annetutil/annet/blob/e05a505be98ee82ffe28da3cb227488d8864852e/annet/annlib/patching.py#L425), their local children [are combined](https://github.com/annetutil/annet/blob/e05a505be98ee82ffe28da3cb227488d8864852e/annet/annlib/patching.py#L506). But what about global children (`~  %global=1` from the first acl)? For some reason they are [taken only from the first rule](https://github.com/annetutil/annet/blob/e05a505be98ee82ffe28da3cb227488d8864852e/annet/annlib/patching.py#L512). And the first rule is `rib inet6.0`, because of [this metric](https://github.com/annetutil/annet/blob/e05a505be98ee82ffe28da3cb227488d8864852e/annet/annlib/patching.py#L469). So global children from the second rule (from the first generator) are lost, and we can not match `route ::1/128 discard;`.

Fixed by adding global children the same way local children are added.