### PR TITLE
Always create new event loop

### DIFF
--- a/annet/executor.py
+++ b/annet/executor.py
@@ -15,6 +15,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import colorama
 import psutil
+
+import annet.lib
 from annet.annlib.command import Command, CommandList, Question  # noqa: F401
 from annet.storage import Device
 
@@ -146,7 +148,7 @@ def async_bulk(
     kwargs["policy"] = policy
 
     if processes == 1:
-        host_res, host_duration = asyncio.get_event_loop().run_until_complete(bulk(executor, devices, coro_gen, *args, **kwargs))
+        host_res, host_duration = annet.lib.do_async(bulk(executor, devices, coro_gen, *args, **kwargs))
         res.update(host_res)
         deploy_durations.update(host_duration)
     else:
@@ -313,10 +315,7 @@ def _print_failed(host, res):
 
 
 def _mp_async_bulk(res_q: multiprocessing.Queue, *args, **kwargs):
-    asyncio.get_event_loop().close()
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    res = loop.run_until_complete(bulk(*args, **kwargs))
+    res = annet.lib.do_async(bulk(*args, **kwargs))
     res_q.put(res)
     res_q.close()
 


### PR DESCRIPTION
```
import asyncio

async def a():
    print(1)

print(asyncio.get_event_loop())
```

->

```
(.venv) ozhegov-osx:annushka ozhegov$ ./ann deploy -g hostname example
/Users/ozhegov/Workspace/arc/a.yandex-team.ru/noc/annushka/./ann:14: DeprecationWarning: There is no current event loop
  print(asyncio.get_event_loop())
<_UnixSelectorEventLoop running=False closed=False debug=False>
```

But:
```
import asyncio

async def a():
    print(1)

asyncio.run(a())
print(asyncio.get_event_loop())
```

->


```
(.venv) ozhegov-osx:annushka ozhegov$ ./ann deploy -g hostname example
1
Traceback (most recent call last):
  File "/Users/ozhegov/Workspace/arc/a.yandex-team.ru/noc/annushka/./ann", line 14, in <module>
    print(asyncio.get_event_loop())
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/asyncio/events.py", line 692, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
RuntimeError: There is no current event loop in thread 'MainThread'
```

annet destroy loop during execution, if was used `annet.lib.do_async`.
It is proposed use `annet.lib.do_async` everywhere as single way for run async from sync.