### PR TITLE
link-flap trigger error-down is default command in CE

### DIFF
--- a/annet/implicit.py
+++ b/annet/implicit.py
@@ -46,6 +46,7 @@ def _implicit_tree(device):
                 !user-interface vty ~
                     protocol inbound all
                 netconf
+                port link-flap trigger error-down
             """
         elif device.hw.Huawei.NE:
             text = """


### PR DESCRIPTION
Adding link-flap trigger error-down in implicit because it's default command in Huawei CE's