### PR TITLE
fix cisco rulebook for "no ip address"

### DIFF
--- a/annet/implicit.py
+++ b/annet/implicit.py
@@ -137,7 +137,6 @@ def _implicit_tree(device):
         text += r"""
             !interface
                 no shutdown
-                no ip address
         """
         if device.hw.Cisco.Catalyst:
             # this configuration is not visible in running-config when enabled

--- a/annet/rulebook/texts/cisco.rul
+++ b/annet/rulebook/texts/cisco.rul
@@ -45,6 +45,7 @@ no snmp-server sysobjectid type stack-oid
 interface Loopback
     ipv6 address *
     ip address ~
+    ! no ip address
 
 # SVI/Subifs/Lagg
 interface */(Vlan|Ethernet.*\.|port-channel.*\.?)\d+$/ %diff_logic=cisco.iface.diff
@@ -53,6 +54,7 @@ interface */(Vlan|Ethernet.*\.|port-channel.*\.?)\d+$/ %diff_logic=cisco.iface.d
     ipv6 address *
     ipv6 nd ~                      %logic=cisco.misc.no_ipv6_nd_suppress_ra
     ip address ~
+    ! no ip address
     mtu
 
 # Physical
@@ -65,6 +67,7 @@ interface */\w*Ethernet[0-9\/]+$/     %logic=common.permanent %diff_logic=cisco.
     ipv6 link-local
     ipv6 address *
     ip address ~
+    ! no ip address
     channel-group
     mtu
     storm-control * level

--- a/tests/annet/test_patch/cisco_physical_iface_delete.yaml
+++ b/tests/annet/test_patch/cisco_physical_iface_delete.yaml
@@ -10,7 +10,6 @@ patch: |
   interface Ethernet1/2
     no description
     shutdown
-    ip address
     exit
   exit
   copy running-config startup-config

--- a/tests/annet/test_patch/cisco_port_channel_members_config.yaml
+++ b/tests/annet/test_patch/cisco_port_channel_members_config.yaml
@@ -52,7 +52,6 @@ patch: |
     switchport mode trunk
     switchport trunk allowed vlan add 2
     switchport
-    no ip address
     mtu 9000
     no shutdown
     exit


### PR DESCRIPTION
We faced with an issue related to assign "no ip address" to implicit commands. The issue is resolved by adding "! no ip address" to cisco.rul file.