### PR TITLE
Fix in json_fragment leaf

### DIFF
--- a/annet/annlib/jsontools.py
+++ b/annet/annlib/jsontools.py
@@ -59,11 +59,11 @@ def _ensure_pointer_exists(doc: Dict[str, Any], pointer: jsonpointer.JsonPointer
     parts_except_the_last = pointer.get_parts()[:-1]
     doc_pointer: Dict[str, Any] = doc
     for part in parts_except_the_last:
-        if part not in doc_pointer:
-            # create an empty object by the pointer part
-            doc_pointer[part] = {}
-
         if isinstance(doc_pointer, dict):
+            if part not in doc_pointer or doc_pointer[part] is None:
+                # create an empty object by the pointer part
+                doc_pointer[part] = {}
+
             # follow the pointer to delve deeper
             doc_pointer = doc_pointer[part]
         else:


### PR DESCRIPTION
If as a source of old config will be used corrupted config, ex:

```
{
  "AAA": null,
  "BGP_GLOBALS": null,
  "BGP_GLOBALS_AF": null,
  "BGP_NEIGHBOR": null,
  "BGP_NEIGHBOR_AF": null,
  "BREAKOUT_CFG": null,
  "BUFFER_POOL": null,
  "BUFFER_PROFILE": null,
  "BUFFER_QUEUE": null,
  "COMMUNITY_SET": null,
  "DEVICE_METADATA": null,
  "DNS_NAMESERVER": null,
  "DSCP_TO_TC_MAP": null,
  "FEATURE": null,
  "INTERFACE": null,
  "LOOPBACK_INTERFACE": null,
  "MGMT_INTERFACE": null,
  "MGMT_PORT": null,
  "MGMT_VRF_CONFIG": null,
  "NTP": null,
  "NTP_SERVER": null,
  "PORT": null,
  "PORTCHANNEL": null,
  "PORTCHANNEL_INTERFACE": null,
  "PORTCHANNEL_MEMBER": null,
  "PORT_QOS_MAP": null,
  "QUEUE": null,
  "ROUTE_MAP": null,
  "SAI_METADATA": null,
  "SCHEDULER": null,
  "SNMP": null,
  "SNMP_COMMUNITY": null,
  "SNMP_TRAP_CONFIG": null,
  "SYSLOG_SERVER": null,
  "TACPLUS": null,
  "TACPLUS_SERVER": null,
  "TC_TO_PRIORITY_GROUP_MAP": null,
  "TC_TO_QUEUE_MAP": null,
  "WRED_PROFILE": null
}
```

diff/patch with acl `/FEATURE/dhcp_relay/state` will crash