### PR TITLE
fix Aruba, Nexus and B4com parsers

### DIFF
--- a/annet/annlib/tabparser.py
+++ b/annet/annlib/tabparser.py
@@ -330,6 +330,30 @@ class CiscoFormatter(BlockExitFormatter):
             yield from super().block_exit(context)
 
 
+class NexusFormatter(BlockExitFormatter):
+    def __init__(self, indent="  "):
+        super().__init__("exit", indent)
+
+    def split(self, text):
+        return self.split_remove_spaces(text)
+
+
+class B4comFormatter(BlockExitFormatter):
+    def __init__(self, indent="  "):
+        super().__init__("exit", indent)
+
+    def split(self, text):
+        return self.split_remove_spaces(text)
+
+
+class ArubaFormatter(BlockExitFormatter):
+    def __init__(self, indent="  "):
+        super().__init__("exit", indent)
+
+    def split(self, text):
+        return self.split_remove_spaces(text)
+
+
 class AristaFormatter(CiscoFormatter):
 
     def block_exit(self, context: Optional[FormatterContext]) -> str:

--- a/annet/annlib/tabparser.py
+++ b/annet/annlib/tabparser.py
@@ -737,16 +737,16 @@ def make_formatter(vendor, **kwargs):
     formatters = {
         "juniper": JuniperFormatter,
         "cisco": CiscoFormatter,
-        "nexus": CiscoFormatter,
+        "nexus": NexusFormatter,
         "huawei": HuaweiFormatter,
         "optixtrans": OptixtransFormatter,
         "arista": AristaFormatter,
         "nokia": NokiaFormatter,
         "routeros": RosFormatter,
-        "aruba": CiscoFormatter,
+        "aruba": ArubaFormatter,
         "pc": CommonFormatter,
         "ribbon": RibbonFormatter,
-        "b4com": CiscoFormatter,
+        "b4com": B4comFormatter,
     }
     return formatters[vendor](**kwargs)
 

--- a/annet/tabparser.py
+++ b/annet/tabparser.py
@@ -25,14 +25,14 @@ def make_formatter(hw, **kwargs):
         cls = HuaweiFormatter
     elif hw.Cisco.ASR or hw.Cisco.XRV:
         cls = AsrFormatter
+    elif hw.Nexus:
+        cls = NexusFormatter
     elif hw.Cisco:
         cls = CiscoFormatter
     elif hw.B4com:
         cls = B4comFormatter
     elif hw.Aruba:
         cls = ArubaFormatter
-    elif hw.Nexus:
-        cls = NexusFormatter
     elif hw.Juniper:
         cls = JuniperFormatter
     elif hw.Nokia:

--- a/annet/tabparser.py
+++ b/annet/tabparser.py
@@ -12,6 +12,9 @@ from annet.annlib.tabparser import (  # pylint: disable=unused-import
     RosFormatter,
     parse_to_tree,
     AristaFormatter,
+    NexusFormatter,
+    B4comFormatter,
+    ArubaFormatter,
 )
 
 
@@ -22,8 +25,14 @@ def make_formatter(hw, **kwargs):
         cls = HuaweiFormatter
     elif hw.Cisco.ASR or hw.Cisco.XRV:
         cls = AsrFormatter
-    elif hw.Nexus or hw.Cisco or hw.Aruba or hw.B4com:
+    elif hw.Cisco:
         cls = CiscoFormatter
+    elif hw.B4com:
+        cls = B4comFormatter
+    elif hw.Aruba:
+        cls = ArubaFormatter
+    elif hw.Nexus:
+        cls = NexusFormatter
     elif hw.Juniper:
         cls = JuniperFormatter
     elif hw.Nokia:


### PR DESCRIPTION
The PR fixes an issue with Nexus, Aruba and B4com parsers since they overlap with the Cisco one