### PR TITLE
Fix the FileNotFoundError in the file-diff/file-patch commands

### DIFF
--- a/annet/api/__init__.py
+++ b/annet/api/__init__.py
@@ -142,7 +142,7 @@ def _read_device_config(path, hw):
     _logger.debug("Reading %r ...", path)
     score = 1
 
-    with open(path) as cfgdump_file:
+    with open(path.split(",")[0]) as cfgdump_file:
         text = cfgdump_file.read()
     try:
         if not hw:


### PR DESCRIPTION
Found a problem in **file-diff/file-patch**, you can reproduce it by calling the comparison of two files:

`./annet.py file-patch ../msk-td-rt-01.conf, ../msk-td-rt-01_new.conf`

The error appears as follows:

![telegram-cloud-document-2-5354783096564639798](https://github.com/user-attachments/assets/51fb3441-993c-4870-8f86-b9a6e00650ec)

I have corrected the `_read_device_config` function, and now both commands work correctly:

![image](https://github.com/user-attachments/assets/9268321a-d3c2-48a7-845c-d9fcf1f72298)
