### PR TITLE
per-interface MTU for old cisco switches

### DIFF
--- a/annet/implicit.py
+++ b/annet/implicit.py
@@ -133,17 +133,29 @@ def _implicit_tree(device):
                         no shutdown
             """
     elif device.hw.Cisco:
-        text += r"""
-            !interface */\S*Ethernet\S+/
-                mtu 1500
-                no shutdown
-            !interface */Loopback[0-9.]+/
-                mtu 1500
-                no shutdown
-            !interface */port-channel[0-9.]+/
-                mtu 1500
-                no shutdown
-        """
+        # C2900/C3500/C3600 does not support the MTU on a per-interface basis
+        if device.hw.Cisco.Catalyst.C2900 or device.hw.Cisco.Catalyst.C3500 \
+           or device.hw.Cisco.Catalyst.C3600:
+            text += r"""
+                !interface */\S*Ethernet\S+/
+                    no shutdown
+                !interface */Loopback[0-9.]+/
+                    no shutdown
+                !interface */port-channel[0-9.]+/
+                    no shutdown
+            """
+        else:
+            text += r"""
+                !interface */\S*Ethernet\S+/
+                    mtu 1500
+                    no shutdown
+                !interface */Loopback[0-9.]+/
+                    mtu 1500
+                    no shutdown
+                !interface */port-channel[0-9.]+/
+                    mtu 1500
+                    no shutdown
+            """
         if device.hw.Cisco.Catalyst:
             # this configuration is not visible in running-config when enabled
             text += r"""


### PR DESCRIPTION
Old models Cisco Catalyst does not support the MTU on a per-interface basis. 
We must exclude the implicit "mtu 1500" on the interfaces of these models.

For example, docs for C2960 - https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst2960/software/release/15-2_2_e/configuration/guide/b_1522e_2960_2960c_2960s_2960sf_2960p_cg/b_1522e_2960_2960c_2960s_2960sf_2960p_cg_chapter_01001.html