### PR TITLE
Properly assign breed to Moxa console servers

### DIFF
--- a/annet/adapters/netbox/common/manufacturer.py
+++ b/annet/adapters/netbox/common/manufacturer.py
@@ -54,6 +54,8 @@ def get_breed(manufacturer: str, model: str):
         return "bcom-os"
     elif manufacturer == "MikroTik":
         return "routeros"
+    elif manufacturer == "Moxa":
+        return "moxa"
     elif manufacturer == "PC":
         return "pc"
     return ""

--- a/annet/adapters/netbox/common/models.py
+++ b/annet/adapters/netbox/common/models.py
@@ -214,7 +214,7 @@ class NetboxDevice(Entity):
         return type(self) is type(other) and self.url == other.url
 
     def is_pc(self) -> bool:
-        return self.device_type.manufacturer.name == "Mellanox" or self.breed == "pc"
+        return self.device_type.manufacturer.name in ("Mellanox", "Moxa") or self.breed == "pc"
 
     def _make_interface(self, name: str, type: InterfaceType) -> Interface:
         return Interface(


### PR DESCRIPTION
Assign breed "moxa" to a device which manufacturer is "Moxa" so executor would be able to download configs. Also, is_pc() should return True so annet would compare downloaded files and not "running config".