### PR TITLE
Replace Cisco hash algo 5 (MD5) with a star glob

### DIFF
--- a/annet/rulebook/texts/cisco.deploy
+++ b/annet/rulebook/texts/cisco.deploy
@@ -20,7 +20,7 @@
 crypto key generate rsa %timeout=60
     dialog: Do you really want to replace them? [yes/no]: ::: no
     dialog: How many bits in the modulus [512]: ::: 2048
-no username * privilege * secret 5 *
+no username * privilege * secret * *
     dialog: This operation will remove all username related configurations with same name.Do you want to continue? [confirm] ::: Y  %send_nl=0
 
 copy running-config startup-config


### PR DESCRIPTION
Replace Cisco hash algo 5 (MD5) with a star glob as it could be a different number. Modern IOS XE devices use 9 (scrypt) for example.