### PR TITLE
stricter match for Huawei OptiXtrans

### DIFF
--- a/annet/annlib/netdev/devdb/data/devdb.json
+++ b/annet/annlib/netdev/devdb/data/devdb.json
@@ -70,8 +70,8 @@
     "Huawei.EI": "-EI(-|$)",
     "Huawei.HI": "-HI(-|$)",
     "Huawei.SI": "-SI(-|$)",
-    "Huawei.OptiXtrans": " OptiXtrans|DC",
-    "Huawei.OptiXtrans.DC": " DC",
+    "Huawei.OptiXtrans": " (OptiXtrans|DC\\d\\d\\d)",
+    "Huawei.OptiXtrans.DC": " DC\\d\\d\\d",
     "Huawei.OptiXtrans.DC.DC908": " DC908",
 
     "Juniper": "^[Jj]uniper",


### PR DESCRIPTION
Currently we match everything that contains `DC` as Huawei OptiXtrans. That is not correct, for example `Huawei S5720I-12X-PWH-SI-DC` is not OptiXtrans.

Made regex more strict, match only DC with three digits after. According to the [official site](https://e.huawei.com/en/products/optical-transmission) DC908 is the only existing DC model.