### PR TITLE
Remove workaround for the fixed bug in `asyncio.streams`

### DIFF
--- a/annet/__init__.py
+++ b/annet/__init__.py
@@ -49,11 +49,6 @@ def init(options: Namespace):
         colorama.init = lambda *_, **__: None
     colorama.init()
 
-    # Workaround for Python 3.8.0: https://bugs.python.org/issue38529
-    import asyncio.streams
-    if hasattr(asyncio.streams.StreamReaderProtocol, "_on_reader_gc"):
-        asyncio.streams.StreamReaderProtocol._on_reader_gc = lambda *args, **kwargs: None  # pylint: disable=protected-access
-
 
 def assert_python_version():
     if sys.version_info < (3, 10, 0):


### PR DESCRIPTION
It should be no longer needed, since it was fixed at least in CPython 3.9+ (see https://bugs.python.org/issue38529), and `annet` currently requires 3.10+.