### PR TITLE
Fixed 'unsupported breed' exception for devices with manufacturer 'NVIDIA'

### DIFF
--- a/annet/adapters/netbox/common/models.py
+++ b/annet/adapters/netbox/common/models.py
@@ -214,7 +214,7 @@ class NetboxDevice(Entity):
         return type(self) is type(other) and self.url == other.url
 
     def is_pc(self) -> bool:
-        return self.device_type.manufacturer.name in ("Mellanox", "Moxa") or self.breed == "pc"
+        return self.device_type.manufacturer.name in ("Mellanox", "NVIDIA", "Moxa") or self.breed == "pc"
 
     def _make_interface(self, name: str, type: InterfaceType) -> Interface:
         return Interface(


### PR DESCRIPTION
 NVIDIA was assigned a breed 'cuml2'. This requires an explicit
 mention in the is_pc method, which was missed.