### PR TITLE
fix prefix format for arista prefix list gen

### DIFF
--- a/annet/rpl_generators/prefix_lists.py
+++ b/annet/rpl_generators/prefix_lists.py
@@ -128,8 +128,7 @@ class PrefixListFilterGenerator(PartialGenerator, ABC):
                 name,
                 f"seq {i * 5 + 5}",
                 "permit",
-                str(addr_mask.ip).upper(),
-                str(addr_mask.network.prefixlen),
+                addr_mask.with_prefixlen,
             ) + (
                 ("ge", str(match.greater_equal)) if match.greater_equal is not None else ()
             ) + (


### PR DESCRIPTION
Fix format prefixes for Arista prefix list generators:
```diff
-ip prefix-list LOCAL_NETS seq 5 permit 192.168.0.0 16 ge 25 le 32
+ip prefix-list LOCAL_NETS seq 5 permit 192.168.0.0/16 ge 25 le 32
```