### PR TITLE
Juniper comments fix #2

### DIFF
--- a/annet/annlib/rbparser/platform.py
+++ b/annet/annlib/rbparser/platform.py
@@ -25,7 +25,7 @@ VENDOR_DIFF = {
     "routeros": "common.default_diff",
     "aruba": "aruba.default_diff",
     "pc": "common.default_diff",
-    "ribbon": "common.default_diff",
+    "ribbon": "juniper.default_diff",
     "b4com": "common.default_diff",
 }
 
@@ -40,7 +40,7 @@ VENDOR_DIFF_ORDERED = {
     "routeros": "common.ordered_diff",
     "aruba": "common.ordered_diff",
     "pc": "common.ordered_diff",
-    "ribbon": "common.ordered_diff",
+    "ribbon": "juniper.ordered_diff",
     "b4com": "common.ordered_diff",
 }
 

--- a/annet/annlib/tabparser.py
+++ b/annet/annlib/tabparser.py
@@ -387,6 +387,24 @@ class AsrFormatter(BlockExitFormatter):
             yield from super().block_exit(context)
 
 
+class JuniperPatch:
+    def __init__(self):
+        """In the case of comments, odict is not suitable: there may be several identical edit and exit"""
+        self._items = []
+
+    def __setitem__(self, key, value):
+        self._items.append((key, value))
+
+    def keys(self):
+        return list(self)
+
+    def items(self):
+        return self._items
+
+    def __iter__(self):
+        return iter(item[0] for item in self._items)
+
+
 class JuniperFormatter(CommonFormatter):
     patch_set_prefix = "set"
 
@@ -399,7 +417,7 @@ class JuniperFormatter(CommonFormatter):
         comment: str
 
         def __post_init__(self):
-            self.row = self.row.strip()
+            self.row = " ".join(map(lambda x: x.strip("\"'"), self.row.strip().split(" ")))
             self.comment = self.comment.strip()
 
         @classmethod
@@ -485,7 +503,8 @@ class JuniperFormatter(CommonFormatter):
             yield line + self._statement_end
 
     def cmd_paths(self, patch, _prev=tuple()):
-        commands = odict()
+        commands = JuniperPatch()
+
         for item in patch.itms:
             key, childs, context = item.row, item.child, item.context
 
@@ -497,33 +516,39 @@ class JuniperFormatter(CommonFormatter):
                     value = (
                         ""
                         if key.startswith("delete")
-                        else context["comment"]
+                        else key.removeprefix(self.Comment.begin).removesuffix(self.Comment.end).strip()
                     )
-
-                    cmd = "\n".join(
-                        (
-                            "edit " + " ".join(_prev),
-                            " ".join(("annotate", context["row"].split(" ")[0], f'"{value}"')),
-                            "exit"
-                        )
+                    cmds = (
+                        f"edit {' '.join(_prev)}",
+                        " ".join(("annotate", context["row"].split(" ")[0], f'"{value}"')),
+                        "exit"
                     )
                 elif key.startswith("delete"):
-                    cmd = " ".join(("delete", *_prev, key.replace("delete", "", 1).strip()))
+                    cmds = (
+                        " ".join(("delete", *_prev, key.replace("delete", "", 1).strip())),
+                    )
                 elif key.startswith("activate"):
-                    cmd = " ".join(("activate", *_prev, key.replace("activate", "", 1).strip()))
+                    cmds = (
+                        " ".join(("activate", *_prev, key.replace("activate", "", 1).strip())),
+                    )
                 elif key.startswith("deactivate"):
-                    cmd = " ".join(("deactivate", *_prev, key.replace("deactivate", "", 1).strip()))
+                    cmds = (
+                        " ".join(("deactivate", *_prev, key.replace("deactivate", "", 1).strip())),
+                    )
                 else:
-                    cmd = " ".join((self.patch_set_prefix, *_prev, key.strip()))
+                    cmds = (
+                        " ".join((self.patch_set_prefix, *_prev, key.strip())),
+                    )
 
                 # Expanding [ a b c ] junipers list of arguments
-                if matches := re.search(r"^(.*)\s+\[(.+)\]$", cmd):
-                    for c in matches.group(2).split(" "):
-                        if c.strip():
-                            cmd = " ".join([matches.group(1), c])
-                            commands[(cmd,)] = context
-                else:
-                    commands[(cmd,)] = context
+                for cmd in cmds:
+                    if matches := re.search(r"^(.*)\s+\[(.+)\]$", cmd):
+                        for c in matches.group(2).split(" "):
+                            if c.strip():
+                                items = " ".join([matches.group(1), c])
+                                commands[(items,)] = context
+                    else:
+                        commands[(cmd,)] = context
 
         return commands
 

--- a/annet/api/__init__.py
+++ b/annet/api/__init__.py
@@ -700,7 +700,7 @@ async def adeploy(
         ans = deployer.ask_deploy()
         if ans != "y":
             return 2 ** 2
-        progress_bar = None
+
         if sys.stdout.isatty() and not args.no_progress:
             progress_bar = annet.deploy_ui.ProgressBars(odict([(device.fqdn, {}) for device in deploy_cmds]))
             progress_bar.init()

--- a/annet/rulebook/juniper/__init__.py
+++ b/annet/rulebook/juniper/__init__.py
@@ -12,8 +12,8 @@ def comment_processor(item: common.DiffItem):
     if item.op in (Op.REMOVED, Op.ADDED) and item.row.startswith(JuniperFormatter.Comment.begin):
         comment = JuniperFormatter.Comment.loads(item.row)
 
+        item.diff_pre["attrs"]["context"]["comment"] = True
         item.diff_pre["attrs"]["context"]["row"] = comment.row
-        item.diff_pre["attrs"]["context"]["comment"] = comment.comment
         item.diff_pre["key"] = item.diff_pre["raw_rule"] = (
             f"{JuniperFormatter.Comment.begin} {comment.row} {JuniperFormatter.Comment.end}"
         )


### PR DESCRIPTION
1. Not use OrderedDict. Commands in patch may duplicated
2. Fix RIbbon differ (due using JuniperFormatter)
3. Fix new comment value in patch