### PR TITLE
Fix diff acl

### DIFF
--- a/annet/annlib/filter_acl.py
+++ b/annet/annlib/filter_acl.py
@@ -32,7 +32,6 @@ def filter_config(acl: Acl, fmtr: tabparser.CommonFormatter, input_config: Input
         config = patching.apply_acl(config, acl, fatal_acl=False)
         config = fmtr.join(config)
     else:
-        config = typing.cast(input_config, FileConfigTree)
         config = apply_acl_fileconfig(input_config, acl)
     return config
 
@@ -47,7 +46,6 @@ def filter_diff(acl: Acl, fmtr: tabparser.CommonFormatter, input_config: InputCo
         config = unshift_op(config)
         config = config.rstrip()
     else:
-        config = typing.cast(input_config, FileConfigTree)
         config = apply_acl_fileconfig(input_config, acl)
     return config
 
@@ -108,17 +106,23 @@ def get_op(line: str) -> typing.Tuple[str, str, str]:
     indent = ""
     opidx = -1
     rowstart = 0
+
     for rowstart in range(len(line)):
+        if line[rowstart] != " " and line[0:rowstart].strip():
+            break
         if line[rowstart] not in diff_ops:
             break
+
     for opidx in range(rowstart):
         if line[opidx] != " ":
             break
+
     if opidx >= 0:
         op = line[opidx]
         indent = line[:opidx] + line[opidx + 1:rowstart]
     if op != " ":
         indent = indent + " "
+
     return op, indent, line[rowstart:]
 
 

--- a/tests/annet/test_filter_acl.py
+++ b/tests/annet/test_filter_acl.py
@@ -1,0 +1,29 @@
+import textwrap
+
+from annet.annlib import tabparser
+import annet.annlib.filter_acl
+
+
+def test_filter_diff():
+    """Specificity of this test: sign `+` in public-key"""
+
+    vendor = "huawei"
+    diff = textwrap.dedent("""
+    - rsa peer-public-key johndoe encoding-type openssh
+    -   public-key-code begin
+    -     ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCvdj0k/ptPUbPMXwzPPIBqwMv1MW/xBRlf7Io+hwhV
+    -     rJFIFn88Z9oHdvlvnGWO1R9VR+ZNSkncammcdhDElenqQVndLFnxav77445cLBS/AiyjBOxPv3WI6gxp
+    -     +wtNcbkcJrIixDPTzOy9WRre70FKzvy1eIQK/79C7BSLtSlZgldXEnIrDolImUeMGS/c3KM= rsa-key
+    -   public-key-code end
+    -   foo bar
+      aaa
+        local-aaa-user password policy administrator
+    """).strip()
+
+    fmtr = tabparser.make_formatter(vendor)
+    acl = annet.annlib.filter_acl.make_acl("rsa ~\n  foo *", vendor)
+
+    assert annet.annlib.filter_acl.filter_diff(acl, fmtr, diff) == textwrap.dedent("""
+    - rsa peer-public-key johndoe encoding-type openssh
+    -   foo bar
+    """).strip()


### PR DESCRIPTION
```
    - rsa peer-public-key johndoe encoding-type openssh
    -   public-key-code begin
    -     ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCvdj0k/ptPUbPMXwzPPIBqwMv1MW/xBRlf7Io+hwhV
    -     rJFIFn88Z9oHdvlvnGWO1R9VR+ZNSkncammcdhDElenqQVndLFnxav77445cLBS/AiyjBOxPv3WI6gxp
    -     +wtNcbkcJrIixDPTzOy9WRre70FKzvy1eIQK/79C7BSLtSlZgldXEnIrDolImUeMGS/c3KM= rsa-key
    -   public-key-code end
    -   foo bar
      aaa
        local-aaa-user password policy administrator
```

If row start with op (+, -, >), indents is breaking