### PR TITLE
Fix testes on Windows platform

### DIFF
--- a/annet/executor.py
+++ b/annet/executor.py
@@ -3,7 +3,9 @@ import logging
 import multiprocessing
 import os
 import platform
-import resource
+_platform = platform.system()
+if _platform != "Windows":
+    import resource
 import signal
 import statistics
 import time
@@ -478,8 +480,10 @@ def _get_remaining(tasks, pending, tasks_to_device):
         yield (tasks_to_device[task], task)
 
 
-_platform = platform.system()
-_fd_available = resource.getrlimit(resource.RLIMIT_NOFILE)[0]
+if _platform == "Windows":
+    _fd_available = 1024
+else:
+    _fd_available = resource.getrlimit(resource.RLIMIT_NOFILE)[0]
 
 
 def fd_left():

--- a/annet/rulebook/__init__.py
+++ b/annet/rulebook/__init__.py
@@ -98,7 +98,7 @@ class DefaultRulebookProvider(RulebookProvider):
             return self._escaped_rul_cache[name]
         for root_dir in self.root_dir:
             try:
-                with open(path.join(root_dir, "texts", name), "r") as f:
+                with open(path.join(root_dir, "texts", name), "r", encoding="utf-8") as f:
                     self._escaped_rul_cache[name] = self._escape_mako(f.read())
                     return self._escaped_rul_cache[name]
             except FileNotFoundError:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -64,7 +64,7 @@ def get_test_data_path(path):
 
 
 def get_test_data(path, mode="r"):
-    with open(get_test_data_path(path), mode) as data_file:
+    with open(get_test_data_path(path), mode, encoding="utf-8") as data_file:
         return data_file.read()
 
 

--- a/tests/annet/test_fs_storage.py
+++ b/tests/annet/test_fs_storage.py
@@ -2,11 +2,22 @@ from annet.adapters.file.provider import FS, Query, StorageOpts, Device
 from annet.storage import StorageProvider, Storage
 import typing
 import tempfile
+import sys
+import platform
+
+kwargs = dict()
+if platform.system() == "Windows":
+    if sys.version_info < (3, 12):
+        kwargs = {"delete": False}
+    else:
+        kwargs = {"delete": True, "delete_on_close": False}
+
 
 def test_fs():
     Device
-    with tempfile.NamedTemporaryFile(delete=True, delete_on_close=False) as f:
-        f.write(b"""
+    with tempfile.NamedTemporaryFile(**kwargs) as f:
+        f.write(
+            b"""
 devices:
   - hostname: hostname
     fqdn: hostname.domain
@@ -14,7 +25,8 @@ devices:
     interfaces:
       - name: eth0
         description: description
-""")
+"""
+        )
         f.flush()
         fs = FS(StorageOpts(path=f.name))
     print(fs)

--- a/tests/annet/test_fs_storage.py
+++ b/tests/annet/test_fs_storage.py
@@ -5,7 +5,7 @@ import tempfile
 
 def test_fs():
     Device
-    with tempfile.NamedTemporaryFile() as f:
+    with tempfile.NamedTemporaryFile(delete=True, delete_on_close=False) as f:
         f.write(b"""
 devices:
   - hostname: hostname


### PR DESCRIPTION
If you clone the repository and run the tests on Windows, they will almost all fail.
I would like to fix this.
Issue 1: When working with files, UTF-8 encoding should be used.
Issue 2: On Windows, when working with temporary files, a PermissionDenied error is issued.
Issue 3: On Windows, there is no module named 'resource'. As a workaround, we can hardcode the number of available file descriptors to 1024.

tempfile
Changed in version 3.12: Added delete_on_close parameter.