### PR TITLE
Fix testes on Windows platform

### DIFF
--- a/annet/deploy_ui.py
+++ b/annet/deploy_ui.py
@@ -5,6 +5,7 @@ import os
 import sys
 import math
 import asyncio
+import platform
 import textwrap
 import time
 import traceback
@@ -23,7 +24,7 @@ try:
 except ImportError:
     curses = None
 
-uname = os.uname()[0]
+uname = platform.uname()[0]
 NCURSES_SIZE_T = 2 ** 15 - 1
 MIN_CONTENT_HEIGHT = 20
 

--- a/annet/executor.py
+++ b/annet/executor.py
@@ -162,7 +162,7 @@ class DeferredFileWrite:
             raise Exception()
 
     def write(self, data):
-        with open(self._file, self._mode) as fh:
+        with open(self._file, self._mode, encoding="utf-8") as fh:
             fh.write(data)
 
     def close(self):

--- a/annet/rulebook/__init__.py
+++ b/annet/rulebook/__init__.py
@@ -98,7 +98,7 @@ class DefaultRulebookProvider(RulebookProvider):
             return self._escaped_rul_cache[name]
         for root_dir in self.root_dir:
             try:
-                with open(path.join(root_dir, "texts", name), "r") as f:
+                with open(path.join(root_dir, "texts", name), "r", encoding="utf-8") as f:
                     self._escaped_rul_cache[name] = self._escape_mako(f.read())
                     return self._escaped_rul_cache[name]
             except FileNotFoundError:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -65,12 +65,12 @@ def get_test_data_path(path):
 
 
 def get_test_data(path, mode="r"):
-    with open(get_test_data_path(path), mode) as data_file:
+    with open(get_test_data_path(path), mode, encoding="utf-8") as data_file:
         return data_file.read()
 
 
 def save_test_data(path, data, mode="w"):
-    with open(get_test_data_path(path), mode) as data_file:
+    with open(get_test_data_path(path), mode, encoding="utf-8") as data_file:
         data_file.write(data)
 
 

--- a/tests/annet/test_fs_storage.py
+++ b/tests/annet/test_fs_storage.py
@@ -2,10 +2,19 @@ from annet.adapters.file.provider import FS, Query, StorageOpts, Device
 from annet.storage import StorageProvider, Storage
 import typing
 import tempfile
+import platform
+import sys
+
+kwargs = dict()
+if platform.system() == "Windows":
+    if sys.version_info < (3, 12):
+        kwargs = {"delete": False}
+    else:
+        kwargs = {"delete": True, "delete_on_close": False}
 
 def test_fs():
     Device
-    with tempfile.NamedTemporaryFile() as f:
+    with tempfile.NamedTemporaryFile(**kwargs) as f:
         f.write(b"""
 devices:
   - hostname: hostname


### PR DESCRIPTION
If you clone the repository and run the tests on Windows, they will almost all fail.
I would like to fix this.
Issue 1: When working with files, UTF-8 encoding should be used.
Issue 2: On Windows, when working with temporary files, a PermissionDenied error is issued.

tempfile
Changed in version 3.12: Added delete_on_close parameter.