### PR TITLE
mesh: extend existing logic of indirect peers to virtual peers

### DIFF
--- a/annet/adapters/netbox/common/models.py
+++ b/annet/adapters/netbox/common/models.py
@@ -151,14 +151,22 @@ class Interface(Entity, Generic[_IpAddressT]):
     speed: int | None = None
 
     def add_addr(self, address_mask: str, vrf: str | None) -> None:
+        addr = ip_interface(address_mask)
+
+        # when comparing ip addressess
+        # we dont care about the vrf of an addr
+        # because the actual vrf will be
+        # determined by an interface's vrf
+        # and there can be only one
+        #
+        # also we dont care about a mask
+        # because no device will allow
+        # the same addr with multiple masks
         for existing_addr in self.ip_addresses:
-            if existing_addr.address == address_mask and (
-                    (existing_addr.vrf is None and vrf is None) or
-                    (existing_addr.vrf is not None and existing_addr.vrf.name == vrf)
-            ):
+            existing = ip_interface(existing_addr.address)
+            if existing.ip == addr.ip:
                 return
 
-        addr = ip_interface(address_mask)
         vrf_obj = vrf_object(vrf)
         if isinstance(addr, IPv6Interface):
             family = IpFamily(value=6, label="IPv6")

--- a/annet/mesh/executor.py
+++ b/annet/mesh/executor.py
@@ -194,7 +194,7 @@ class MeshExecutor:
         for rule in self._registry.lookup_virtual(device.fqdn):
             for order_number in rule.num:
                 handler_name = self._handler_name(rule.handler)
-                logger.debug("Running direct handler: %s", handler_name)
+                logger.debug("Running virtual handler: %s", handler_name)
                 session = MeshSession()
                 peer_device = VirtualLocal(rule.match, device)
                 peer_virtual = VirtualPeer(num=order_number)
@@ -219,11 +219,6 @@ class MeshExecutor:
                         f"peer data for device `{device.fqdn}`:\n" + str(e)
                     ) from e
 
-                if not hasattr(device_dto, "svi"):
-                    raise ValueError(
-                        f"Handler `{handler_name}` did not provide `svi` number. "
-                        "Virtual peer must be connected to SVI interface."
-                    )
                 pair = VirtualPair(local=device_dto, connected=virtual_dto)
                 virtual_peers.append(pair)
         return virtual_peers

--- a/annet/mesh/models_converter.py
+++ b/annet/mesh/models_converter.py
@@ -17,7 +17,7 @@ LocalDTO = Union[DirectPeerDTO, IndirectPeerDTO, VirtualLocalDTO]
 
 @dataclass
 class InterfaceChanges:
-    addr: str
+    addr: Optional[str] = None
     lag: Optional[int] = None
     lag_links_min: Optional[int] = None
     svi: Optional[int] = None

--- a/annet/mesh/peer_models.py
+++ b/annet/mesh/peer_models.py
@@ -100,14 +100,10 @@ class IndirectPeerDTO(MeshSession, _OptionsDTO):
     svi: Optional[int]
 
 
-class VirtualLocalDTO(_OptionsDTO):
-    asnum: Union[int, str]
+class VirtualLocalDTO(MeshSession, _OptionsDTO):
     pod: int
     addr: str
     description: str
-
-    import_policy: str
-    export_policy: str
     update_source: str
 
     svi: int


### PR DESCRIPTION
Currently virtual peers was created only for svi.
Also addresses that has been assigned for the peering was not added to the address list.

* rename _apply_indirect_interface_changes -> _apply_nondirect_interface_changes
* allow virtual peers to be created even without an svi
* extend VirtualLocalDTO to allow configure everything that MeshSession supports

Also a minor change in netbox interface.add_addr method - more relaxed checking of already existing addresses.