### PR TITLE
Vendor decomposition, chapter 3: apply

### DIFF
--- a/annet/vendors/base.py
+++ b/annet/vendors/base.py
@@ -1,6 +1,7 @@
 import abc
 from typing import ClassVar
 
+from annet.annlib.command import CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.annlib.tabparser import CommonFormatter
 
@@ -11,6 +12,11 @@ class AbstractVendor(abc.ABC):
     @abc.abstractmethod
     def match(self) -> list[str]:
         raise NotImplementedError
+
+    def apply(
+        self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str
+    ) -> tuple[CommandList, CommandList]:
+        return CommandList(), CommandList()
 
     @property
     @abc.abstractmethod

--- a/annet/vendors/library/arista.py
+++ b/annet/vendors/library/arista.py
@@ -1,3 +1,4 @@
+from annet.annlib.command import Command, CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.annlib.tabparser import AristaFormatter
 from annet.vendors.base import AbstractVendor
@@ -7,6 +8,19 @@ from annet.vendors.registry import registry
 @registry.register
 class AristaVendor(AbstractVendor):
     NAME = "arista"
+
+    def apply(self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str) -> tuple[CommandList, CommandList]:
+        before, after = CommandList(), CommandList()
+
+        before.add_cmd(Command("conf s"))
+        if do_commit:
+            after.add_cmd(Command("commit"))
+        else:
+            after.add_cmd(Command("abort"))  # просто exit оставит висеть configure session
+        if do_finalize:
+            after.add_cmd(Command("write memory"))
+
+        return before, after
 
     def match(self) -> list[str]:
         return ["Arista"]

--- a/annet/vendors/library/aruba.py
+++ b/annet/vendors/library/aruba.py
@@ -1,3 +1,4 @@
+from annet.annlib.command import Command, CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.annlib.tabparser import ArubaFormatter
 from annet.vendors.base import AbstractVendor
@@ -7,6 +8,18 @@ from annet.vendors.registry import registry
 @registry.register
 class ArubaVendor(AbstractVendor):
     NAME = "aruba"
+
+    def apply(self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str) -> tuple[CommandList, CommandList]:
+        before, after = CommandList(), CommandList()
+
+        before.add_cmd(Command("conf t"))
+        after.add_cmd(Command("end"))
+        if do_commit:
+            after.add_cmd(Command("commit apply"))
+        if do_finalize:
+            after.add_cmd(Command("write memory"))
+
+        return before, after
 
     def match(self) -> list[str]:
         return ["Aruba"]

--- a/annet/vendors/library/b4com.py
+++ b/annet/vendors/library/b4com.py
@@ -1,3 +1,4 @@
+from annet.annlib.command import Command, CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.annlib.tabparser import B4comFormatter
 from annet.vendors.base import AbstractVendor
@@ -7,6 +8,24 @@ from annet.vendors.registry import registry
 @registry.register
 class B4ComVendor(AbstractVendor):
     NAME = "b4com"
+
+    def apply(self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str) -> tuple[CommandList, CommandList]:
+        before, after = CommandList(), CommandList()
+
+        if hw.B4com.CS2148P:
+            before.add_cmd(Command("conf t"))
+            after.add_cmd(Command("end"))
+            if do_finalize:
+                after.add_cmd(Command("write", timeout=40))
+        else:
+            before.add_cmd(Command("conf t"))
+            if do_commit:
+                after.add_cmd(Command("commit"))
+                after.add_cmd(Command("end"))
+            if do_finalize:
+                after.add_cmd(Command("write", timeout=40))
+
+        return before, after
 
     def match(self) -> list[str]:
         return ["B4com"]

--- a/annet/vendors/library/cisco.py
+++ b/annet/vendors/library/cisco.py
@@ -1,3 +1,4 @@
+from annet.annlib.command import Command, CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.annlib.tabparser import CiscoFormatter
 from annet.vendors.base import AbstractVendor
@@ -7,6 +8,16 @@ from annet.vendors.registry import registry
 @registry.register
 class CiscoVendor(AbstractVendor):
     NAME = "cisco"
+
+    def apply(self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str) -> tuple[CommandList, CommandList]:
+        before, after = CommandList(), CommandList()
+
+        before.add_cmd(Command("conf t"))
+        after.add_cmd(Command("exit"))
+        if do_finalize:
+            after.add_cmd(Command("copy running-config startup-config", timeout=40))
+
+        return before, after
 
     def match(self) -> list[str]:
         return ["Cisco"]

--- a/annet/vendors/library/h3c.py
+++ b/annet/vendors/library/h3c.py
@@ -1,3 +1,4 @@
+from annet.annlib.command import Command, CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.annlib.tabparser import HuaweiFormatter
 from annet.vendors.base import AbstractVendor
@@ -7,6 +8,15 @@ from annet.vendors.registry import registry
 @registry.register
 class H3CVendor(AbstractVendor):
     NAME = "h3c"
+
+    def apply(self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str) -> tuple[CommandList, CommandList]:
+        before, after = CommandList(), CommandList()
+
+        before.add_cmd(Command("system-view"))
+        if do_finalize:
+            after.add_cmd(Command("save force", timeout=90))
+
+        return before, after
 
     def match(self) -> list[str]:
         return ["H3C"]

--- a/annet/vendors/library/huawei.py
+++ b/annet/vendors/library/huawei.py
@@ -1,3 +1,4 @@
+from annet.annlib.command import Command, CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.annlib.tabparser import HuaweiFormatter
 from annet.vendors.base import AbstractVendor
@@ -7,6 +8,18 @@ from annet.vendors.registry import registry
 @registry.register
 class HuaweiVendor(AbstractVendor):
     NAME = "huawei"
+
+    def apply(self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str) -> tuple[CommandList, CommandList]:
+        before, after = CommandList(), CommandList()
+
+        before.add_cmd(Command("system-view"))
+        if do_commit and (hw.Huawei.CE or hw.Huawei.NE):
+            after.add_cmd(Command("commit"))
+        after.add_cmd(Command("q"))
+        if do_finalize:
+            after.add_cmd(Command("save", timeout=20))
+
+        return before, after
 
     def match(self) -> list[str]:
         return ["Huawei"]

--- a/annet/vendors/library/iosxr.py
+++ b/annet/vendors/library/iosxr.py
@@ -1,3 +1,4 @@
+from annet.annlib.command import Command, CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.annlib.tabparser import AsrFormatter
 from annet.vendors.base import AbstractVendor
@@ -7,6 +8,16 @@ from annet.vendors.registry import registry
 @registry.register
 class IosXrVendor(AbstractVendor):
     NAME = "iosxr"
+
+    def apply(self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str) -> tuple[CommandList, CommandList]:
+        before, after = CommandList(), CommandList()
+
+        before.add_cmd(Command("configure exclusive"))
+        if do_commit:
+            after.add_cmd(Command("commit"))
+        after.add_cmd(Command("exit"))
+
+        return before, after
 
     def match(self) -> list[str]:
         return ["Cisco.ASR", "Cisco.XR", "Cisco.XRV"]

--- a/annet/vendors/library/juniper.py
+++ b/annet/vendors/library/juniper.py
@@ -1,3 +1,4 @@
+from annet.annlib.command import Command, CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.annlib.tabparser import JuniperFormatter
 from annet.vendors.base import AbstractVendor
@@ -7,6 +8,16 @@ from annet.vendors.registry import registry
 @registry.register
 class JuniperVendor(AbstractVendor):
     NAME = "juniper"
+
+    def apply(self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str) -> tuple[CommandList, CommandList]:
+        before, after = CommandList(), CommandList()
+
+        before.add_cmd(Command("configure exclusive"))
+        if do_commit:
+            after.add_cmd(Command("commit", timeout=30))
+        after.add_cmd(Command("exit"))
+
+        return before, after
 
     def match(self) -> list[str]:
         return ["Juniper"]

--- a/annet/vendors/library/nexus.py
+++ b/annet/vendors/library/nexus.py
@@ -1,3 +1,4 @@
+from annet.annlib.command import Command, CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.annlib.tabparser import NexusFormatter
 from annet.vendors.base import AbstractVendor
@@ -7,6 +8,16 @@ from annet.vendors.registry import registry
 @registry.register
 class NexusVendor(AbstractVendor):
     NAME = "nexus"
+
+    def apply(self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str) -> tuple[CommandList, CommandList]:
+        before, after = CommandList(), CommandList()
+
+        before.add_cmd(Command("conf t"))
+        after.add_cmd(Command("exit"))
+        if do_finalize:
+            after.add_cmd(Command("copy running-config startup-config", timeout=40))
+
+        return before, after
 
     def match(self) -> list[str]:
         return ["Cisco.Nexus"]

--- a/annet/vendors/library/nokia.py
+++ b/annet/vendors/library/nokia.py
@@ -1,3 +1,4 @@
+from annet.annlib.command import Command, CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.annlib.tabparser import NokiaFormatter
 from annet.vendors.base import AbstractVendor
@@ -7,6 +8,15 @@ from annet.vendors.registry import registry
 @registry.register
 class NokiaVendor(AbstractVendor):
     NAME = "nokia"
+
+    def apply(self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str) -> tuple[CommandList, CommandList]:
+        before, after = CommandList(), CommandList()
+
+        before.add_cmd(Command("configure private"))
+        if do_commit:
+            after.add_cmd(Command("commit"))
+
+        return before, after
 
     def match(self) -> list[str]:
         return ["Nokia"]

--- a/annet/vendors/library/optixtrans.py
+++ b/annet/vendors/library/optixtrans.py
@@ -1,19 +1,16 @@
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.annlib.tabparser import OptixtransFormatter
-from annet.vendors.base import AbstractVendor
 from annet.vendors.registry import registry
+
+from .huawei import HuaweiVendor
 
 
 @registry.register
-class OptixTransVendor(AbstractVendor):
+class OptixTransVendor(HuaweiVendor):
     NAME = "optixtrans"
 
     def match(self) -> list[str]:
-        return ["OptiXtrans"]
-
-    @property
-    def reverse(self) -> str:
-        return "undo"
+        return ["Huawei.OptiXtrans"]
 
     @property
     def hardware(self) -> HardwareView:
@@ -22,6 +19,5 @@ class OptixTransVendor(AbstractVendor):
     def make_formatter(self, **kwargs) -> OptixtransFormatter:
         return OptixtransFormatter(**kwargs)
 
-    @property
-    def exit(self) -> str:
-        return "quit"
+    def svi_name(self, num: int) -> str:
+        return f"vlan{num}"

--- a/annet/vendors/library/pc.py
+++ b/annet/vendors/library/pc.py
@@ -1,3 +1,6 @@
+import os
+
+from annet.annlib.command import Command, CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.annlib.tabparser import CommonFormatter
 from annet.vendors.base import AbstractVendor
@@ -14,6 +17,15 @@ class PCVendor(AbstractVendor):
     @property
     def reverse(self) -> str:
         return "-"
+
+    def apply(self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str) -> tuple[CommandList, CommandList]:
+        before, after = CommandList(), CommandList()
+
+        if hw.soft.startswith(("Cumulus", "SwitchDev")):
+            if os.environ.get("ETCKEEPER_CHECK", False):
+                before.add_cmd(Command("etckeeper check"))
+
+        return before, after
 
     @property
     def hardware(self) -> HardwareView:

--- a/annet/vendors/library/ribbon.py
+++ b/annet/vendors/library/ribbon.py
@@ -1,3 +1,4 @@
+from annet.annlib.command import Command, CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.annlib.tabparser import RibbonFormatter
 from annet.vendors.base import AbstractVendor
@@ -7,6 +8,16 @@ from annet.vendors.registry import registry
 @registry.register
 class RibbonVendor(AbstractVendor):
     NAME = "ribbon"
+
+    def apply(self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str) -> tuple[CommandList, CommandList]:
+        before, after = CommandList(), CommandList()
+
+        before.add_cmd(Command("configure exclusive"))
+        if do_commit:
+            after.add_cmd(Command("commit", timeout=30))
+        after.add_cmd(Command("exit"))
+
+        return before, after
 
     def match(self) -> list[str]:
         return ["Ribbon"]

--- a/annet/vendors/library/routeros.py
+++ b/annet/vendors/library/routeros.py
@@ -1,3 +1,4 @@
+from annet.annlib.command import Command, CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.annlib.tabparser import RosFormatter
 from annet.vendors.base import AbstractVendor
@@ -7,6 +8,18 @@ from annet.vendors.registry import registry
 @registry.register
 class RouterOSVendor(AbstractVendor):
     NAME = "routeros"
+
+    def apply(self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str) -> tuple[CommandList, CommandList]:
+        before, after = CommandList(), CommandList()
+
+        # FIXME: пока не удалось победить \x1b[c после включения safe mode
+        # if len(cmds) > 99:
+        #     raise Exception("RouterOS does not support more 100 actions in safe mode")
+        # before.add_cmd(RosDevice.SAFE_MODE)
+        pass
+        # after.add_cmd(RosDevice.SAFE_MODE)
+
+        return before, after
 
     def match(self) -> list[str]:
         return ["RouterOS"]

--- a/tests/annet/test_patch.py
+++ b/tests/annet/test_patch.py
@@ -1,3 +1,4 @@
+import os
 from unittest import mock
 
 import pytest
@@ -16,7 +17,11 @@ from . import patch_data
 )
 def test_patch(name, sample, ann_connectors):
     vendor = sample.get("vendor", "huawei").lower()
+
     hw = make_hw_stub(vendor)
+    if soft := sample.get("soft"):
+        hw.soft = soft
+
     rb = rulebook.get_rulebook(hw)
     formatter = registry_connector.get().match(hw).make_formatter(indent="")
 
@@ -30,9 +35,15 @@ def test_patch(name, sample, ann_connectors):
 
     diff = patching.make_diff(old, new, rb, [])
     pre = patching.make_pre(diff)
-    patch_tree = patching.make_patch(pre=pre, rb=rb, hw=hw, add_comments=False)
-    cmd_paths = formatter.cmd_paths(patch_tree)
-    cmds = deploy.apply_deploy_rulebook(hw, cmd_paths)
+
+    fake_environ = os.environ.copy()
+    with mock.patch.object(os, "environ", new=fake_environ):
+        if sample_environ := sample.get("env"):
+            fake_environ.update(sample_environ)
+
+        patch_tree = patching.make_patch(pre=pre, rb=rb, hw=hw, add_comments=False)
+        cmd_paths = formatter.cmd_paths(patch_tree)
+        cmds = deploy.apply_deploy_rulebook(hw, cmd_paths)
 
     generated = []
     for cmd in cmds:

--- a/tests/annet/test_patch/h3_single.yaml
+++ b/tests/annet/test_patch/h3_single.yaml
@@ -1,0 +1,8 @@
+- vendor: h3c
+  before: ""
+  after: |
+    hostname "test"
+  patch: |
+    system-view
+    hostname "test"
+    save force

--- a/tests/annet/test_patch/nokia_single.yaml
+++ b/tests/annet/test_patch/nokia_single.yaml
@@ -1,0 +1,8 @@
+- vendor: Nokia
+  before: ""
+  after: |
+    hostname "test"
+  patch: |
+    configure private
+    /configure hostname "test"
+    commit

--- a/tests/annet/test_patch/pc_single.yaml
+++ b/tests/annet/test_patch/pc_single.yaml
@@ -1,0 +1,10 @@
+- vendor: PC
+  soft: Cumulus
+  env:
+    ETCKEEPER_CHECK: "true"
+  before: ""
+  after: |
+    hostname "test"
+  patch: |
+    etckeeper check
+    hostname "test"

--- a/tests/annet/test_patch/ribbon_single.yaml
+++ b/tests/annet/test_patch/ribbon_single.yaml
@@ -1,0 +1,9 @@
+- vendor: Ribbon
+  before: ""
+  after: |
+    hostname "test"
+  patch: |
+    configure exclusive
+    set hostname "test"
+    commit
+    exit

--- a/tests/annet/test_patch/routeros_single.yaml
+++ b/tests/annet/test_patch/routeros_single.yaml
@@ -1,0 +1,8 @@
+- vendor: RouterOS
+  before: ""
+  after: |
+    system
+      hostname "test"
+  patch: |
+    /system
+    hostname "test"


### PR DESCRIPTION
# Pull Request: Refactor apply Function into Vendor-Specific Implementation

## Overview
This PR refactors the apply function in annet/annlib/rulebook/common.py by moving vendor-specific command generation logic to their respective vendor classes. This change improves code organization and maintainability by:

1. Following the Single Responsibility Principle by moving vendor-specific logic to respective vendor classes
2. Enabling easier extension for new vendor support
3. Reducing the size and complexity of the central apply function

## Changes

- Moved the monolithic apply function from common.py to individual vendor implementations
- Added an apply method to the AbstractVendor base class with a default implementation
- Updated each vendor class with its specific command generation logic
- Modified the apply function in common.py to delegate to the appropriate vendor implementation
- Added tests for new vendor implementations (H3C, Nokia, PC, Ribbon, RouterOS)
- Fixed the OptiXtrans vendor implementation to properly inherit from HuaweiVendor

## Implementation Details

The refactored apply function now simply delegates to the vendor-specific implementation:
def apply(hw, do_commit, do_finalize, path):
    return registry_connector.get().match(hw).apply(hw, do_commit, do_finalize, path)
Each vendor class now implements its own apply method that generates the appropriate command sequences based on the hardware, commit, and finalize parameters.

## Testing

Added new test cases for H3C, Nokia, PC, Ribbon, and RouterOS vendors to validate the refactored implementation. All existing tests continue to pass.

Context: [ p:8199 c:389]

© Claude 3.7 Sonnet