### PR TITLE
bgp model: add ipv4_vpn_unicast/ipv6_vpn_unicast families

### DIFF
--- a/annet/bgp_models.py
+++ b/annet/bgp_models.py
@@ -139,7 +139,15 @@ class BFDTimers:
     multiplier: int = 4
 
 
-Family = Literal["ipv4_unicast", "ipv6_unicast", "ipv4_labeled_unicast", "ipv6_labeled_unicast", "l2vpn_evpn"]
+Family = Literal[
+    "ipv4_unicast",
+    "ipv6_unicast",
+    "ipv4_vpn_unicast",
+    "ipv6_vpn_unicast",
+    "ipv4_labeled_unicast",
+    "ipv6_labeled_unicast",
+    "l2vpn_evpn",
+]
 
 
 @dataclass(frozen=True)

--- a/annet/mesh/device_models.py
+++ b/annet/mesh/device_models.py
@@ -40,12 +40,16 @@ class _FamiliesMixin:
     def __init__(self, **kwargs):
         kwargs.setdefault("ipv4_unicast", FamilyOptions(family="ipv4_unicast"))
         kwargs.setdefault("ipv6_unicast", FamilyOptions(family="ipv6_unicast"))
+        kwargs.setdefault("ipv4_vpn_unicast", FamilyOptions(family="ipv4_vpn_unicast"))
+        kwargs.setdefault("ipv6_vpn_unicast", FamilyOptions(family="ipv6_vpn_unicast"))
         kwargs.setdefault("ipv4_labeled_unicast", FamilyOptions(family="ipv4_labeled_unicast"))
         kwargs.setdefault("ipv6_labeled_unicast", FamilyOptions(family="ipv6_labeled_unicast"))
         kwargs.setdefault("l2vpn_evpn", FamilyOptions(family="l2vpn_evpn"))
         super().__init__(**kwargs)
     ipv4_unicast: Annotated[FamilyOptions, Merge()]
     ipv6_unicast: Annotated[FamilyOptions, Merge()]
+    ipv4_vpn_unicast: Annotated[FamilyOptions, Merge()]
+    ipv6_vpn_unicast: Annotated[FamilyOptions, Merge()]
     ipv4_labeled_unicast: Annotated[FamilyOptions, Merge()]
     ipv6_labeled_unicast: Annotated[FamilyOptions, Merge()]
     l2vpn_evpn: Annotated[FamilyOptions, Merge()]
@@ -55,6 +59,8 @@ class VrfOptions(_FamiliesMixin, BaseMeshModel):
     def __init__(self, vrf_name: str, **kwargs):
         kwargs.setdefault("ipv4_unicast", FamilyOptions(family="ipv4_unicast", vrf_name=vrf_name))
         kwargs.setdefault("ipv6_unicast", FamilyOptions(family="ipv6_unicast", vrf_name=vrf_name))
+        kwargs.setdefault("ipv4_vpn_unicast", FamilyOptions(family="ipv4_unicast", vrf_name=vrf_name))
+        kwargs.setdefault("ipv6_vpn_unicast", FamilyOptions(family="ipv6_unicast", vrf_name=vrf_name))
         kwargs.setdefault("ipv4_labeled_unicast", FamilyOptions(family="ipv4_labeled_unicast", vrf_name=vrf_name))
         kwargs.setdefault("ipv6_labeled_unicast", FamilyOptions(family="ipv6_labeled_unicast", vrf_name=vrf_name))
         kwargs.setdefault("l2vpn_evpn", FamilyOptions(family="l2vpn_evpn", vrf_name=vrf_name))


### PR DESCRIPTION
The naming is taken from https://github.com/annetutil/annet/issues/154