### PR TITLE
Fix for incorrect indent (CiscoFormatter)

### DIFF
--- a/annet/vendors/tabparser.py
+++ b/annet/vendors/tabparser.py
@@ -316,6 +316,9 @@ class CiscoFormatter(BlockExitFormatter):
         block_exit_strings = [self._block_exit]
         tree = self.split_remove_spaces(text)
         for i, item in enumerate(tree):
+            # fix incorrect indent for "exit-address-family"
+            if item == " exit-address-family":
+                item = "  exit-address-family"
             block_exit_strings, new_indent = self._split_indent(
                 item, additional_indent, block_exit_strings
             )

--- a/annet/vendors/tabparser.py
+++ b/annet/vendors/tabparser.py
@@ -319,6 +319,10 @@ class CiscoFormatter(BlockExitFormatter):
             # fix incorrect indent for "exit-address-family"
             if item == " exit-address-family":
                 item = "  exit-address-family"
+            # fix incorrect indent for "class-map match.*"
+            if i and tree[i - 1].startswith("class-map match"):
+                if item.startswith("  description"):
+                    item = item[1:]
             block_exit_strings, new_indent = self._split_indent(
                 item, additional_indent, block_exit_strings
             )


### PR DESCRIPTION
#333 #332 

```
!
class-map match-all MASTER
  description ## WOLAND ##
 match dscp ef
!
```

```
!
vrf definition MARGARITA
 rd 1.1.1.1:1
 route-target export 65000:1
 route-target import 65000:1
 !
 address-family ipv4
 exit-address-family
!
```

```
!
router isis Behemoth
 metric-style wide
 !
 address-family ipv6
  maximum-paths 6
 exit-address-family
!
```