### PR TITLE
fix: undo ntp unicast-server for VRP8 and VRP5

### DIFF
--- a/annet/rulebook/texts/huawei.rul
+++ b/annet/rulebook/texts/huawei.rul
@@ -55,9 +55,9 @@ dhcp snooping user-bind http
 
 ntp server disable
 ntp ipv6 server disable
-ntp unicast-server *
 ntp unicast-server domain *
 ntp unicast-server ipv6 *
+ntp unicast-server *
 ntp ~
 dns snooping ttl delay-time
 dns ~

--- a/annet/rulebook/texts/huawei.rul
+++ b/annet/rulebook/texts/huawei.rul
@@ -58,6 +58,8 @@ ntp ipv6 server disable
 ntp unicast-server domain *
 ntp unicast-server ipv6 *
 ntp unicast-server *
+ntp-service unicast-server ipv6 *
+ntp-service unicast-server *
 ntp ~
 dns snooping ttl delay-time
 dns ~

--- a/annet/rulebook/texts/huawei.rul
+++ b/annet/rulebook/texts/huawei.rul
@@ -55,6 +55,9 @@ dhcp snooping user-bind http
 
 ntp server disable
 ntp ipv6 server disable
+ntp unicast-server *
+ntp unicast-server domain *
+ntp unicast-server ipv6 *
 ntp ~
 dns snooping ttl delay-time
 dns ~

--- a/tests/annet/test_patch/huawei_undo_ntp.yaml
+++ b/tests/annet/test_patch/huawei_undo_ntp.yaml
@@ -1,0 +1,49 @@
+- vendor: huawei
+  before: |
+    ntp unicast-server 10.10.10.10 preferred
+  after: ''
+  patch: |
+    system-view
+    undo ntp unicast-server 10.10.10.10
+    q
+    save
+
+- vendor: huawei
+  before: |
+    ntp unicast-server domain test
+  after: ''
+  patch: |
+    system-view
+    undo ntp unicast-server domain test
+    q
+    save
+
+- vendor: huawei
+  before: |
+    ntp unicast-server ipv6 2001:4860:4860::8888 preferred
+  after: ''
+  patch: |
+    system-view
+    undo ntp unicast-server ipv6 2001:4860:4860::8888
+    q
+    save
+
+- vendor: huawei
+  before: |
+    ntp-service unicast-server 10.10.10.10 preference
+  after: ''
+  patch: |
+    system-view
+    undo ntp-service unicast-server 10.10.10.10
+    q
+    save
+
+- vendor: huawei
+  before: |
+    ntp-service unicast-server ipv6 2001:4860:4860::8888 preference
+  after: ''
+  patch: |
+    system-view
+    undo ntp-service unicast-server ipv6 2001:4860:4860::8888
+    q
+    save


### PR DESCRIPTION
Changing the NTP unicast-server IP on Huawei VRP 8 results in an error:

```
│cmd: undo ntp unicast-server 10.10.10.10 preferred
│                                                ^
│Error: Too many parameters found at '^' position.
```
Configuration example:
```
ntp unicast-server 10.10.10.10 preferred
```
Rules for deleting nested commands within a section have also been added.