### PR TITLE
fix: juniper syslog match comands

### DIFF
--- a/annet/rulebook/texts/juniper.rul
+++ b/annet/rulebook/texts/juniper.rul
@@ -18,7 +18,11 @@ system
     ntp
         server *
         source-address *
-
+    syslog
+        host *
+            match
+        file messages
+            match
 routing-options
     autonomous-system *
     ~

--- a/annet/rulebook/texts/juniper.rul
+++ b/annet/rulebook/texts/juniper.rul
@@ -23,6 +23,7 @@ system
             match
         file messages
             match
+
 routing-options
     autonomous-system *
     ~

--- a/tests/annet/test_patch/juniper_syslog.yaml
+++ b/tests/annet/test_patch/juniper_syslog.yaml
@@ -1,0 +1,67 @@
+- vendor: juniper
+  before: |-
+    system {
+        syslog {
+            host 10.10.10.10 {
+                match "!(.*requires a license.*)|(.*LICENSE_EXPIRED:.*)";                          
+            }
+        }
+    }
+  after: |-
+    system {
+        syslog {
+            host 10.10.10.10;
+        }
+    }
+  patch: |
+    configure exclusive
+    delete system syslog host 10.10.10.10 match
+    commit
+    exit
+
+- vendor: juniper
+  before: |-
+    system {
+        syslog {
+            host 10.10.10.10 {
+                match "!(.*requires a license.*)|(.*LICENSE_EXPIRED:.*)";
+                port 10001;
+            }
+        }
+    }
+  after: |-
+    system {
+        syslog {
+            host 10.10.10.10;
+        }
+    }
+  patch: |
+    configure exclusive
+    delete system syslog host 10.10.10.10 match
+    delete system syslog host 10.10.10.10 port 10001
+    commit
+    exit
+
+- vendor: juniper
+  before: |-
+    system {
+        syslog {
+            file messages {
+                any notice;
+                match "!(.*requires a license.*)|(.*LICENSE_EXPIRED:.*)";
+            }
+        }
+    }
+  after: |-
+    system {
+        syslog {
+            file messages {
+              any notice;
+            }
+        }
+    }
+  patch: |
+    configure exclusive
+    delete system syslog file messages match
+    commit
+    exit


### PR DESCRIPTION
Modifications to the processing rules for syslog match commands on Juniper devices, which may include regular expressions and control characters, may result in a "statement not found" error during configuration parsing.