### PR TITLE
rest of bgp peer parameters must be specified before peer will be ena…

### DIFF
--- a/annet/rulebook/texts/huawei.order
+++ b/annet/rulebook/texts/huawei.order
@@ -250,6 +250,7 @@ bgp
     group
     peer * as-number *
     peer * local-as *
+    peer ~
     ipv[46]-family|link-state-family unicast|l2vpn-family evpn
         undo undo maximum load-balancing %order_reverse
         maximum load-balancing


### PR DESCRIPTION
Параметры BGP пира должны быть описаны в одном месте, до того как пир может быть включен в address-family