### PR TITLE
fix: determine netbox device breed based on devdb 

### DIFF
--- a/annet/adapters/netbox/common/manufacturer.py
+++ b/annet/adapters/netbox/common/manufacturer.py
@@ -27,6 +27,8 @@ def get_breed(manufacturer: str, model: str):
         return "cuml2"
     elif hw.Juniper:
         return "jun10"
+    elif hw.Cisco.Nexus:
+        return "nxos"
     elif hw.Cisco:
         return "ios12"
     elif hw.Arista:


### PR DESCRIPTION
devdb already does manufacturer parsing, so there is no need to duplicate this.

* use HardwareView() for get_breed()
* return nxos breed for nexus devices
* remove adva breed - its not supported currently anyway

Also fixes https://github.com/annetutil/gnetcli_adapter/issues/58
Reimplements https://github.com/annetutil/annet/pull/342
