### PR TITLE
Fix `Command.__str__` may return bytes if `cmd` is bytes

### DIFF
--- a/annet/annlib/command.py
+++ b/annet/annlib/command.py
@@ -17,7 +17,7 @@ class Question:
 
 @dataclass
 class Command:
-    cmd: str
+    cmd: str | bytes
     questions: Optional[List[Question]] = None
     exc_handler: Optional[List[Question]] = None
     timeout: Optional[int] = None  # total timeout
@@ -26,6 +26,8 @@ class Command:
     suppress_eof: bool = False
 
     def __str__(self) -> str:
+        if isinstance(self.cmd, bytes):
+            return self.cmd.decode("utf-8")
         return self.cmd
 
 


### PR DESCRIPTION
It's currently a legal case for pre and after cmds.

Returning bytes from `__str__` method leads to `TypeError: __str__ returned non-string (type bytes)` exception.