### PR TITLE
feat: juniper ipv6 diff

### DIFF
--- a/annet/rulebook/juniper/iface.py
+++ b/annet/rulebook/juniper/iface.py
@@ -1,0 +1,39 @@
+import ipaddress
+from annet.annlib.types import Op
+from annet.rulebook import common
+from annet.rulebook.common import DiffItem
+
+
+def ipv6_addr(old, new, diff_pre, _pops):
+    """
+    Приводим все ipv6-адреса в объекты IPv6Interface и далее сравниваем
+    """
+    address_new_line = [a for a in map(_parse_ipv6, new) if a]
+    address_old_line = [a for a in map(_parse_ipv6, old) if a]
+
+    ret = []
+    for item in common.default_diff(old, new, diff_pre, _pops):
+        # Проверяем адрес помеченный под снос на наличии в новом списке
+        if item.op == Op.REMOVED and _parse_ipv6(item.row) in address_new_line:
+            result_item = DiffItem(Op.AFFECTED, item.row, item.children, item.diff_pre)
+        # Проверяем адрес помеченный для добавления на наличии в старом списке
+        elif item.op == Op.ADDED and _parse_ipv6(item.row) in address_old_line:
+            result_item = None
+        # Остальное без изменений
+        else:
+            result_item = item
+        if result_item:
+            ret.append(result_item)
+    return ret
+
+
+def _parse_ipv6(row):
+    """
+    Парсит IPv6-интерфейс из строки, предполагая, что адрес находится на втором месте.
+    Возвращает объект IPv6Interface или None.
+    """
+    if row:
+        parts = row.split()
+        if len(parts) > 1:
+            return ipaddress.IPv6Interface(parts[1])
+    return None

--- a/annet/rulebook/texts/juniper.rul
+++ b/annet/rulebook/texts/juniper.rul
@@ -72,6 +72,8 @@ interfaces
             description ~
             mtu *
             vlan-tags
+            family inet6
+                address * %diff_logic=juniper.iface.ipv6_addr
         description ~
         mtu *
         hold-time

--- a/tests/annet/test_patch/juniper_ipv6.yaml
+++ b/tests/annet/test_patch/juniper_ipv6.yaml
@@ -1,0 +1,109 @@
+- vendor: juniper
+  before: |-
+    interfaces {
+        xe-0/0/33 {
+            unit 80 {
+                family inet6 {
+                    address fd00:008:fc00:0041:0102::1/80;
+                }
+            }
+        }
+    }
+  after: |-
+    interfaces {
+        xe-0/0/33 {
+            unit 80 {
+                family inet6 {
+                    address fd00:8:fc00:41:102::1/80;
+                }
+            }
+        }
+    }
+  patch: ""
+
+- vendor: juniper
+  before: |-
+    interfaces {
+        xe-0/0/33 {
+            unit 80 {
+                family inet6 {
+                    address fd00:8:fc00:41:102::1/80;
+                }
+            }
+        }
+    }
+  after: |-
+    interfaces {
+        xe-0/0/33 {
+            unit 80 {
+                family inet6 {
+                    address fd00:008:fc00:0041:0102::1/80;
+                }
+            }
+        }
+    }
+  patch: ""
+
+- vendor: juniper
+  before: |-
+    interfaces {
+        xe-0/0/33 {
+            unit 80 {
+                family inet6 {
+                    address fd00:8:fc00:41:102::1/80;
+                    address fd00:0008:fc00:0042:0102:0000:0000:0001/64;
+                }
+            }
+        }
+    }
+  after: |-
+    interfaces {
+        xe-0/0/33 {
+            unit 80 {
+                family inet6 {
+                    address fd00:008:fc00:0041:0102::1/80;
+                    address fd00:8:fc00:42:102::1/64;
+                }
+            }
+        }
+    }
+  patch: ""
+
+- vendor: juniper
+  before: |-
+    interfaces {
+        et-0/0/2 {
+            vlan-tagging;
+            unit 80 {
+                vlan-id 80;
+                family inet6 {
+                    address fd00:8:fa01:1:102::/127;
+                }
+            }
+            unit 90 {
+                vlan-id 90;
+                family inet6 {
+                    address fd00:8:fa01:0:102::/127;
+                }
+            }
+        }
+    }
+  after: |-
+    interfaces {
+        et-0/0/2 {
+            vlan-tagging;
+            unit 80 {
+                vlan-id 80;
+                family inet6 {
+                    address fd00:8:fa01:0001:102::/127;
+                }
+            }
+            unit 90 {
+                vlan-id 90;
+                family inet6 {
+                    address fd00:8:fa01:0000:102::/127;
+                }
+            }
+        }
+    }
+  patch: ""


### PR DESCRIPTION
На Juniper IPv6-адрес может быть записан в полной или короткой форме, например:
 address fd00:008:fc00:0041:0102::1/80
 address fd00:8:fc00:41:102::1/80

Переход от полной записи IPv6-адреса к короткой не считается изменением в кандидатной конфигурации Juniper, соответственно, чтобы не вызывать diff, проверяем идентичные ipv6 адреса, представленные разными способами.

<img width="625" alt="diff" src="https://github.com/user-attachments/assets/c9f79ca3-da04-4beb-9682-b220aaf605f9" />
