### PR TITLE
Nexus mgmt

### DIFF
--- a/annet/rulebook/texts/nexus.rul
+++ b/annet/rulebook/texts/nexus.rul
@@ -35,7 +35,7 @@ snmp-server host ~
 
 ntp distribute %logic=cisco.misc.no_ntp_distribute
 
-!interface */(mgmt|ipmi|Vlan1$)/
+!interface */(ipmi|Vlan1$)/
 
 interface mgmt0$
     !vrf member management


### PR DESCRIPTION
Added the rules prohibiting the removal of `vrf context management' and changing the memership of the `mgmt0` with it.