### PR TITLE
fix: fhrp_group_descr_in_netbox_3.4/3.7

### DIFF
--- a/annet/adapters/netbox/common/models.py
+++ b/annet/adapters/netbox/common/models.py
@@ -139,7 +139,7 @@ class FHRPGroup(Generic[_DeviceIPT]):
     group_id: int
     display: str
     protocol: str
-    description: str
+    description: str | None
 
     name: str
     auth_type: str | None


### PR DESCRIPTION
adaptix.ProviderNotFoundError: Cannot produce converter for <Signature (src: list[annetbox.v37.models.FHRPGroup], /) -> list[annet.adapters.netbox.v37.models.FHRPGroupV37]>
  × Cannot create top-level coercer
  ╰──▷ Cannot create coercer for iterables. Coercer for element cannot be created
     │ Linking: ‹src: list[annetbox.v37.models.FHRPGroup]› ──▷ list[annet.adapters.netbox.v37.models.FHRPGroupV37]
     ╰──▷ Cannot create coercer for models. Coercers for some linkings are not found
        │ Linking: FHRPGroup ──▷ FHRPGroupV37
        ╰──▷ Cannot find coercer
             Linking: ‹FHRPGroup.description: str | None› ──▷ ‹FHRPGroupV37.description: str›