### PR TITLE
fix: huawei undo ssh publickey

### DIFF
--- a/annet/rulebook/texts/huawei.rul
+++ b/annet/rulebook/texts/huawei.rul
@@ -139,6 +139,7 @@ ssh server key-exchange
 ssh server dh-exchange
 ssh server cipher
 ssh server hmac
+ssh server publickey
 
 ftp client source %logic=huawei.misc.undo_redo
 

--- a/tests/annet/test_patch/huawei_undo_ssh_pubkey.yaml
+++ b/tests/annet/test_patch/huawei_undo_ssh_pubkey.yaml
@@ -1,0 +1,20 @@
+- vendor: huawei
+  before: |
+    ssh server publickey ecc dsa rsa
+  after: |
+    ssh server publickey rsa_sha2_512 rsa_sha2_256
+  patch: |
+    system-view
+    ssh server publickey rsa_sha2_512 rsa_sha2_256
+    q
+    save
+
+- vendor: huawei
+  before: |
+    ssh server publickey ecc dsa rsa
+  after:
+  patch: |
+    system-view
+    undo ssh server publickey
+    q
+    save


### PR DESCRIPTION
Before fix:
Patch:
```
undo ssh server publickey ecc dsa rsa
ssh server publickey rsa_sha2_512 rsa_sha2_256

```
Problem:

```
undo ssh server publickey ecc dsa rsa
                                   ^
Error:Too many parameters found at '^' position.
```

After fix:
Patch without undo(Replace parameters):
```
ssh server publickey rsa_sha2_512 rsa_sha2_256
```
Or delete:
```
undo ssh server publickey
```