### PR TITLE
`VRF` configuration must be before `VPC domain` in case vrf is used i…

### DIFF
--- a/annet/rulebook/texts/nexus.order
+++ b/annet/rulebook/texts/nexus.order
@@ -60,6 +60,8 @@ ipv6 dhcp relay
 
 vrf context
 
+vpc domain
+
 interface */Vlan\d+/
 interface *
     no switchport


### PR DESCRIPTION
…n it.