### PR TITLE
Fix applying `--filter-acl` on top of JSON Fragments

### DIFF
--- a/annet/annlib/jsontools.py
+++ b/annet/annlib/jsontools.py
@@ -4,8 +4,9 @@ import copy
 import fnmatch
 import json
 from collections.abc import Mapping, Sequence
+from itertools import starmap
 from operator import itemgetter
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 import jsonpatch
 import jsonpointer
@@ -16,23 +17,28 @@ def format_json(data: Any, stable: bool = False) -> str:
     return json.dumps(data, indent=4, ensure_ascii=False, sort_keys=not stable) + "\n"
 
 
-def _sanitize_json_pointer(pattern: str) -> str:
-    """Replace special characters on the JsonPointer valid ones"""
-    return pattern.replace("~", "~0").replace("/", "~1")
-
-
 def apply_json_fragment(
         old: Dict[str, Any],
-        new_fragment: Dict[str, Any],
-        acl: List[str],
+        new_fragment: Dict[str, Any], *,
+        acl: Sequence[str],
+        filters: Sequence[str] | None = None,
 ) -> Dict[str, Any]:
     """
     Replace parts of the old document with 'new_fragment' using ACL restrictions.
+    If `filter` is not `None`, only those parts which also matches at least one filter
+    from the list will be modified (updated or deleted).
     """
     full_new_config = copy.deepcopy(old)
     for acl_item in acl:
         new_pointers = _resolve_json_pointers(acl_item, new_fragment)
         old_pointers = _resolve_json_pointers(acl_item, full_new_config)
+        if filters is not None:
+            new_pointers = _apply_filters_to_json_pointers(
+                new_pointers, filters, content=new_fragment
+            )
+            old_pointers = _apply_filters_to_json_pointers(
+                old_pointers, filters, content=full_new_config
+            )
 
         for pointer in new_pointers:
             new_value = pointer.get(new_fragment)
@@ -102,30 +108,7 @@ def apply_patch(content: Optional[bytes], patch_bytes: bytes) -> bytes:
     return new_contents
 
 
-def apply_acl_filters(content: Dict[str, Any], filters: List[str]) -> Dict[str, Any]:
-    result = {}
-    for f in filters:
-        filter_text = f.strip()
-        if not filter_text:
-            continue
-
-        pointers = _resolve_json_pointers(filter_text, content)
-        for pointer in pointers:
-            part = pointer.get(copy.deepcopy(content))
-
-            sub_tree = result
-            for i in pointer.get_parts():
-                if i not in sub_tree:
-                    sub_tree[i] = {}
-                sub_tree = sub_tree[i]
-
-            patch = jsonpatch.JsonPatch([{"op": "add", "path": pointer.path, "value": part}])
-            result = patch.apply(result)
-
-    return result
-
-
-def _resolve_json_pointers(pattern: str, content: Dict[str, Any]) -> List[jsonpointer.JsonPointer]:
+def _resolve_json_pointers(pattern: str, content: dict[str, Any]) -> list[jsonpointer.JsonPointer]:
     """
     Resolve globbed json pointer pattern to a list of actual pointers, existing in the document.
 
@@ -163,7 +146,7 @@ def _resolve_json_pointers(pattern: str, content: Dict[str, Any]) -> List[jsonpo
     ]
     """
     parts = jsonpointer.JsonPointer(pattern).parts
-    matched = [([], content)]
+    matched = [((), content)]
     for part in parts:
         new_matched = []
         for matched_parts, doc in matched:
@@ -179,10 +162,64 @@ def _resolve_json_pointers(pattern: str, content: Dict[str, Any]) -> List[jsonpo
                     if fnmatch.fnmatchcase(str(i), part)
                 ]
             for key, sub_doc in keys_and_docs:
-                new_matched.append((matched_parts + [key], sub_doc))
+                new_matched.append((matched_parts + (key,), sub_doc))
         matched = new_matched
 
-    ret: List[jsonpointer.JsonPointer] = []
+    ret: list[jsonpointer.JsonPointer] = []
     for matched_parts, _ in matched:
-        ret.append(jsonpointer.JsonPointer("/" + "/".join([_sanitize_json_pointer(v) for v in matched_parts])))
+        ret.append(jsonpointer.JsonPointer.from_parts(matched_parts))
     return ret
+
+
+def _apply_filters_to_json_pointers(
+        pointers: Iterable[jsonpointer.JsonPointer],
+        filters: Sequence[str], *,
+        content: Any,
+) -> list[jsonpointer.JsonPointer]:
+
+    """
+    Takes a list of pointers, a list of filters and a document
+    and returns a list of pointers that match at least one of the filters
+    (if necessary, pointers may be deeper than from the input).
+
+    For example, given:
+    pointers=["/foo", "/lorem/ipsum", "/lorem/dolor"],
+    filters=["/foo/b*/q*", "/lorem"],
+    content={
+        "foo": {
+            "bar": {
+                "baz": [1, 2],
+                "qux": [3, 4]
+            },
+            "qux": {
+                "baz": [5, 6]
+            }
+        },
+        "lorem": {
+            "ipsum": [7, 8],
+            "dolor": "sit",
+            "amet": "consectetur"
+        }
+    }
+    The function will return:
+    ["/foo/bar/qux", "/lorem/ipsum", "/lorem/dolor"]
+    """
+
+    ret: set[jsonpointer.JsonPointer] = set()
+    for filter_item in filters:
+        filter_parts = jsonpointer.JsonPointer(filter_item).parts
+        for pointer in pointers:
+            pointer_parts = pointer.parts
+            if not all(starmap(fnmatch.fnmatchcase, zip(pointer_parts, filter_parts))):
+                continue  # common part not matched
+            if len(filter_parts) > len(pointer_parts):
+                # filter is deeper than data pointer
+                deeper_doc = pointer.resolve(content)
+                deeper_pattern = "".join((
+                    f"/{jsonpointer.escape(part)}"
+                    for part in filter_parts[len(pointer_parts):]
+                ))
+                ret.update(map(pointer.join, _resolve_json_pointers(deeper_pattern, deeper_doc)))
+            else:
+                ret.add(pointer)
+    return sorted(ret)

--- a/annet/gen.py
+++ b/annet/gen.py
@@ -259,38 +259,19 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
 
         entire_results = res.entire_results
         json_fragment_results = res.json_fragment_results
-        old_json_fragment_files = old_files.json_fragment_files
 
         new_files = res.new_files()
-        new_json_fragment_files = res.new_json_fragment_files(old_json_fragment_files)
 
-        filters: List[str] = []
-        filters_text = build_filter_text(filterer, device, ctx.stdin, ctx.args, ctx.config)
-        if filters_text:
-            filters = filters_text.split("\n")
+        filters = None
+        if filters_text := build_filter_text(filterer, device, ctx.stdin, ctx.args, ctx.config):
+            filters = filters_text.removesuffix("\n").split("\n")
 
-            for file_name in new_json_fragment_files:
-                if new_json_fragment_files.get(file_name) is not None:
-                    new_json_fragment_files = _update_json_config(
-                        new_json_fragment_files,
-                        file_name,
-                        jsontools.apply_acl_filters(new_json_fragment_files[file_name][0], filters)
-                    )
-            for file_name in old_json_fragment_files:
-                if old_json_fragment_files.get(file_name) is not None:
-                    old_json_fragment_files[file_name] = jsontools.apply_acl_filters(old_json_fragment_files[file_name], filters)
+        old_json_fragment_files = old_files.json_fragment_files.copy()
+        new_json_fragment_files = res.new_json_fragment_files(old_json_fragment_files, filters=filters)
 
         if ctx.args.acl_safe:
             safe_new_files = res.new_files(safe=True)
-            safe_new_json_fragment_files = res.new_json_fragment_files(old_json_fragment_files, safe=True)
-            if filters:
-                for file_name in safe_new_json_fragment_files:
-                    if safe_new_json_fragment_files.get(file_name):
-                        safe_new_json_fragment_files = _update_json_config(
-                            safe_new_json_fragment_files,
-                            file_name,
-                            jsontools.apply_acl_filters(safe_new_json_fragment_files[file_name][0], filters)
-                        )
+            safe_new_json_fragment_files = res.new_json_fragment_files(old_json_fragment_files, safe=True, filters=filters)
 
     if ctx.args.profile:
         perf = res.perf_mesures()
@@ -320,13 +301,6 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
         safe_new_json_fragment_files=safe_new_json_fragment_files,
         filter_acl_rules=filter_acl_rules,
     )
-
-
-def _update_json_config(json_files, file_name, new_config):
-    file = list(json_files[file_name])
-    file[0] = new_config
-    json_files[file_name] = tuple(file)
-    return json_files
 
 
 @dataclasses.dataclass

--- a/annet/generators/result.py
+++ b/annet/generators/result.py
@@ -4,9 +4,11 @@ import textwrap
 from collections import OrderedDict as odict
 from typing import (
     Any,
+    Callable,
     Dict,
     Optional,
-    Tuple, Callable,
+    Sequence,
+    Tuple,
 )
 
 from annet.annlib import jsontools
@@ -84,6 +86,7 @@ class RunGeneratorResult:
             self,
             old_files: Dict[str, Optional[str]],
             safe: bool = False,
+            filters: Sequence[str] | None = None,
     ) -> Dict[str, Tuple[Any, Optional[str]]]:
         # TODO: safe
         files: Dict[str, Tuple[Any, Optional[str]]] = {}
@@ -101,9 +104,9 @@ class RunGeneratorResult:
             previous_config: Dict[str, Any] = files[filepath][0]
             new_fragment = generator_result.config
             new_config = jsontools.apply_json_fragment(
-                previous_config,
-                new_fragment,
-                result_acl,
+                previous_config, new_fragment,
+                acl=result_acl,
+                filters=filters,
             )
             if jsontools.format_json(new_config) == jsontools.format_json(previous_config):
                 # config is not changed, deprioritize reload_cmd

--- a/tests/annet/test_jsonfragments.py
+++ b/tests/annet/test_jsonfragments.py
@@ -1,9 +1,10 @@
 import pytest
-from typing import Dict, Any
+from typing import Any
 
 import annet.diff
 from annet.annlib.netdev.views.hardware import HardwareView
-import annet.annlib.jsontools as jsontools
+from annet.generators.result import RunGeneratorResult
+from annet.types import GeneratorJSONFragmentResult, GeneratorPerf
 
 
 @pytest.fixture()
@@ -61,89 +62,6 @@ def edgecore_json_config():
                 "router_id": "1.102.6.8"
             }
         }
-    }
-
-
-@pytest.fixture()
-def acl_filter1() -> str:
-    return """/ACL_RULE/YATTL|RETRANSMIT_RX_klg-10d8-2_0/IN_PORT
-/ACL_TABLE_TYPE"""
-
-
-@pytest.fixture()
-def filter1_result() -> Dict[str, Any]:
-    return {
-        "ACL_RULE": {
-            "YATTL|RETRANSMIT_RX_klg-10d8-2_0": {
-                "IN_PORT": "Ethernet328"
-            }
-        },
-        "ACL_TABLE_TYPE": {
-            "DSCP": {
-                "actions": [
-                    "packet_action"
-                ],
-                "bind_points": [
-                    "PORT"
-                ],
-                "matches": [
-                    "src_ipv6",
-                    "dscp",
-                    "in_port",
-                    "ip_type"
-                ]
-            }
-        }
-    }
-
-
-@pytest.fixture()
-def acl_filter2() -> str:
-    return """
-"""
-
-
-@pytest.fixture()
-def acl_filter3() -> str:
-    return """/BGP_GLOBALS/default/default_ipv4_unicast
-/BGP_GLOBALS/default/default_local_preference
-/BGP_GLOBALS/123hsjd/default_local_preference"""
-
-
-@pytest.fixture()
-def filter3_result():
-    return {
-        "BGP_GLOBALS": {
-            "default": {
-                "default_ipv4_unicast": "false",
-                "default_local_preference": "100"
-            }
-        }
-    }
-
-
-@pytest.fixture()
-def acl_filter4() -> str:
-    return """/ACL_*LE/*/I*"""
-
-
-@pytest.fixture()
-def filter4_result() -> Dict[str, Any]:
-    return {
-        "ACL_RULE": {
-            "YATTL|RETRANSMIT_RX_klg-10d8-2_0": {
-                "IN_PORT": "Ethernet328",
-                "IP_TYPE": "IPV6ANY",
-            },
-            "YATTL|RETRANSMIT_RX_klg-10d8-2_17": {
-                "IN_PORT": "Ethernet328",
-                "IP_TYPE": "IPV6ANY",
-            },
-            "YATTL|RETRANSMIT_RX_klg-10d8-2_25": {
-                "IN_PORT": "Ethernet328",
-                "IP_TYPE": "IPV6ANY",
-            },
-        },
     }
 
 
@@ -297,34 +215,6 @@ def diff_result() -> str:
 +}"""
 
 
-def test_acl_filter_correct_parts(edgecore_json_config, acl_filter1, filter1_result):
-    filters = acl_filter1.split("\n")
-    result = jsontools.apply_acl_filters(edgecore_json_config, filters)
-
-    assert result == filter1_result
-
-
-def test_acl_filter_empty_line(edgecore_json_config, acl_filter2):
-    filters = acl_filter2.split("\n")
-    result = jsontools.apply_acl_filters(edgecore_json_config, filters)
-
-    assert result == {}
-
-
-def test_acl_filter_wrong_filters_skip(edgecore_json_config, acl_filter3, filter3_result):
-    filters = acl_filter3.split("\n")
-    result = jsontools.apply_acl_filters(edgecore_json_config, filters)
-
-    assert result == filter3_result
-
-
-def test_acl_filter_wildcards(edgecore_json_config, acl_filter4, filter4_result):
-    filters = acl_filter4.split("\n")
-    result = jsontools.apply_acl_filters(edgecore_json_config, filters)
-
-    assert result == filter4_result
-
-
 @pytest.fixture()
 def _set_differ():
     orig_device_file_differ_connector_classes = annet.diff.file_differ_connector._classes
@@ -336,6 +226,7 @@ def _set_differ():
 
     annet.diff.file_differ_connector._classes = orig_device_file_differ_connector_classes
     annet.diff.file_differ_connector._cache = orig_device_file_differ_connector_cache
+
 
 def test_diff(diff_old, edgecore_json_config, diff_result, _set_differ):
     old_files = {"filename": (diff_old, "test")}
@@ -351,3 +242,125 @@ def test_diff(diff_old, edgecore_json_config, diff_result, _set_differ):
         if line not in res_lines:
             raise Exception(f"There is wrong line in diff: '{line}'")
         res_lines.remove(line)
+
+
+def test_new_json_fragment_files():
+    def make_interface_fragment(config: dict[str, Any]) -> GeneratorJSONFragmentResult:
+        return GeneratorJSONFragmentResult(
+            name="interfaces",
+            tags=["interfaces"],
+            path="/etc/sonic/config_db.json",
+            acl=["/INTERFACE", "/BREAKOUT_CFG", "/VLAN_INTERFACE"],
+            acl_safe=["/INTERFACE/*/description", "/VLAN_INTERFACE/*/description"],
+            config=config,
+            reload="sonic-reload",
+            perf=GeneratorPerf(1.0, None, None),
+            reload_prio=100,
+        )
+
+    old_files = {
+        "/etc/sonic/config_db.json": {
+            "INTERFACE": {
+                "Ethernet0": {"admin_status": "up", "description": "Ether0"},
+            },
+            "BREAKOUT_CFG": {
+                "Ethernet0": {"brkout_mode": "1x400G"},
+            },
+            "VLAN_INTERFACE": {
+                "Ethernet0": {"vrf_name": "default", "description": "Ether0 VLAN"},
+            },
+        },
+    }
+
+    gen_res = RunGeneratorResult()
+    gen_res.add_json_fragment(
+        make_interface_fragment({
+            "INTERFACE": {
+                "Ethernet0": {"admin_status": "up", "description": "Ether0"},  # unchanged
+                "Ethernet4": {"admin_status": "up", "description": "Ether4"},  # added
+            },
+            "BREAKOUT_CFG": {
+                "Ethernet0": {"brkout_mode": "2x200G"},  # updated
+                "Ethernet4": {"brkout_mode": "1x10G"},  # added
+            },
+            # no "VLAN_INTERFACE"
+        }),
+    )
+
+    # full unsafe diff
+    assert gen_res.new_json_fragment_files(old_files, safe=False) == {
+        "/etc/sonic/config_db.json": (
+            {
+                "INTERFACE": {
+                    "Ethernet0": {"admin_status": "up", "description": "Ether0"},  # unchanged
+                    "Ethernet4": {"admin_status": "up", "description": "Ether4"},  # added
+                },
+                "BREAKOUT_CFG": {
+                    "Ethernet0": {"brkout_mode": "2x200G"},  # updated
+                    "Ethernet4": {"brkout_mode": "1x10G"},  # added
+                },
+                # "VLAN_INTEFACE" deleted
+            },
+            "sonic-reload",
+        ),
+    }
+    # safe diff
+    assert gen_res.new_json_fragment_files(old_files, safe=True) == {
+        "/etc/sonic/config_db.json": (
+            {
+                "INTERFACE": {
+                    "Ethernet0": {"admin_status": "up", "description": "Ether0"},  # unchanged
+                    "Ethernet4": {"description": "Ether4"},  # added (only description)
+                },
+                "BREAKOUT_CFG": {
+                    "Ethernet0": {"brkout_mode": "1x400G"},  # unchanged
+                    # no "Ethernet4" (not in safe ACL)
+                },
+                "VLAN_INTERFACE": {  # unchanged (not in safe ACL)
+                    "Ethernet0": {"vrf_name": "default"},
+                },
+            },
+            "sonic-reload",
+        ),
+    }
+
+    # unsafe diff with filter
+    filters = ["/*/Ethernet4"]
+    assert gen_res.new_json_fragment_files(old_files, safe=False, filters=filters) == {
+        "/etc/sonic/config_db.json": (
+            {
+                "INTERFACE": {
+                    "Ethernet0": {"admin_status": "up", "description": "Ether0"},  # unchanged (not in filters)
+                    "Ethernet4": {"admin_status": "up", "description": "Ether4"},  # added
+                },
+                "BREAKOUT_CFG": {
+                    "Ethernet0": {"brkout_mode": "1x400G"},  # unchanged (not in filters)
+                    "Ethernet4": {"brkout_mode": "1x10G"},  # added
+                },
+                "VLAN_INTERFACE": {
+                    "Ethernet0": {"vrf_name": "default", "description": "Ether0 VLAN"},  # unchanged (not in filters)
+                }
+            },
+            "sonic-reload",
+        ),
+    }
+    # safe diff with filter
+    filters = ["/*/Ethernet4"]
+    assert gen_res.new_json_fragment_files(old_files, safe=True, filters=filters) == {
+        "/etc/sonic/config_db.json": (
+            {
+                "INTERFACE": {
+                    "Ethernet0": {"admin_status": "up", "description": "Ether0"},  # unchanged (not in filters)
+                    "Ethernet4": {"description": "Ether4"},  # added (only description)
+                },
+                "BREAKOUT_CFG": {
+                    "Ethernet0": {"brkout_mode": "1x400G"},  # unchanged (not in filters)
+                    # no "Ethernet4" (not in safe ACL)
+                },
+                "VLAN_INTERFACE": {
+                    "Ethernet0": {"vrf_name": "default", "description": "Ether0 VLAN"},  # unchanged (not in filters)
+                }
+            },
+            "sonic-reload",
+        ),
+    }


### PR DESCRIPTION
### Problem

Previously, the algorithm worked as follows: it filtered the contents of both the old and new configuration data and then created a diff and a patch between the filtered data.

However, this algorithm could cause an unexpected corruption. Consider the following scenario:

* old config: `{"abc": {"a": 1, "b": 2}}`;
* new config: `{"abc": {"b": 2, "c": 3}}`;
* `--filter-acl`: `/abc/c`.

In this case, the filtered old config was `{}`, the filtered new config was `{"abc": {"c": 3}}`, and the resulting JSON patch was `[{"op": "add", "path": "/abc", "value": {"c": 3}}]`.\
When this patch is applied, the result is `{"abc": {"c": 3}}`. This deletes `/abc/a` and `/abc/b`, which might be unexpected for the user.

### Solution

Instead of filtering the contents of the config, we should filter the JSON fragment when applying it to the new data.