### PR TITLE
fixed arista as-path rpl_generator and added test

### DIFF
--- a/annet/rpl_generators/policy.py
+++ b/annet/rpl_generators/policy.py
@@ -696,16 +696,11 @@ class RoutingPolicyGenerator(PartialGenerator, ABC):
             else:
                 yield "set", "as-path match all replacement", *action.value.set
 
-        if action.value.expand_last_as:
-            last_as_suffix: Sequence[str] = "last-as", action.value.expand_last_as
-        else:
-            last_as_suffix = ()
-
         if action.value.prepend:
-            for path_item in action.value.prepend:
-                yield "set", "as-path prepend", path_item, *last_as_suffix
-        else:
-            yield "set", "as-path prepend", *last_as_suffix
+            yield "set", "as-path prepend", *action.value.prepend
+        if action.value.expand_last_as:
+            yield "set", "as-path prepend last-as", action.value.expand_last_as
+
         if action.value.expand:
             raise RuntimeError("as_path.expand is not supported for arista")
         if action.value.delete:


### PR DESCRIPTION
It looks like current implementation has multiple issues. This is the test output before the changes:
```
    route-map policy permit 10
      set as-path match all replacement 65431
  +   set as-path prepend
    route-map policy permit 20
      set as-path prepend 65432
    route-map policy permit 30
  -   set as-path prepend 65435 65435 65435
  ?                       ------------
  +   set as-path prepend 65435
    route-map policy permit 40
      set as-path prepend last-as 3
    route-map policy permit 50
  -   set as-path prepend 65435 65435 65435
  -   set as-path prepend last-as 3
  +   set as-path prepend 65435 last-as 3
```

Test syntax is correct:
```
r1(config)#show ver | grep -iE 'arista|software'
Arista cEOSLab
Software image version: 4.33.2F-40713977.4332F (engineering build)
r1(config)#no route-map policy
r1(config)#route-map policy permit 10
r1(config-route-map-policy)#  set as-path match all replacement 65431
r1(config-route-map-policy)#route-map policy permit 20
r1(config-route-map-policy)#  set as-path prepend 65432
r1(config-route-map-policy)#route-map policy permit 30
r1(config-route-map-policy)#  set as-path prepend 65435 65435 65435
r1(config-route-map-policy)#route-map policy permit 40
r1(config-route-map-policy)#  set as-path prepend last-as 3
r1(config-route-map-policy)#route-map policy permit 50
r1(config-route-map-policy)#  set as-path prepend 65435 65435 65435
r1(config-route-map-policy)#  set as-path prepend last-as 3
r1(config-route-map-policy)#
r1(config-route-map-policy)#exit
r1(config)#
```
