### PR TITLE
feat: add all fqdns filter

### DIFF
--- a/annet/adapters/netbox/common/adapter.py
+++ b/annet/adapters/netbox/common/adapter.py
@@ -47,7 +47,7 @@ class NetboxAdapter(
     ],
 ):
     @abstractmethod
-    def list_all_fqdns(self) -> list[str]:
+    def list_fqdns(self, query: dict[str, list[str]] | None = None) -> list[str]:
         raise NotImplementedError()
 
     @abstractmethod

--- a/annet/adapters/netbox/common/query.py
+++ b/annet/adapters/netbox/common/query.py
@@ -37,19 +37,7 @@ class NetboxQuery(Query):
         return self.query
 
     def parse_query(self) -> Filter:
-        query_groups = defaultdict(list)
-        for q in self.globs:
-            if FIELD_VALUE_SEPARATOR in q:
-                glob_type, param = q.split(FIELD_VALUE_SEPARATOR, 2)
-                if glob_type not in ALLOWED_GLOB_GROUPS:
-                    raise Exception(f"unknown query type: '{glob_type}'")
-                if not param:
-                    raise Exception(f"empty param for '{glob_type}'")
-                query_groups[glob_type].append(param)
-            else:
-                query_groups["name"].append(q)
-
-        query_groups.default_factory = None
+        query_groups = parse_query(self.globs)
         return cast(Filter, query_groups)
 
     def is_empty(self) -> bool:
@@ -62,3 +50,18 @@ class NetboxQuery(Query):
             if FIELD_VALUE_SEPARATOR in q:
                 return False
         return True
+
+
+def parse_query(query: list[str]) -> dict[str, list[str]]:
+    query_groups = defaultdict(list)
+    for q in query:
+        if FIELD_VALUE_SEPARATOR in q:
+            glob_type, param = q.split(FIELD_VALUE_SEPARATOR, 2)
+            if glob_type not in ALLOWED_GLOB_GROUPS:
+                raise Exception(f"unknown query type: '{glob_type}'")
+            if not param:
+                raise Exception(f"empty param for '{glob_type}'")
+            query_groups[glob_type].append(param)
+        else:
+            query_groups["name"].append(q)
+    return dict(query_groups)

--- a/annet/adapters/netbox/common/storage_base.py
+++ b/annet/adapters/netbox/common/storage_base.py
@@ -54,6 +54,7 @@ class BaseNetboxStorage(
             token = opts.token
             threads = opts.threads
             self.exact_host_filter = opts.exact_host_filter
+            self.all_hosts_filter = opts.all_hosts_filter
         self.netbox = self._init_adapter(url=url, token=token, ssl_context=ctx, threads=threads)
         self._all_fqdns: Optional[list[str]] = None
         self._id_devices: dict[int, NetboxDeviceT] = {}
@@ -87,7 +88,7 @@ class BaseNetboxStorage(
 
     def resolve_all_fdnds(self) -> list[str]:
         if self._all_fqdns is None:
-            self._all_fqdns = self.netbox.list_all_fqdns()
+            self._all_fqdns = self.netbox.list_fqdns(self.all_hosts_filter)
         return self._all_fqdns
 
     def make_devices(

--- a/annet/adapters/netbox/common/storage_opts.py
+++ b/annet/adapters/netbox/common/storage_opts.py
@@ -1,5 +1,6 @@
 import os
 from typing import Any, Optional
+from .query import parse_query
 
 DEFAULT_URL = "http://localhost"
 
@@ -12,17 +13,24 @@ class NetboxStorageOpts:
             insecure: bool = False,
             exact_host_filter: bool = False,
             threads: int = 1,
+            all_hosts_filter: dict[str, list[str]] | None = None,
     ):
         self.url = url
         self.token = token
         self.insecure = insecure
         self.exact_host_filter = exact_host_filter
         self.threads = threads
+        self.all_hosts_filter: dict[str, list[str]] = all_hosts_filter or {}
 
     @classmethod
     def parse_params(cls, conf_params: Optional[dict[str, str]], cli_opts: Any):
         url = os.getenv("NETBOX_URL") or conf_params.get("url") or DEFAULT_URL
         token = os.getenv("NETBOX_TOKEN", "").strip() or conf_params.get("token") or ""
+        all_hosts_filter = None
+        if all_hosts_filter_env := os.getenv("NETBOX_ALL_HOSTS_FILTER", "").strip():
+            all_hosts_filter = parse_query(all_hosts_filter_env.split(","))
+        elif all_hosts_filter_params := conf_params.get("all_hosts_filter"):
+            all_hosts_filter = all_hosts_filter_params
         threads = os.getenv("NETBOX_CLIENT_THREADS", "").strip() or conf_params.get("threads") or "1"
         insecure = False
         if insecure_env := os.getenv("NETBOX_INSECURE", "").lower():
@@ -39,4 +47,5 @@ class NetboxStorageOpts:
             insecure=insecure,
             exact_host_filter=exact_host_filter,
             threads=int(threads),
+            all_hosts_filter=all_hosts_filter,
         )

--- a/annet/adapters/netbox/v37/storage.py
+++ b/annet/adapters/netbox/v37/storage.py
@@ -70,10 +70,11 @@ class NetboxV37Adapter(NetboxAdapter[
             list[FHRPGroupV37],
         )
 
-    def list_all_fqdns(self) -> list[str]:
+    def list_fqdns(self, query: dict[str, list[str]] | None = None) -> list[str]:
+        query = query or {}
         return [
             d.name
-            for d in self.netbox.dcim_all_devices_brief().results
+            for d in self.netbox.dcim_all_devices_brief(**query).results
         ]
 
     def list_devices(self, query: dict[str, list[str]]) -> list[NetboxDeviceV37]:

--- a/annet/adapters/netbox/v41/storage.py
+++ b/annet/adapters/netbox/v41/storage.py
@@ -71,10 +71,11 @@ class NetboxV41Adapter(NetboxAdapter[
             list[FHRPGroupV41],
         )
 
-    def list_all_fqdns(self) -> list[str]:
+    def list_fqdns(self, query: dict[str, list[str]] | None = None) -> list[str]:
+        query = query or {}
         return [
             d.name
-            for d in self.netbox.dcim_all_devices_brief().results
+            for d in self.netbox.dcim_all_devices_brief(**query).results
         ]
 
     def list_devices(self, query: dict[str, list[str]]) -> list[NetboxDeviceV41]:

--- a/annet/adapters/netbox/v42/storage.py
+++ b/annet/adapters/netbox/v42/storage.py
@@ -72,10 +72,11 @@ class NetboxV42Adapter(NetboxAdapter[
             list[FHRPGroupV41],
         )
 
-    def list_all_fqdns(self) -> list[str]:
+    def list_fqdns(self, query: dict[str, list[str]] | None = None) -> list[str]:
+        query = query or {}
         return [
             d.name
-            for d in self.netbox.dcim_all_devices_brief().results
+            for d in self.netbox.dcim_all_devices_brief(**query).results
         ]
 
     def list_devices(self, query: dict[str, list[str]]) -> list[NetboxDeviceV42]:


### PR DESCRIPTION
`resolve_all_fdnds()` is used in the mesh. The problem is that if there are extra objects, it takes a long time to load everything.
This patch add `NETBOX_ALL_HOSTS_FILTER` env and `all_hosts_filter` conf param to solve the problem.