### PR TITLE
fix: undo/change_huawei_tac_source_ip

### DIFF
--- a/annet/rulebook/texts/huawei.rul
+++ b/annet/rulebook/texts/huawei.rul
@@ -200,9 +200,11 @@ aaa
 
 hwtacacs-server template *
     hwtacacs-server shared-key
+    hwtacacs-server source-ip
 
 hwtacacs server template *
     hwtacacs server shared-key
+    hwtacacs server source-ip
 
 !radius-server template default
 

--- a/tests/annet/test_patch/huawei_undo_hwtacacs_source_ip.yaml
+++ b/tests/annet/test_patch/huawei_undo_hwtacacs_source_ip.yaml
@@ -1,0 +1,57 @@
+- vendor: huawei
+  before: |
+    hwtacacs-server template tac
+      hwtacacs-server source-ip source-vlanif 10
+  after: |
+    hwtacacs-server template tac
+  patch: |
+    system-view
+    hwtacacs-server template tac
+      undo hwtacacs-server source-ip
+      quit
+    q
+    save
+
+- vendor: huawei
+  before: |
+    hwtacacs-server template tac
+      hwtacacs-server source-ip source-vlanif 10
+  after: |
+    hwtacacs-server template tac
+      hwtacacs-server source-ip 20.20.20.20
+  patch: |
+    system-view
+    hwtacacs-server template tac
+      hwtacacs-server source-ip 20.20.20.20
+      quit
+    q
+    save
+
+- vendor: huawei
+  before: |
+    hwtacacs-server template tac
+      hwtacacs-server source-ip source-vlanif 10
+  after: |
+    hwtacacs-server template tac
+  patch: |
+    system-view
+    hwtacacs-server template tac
+      undo hwtacacs-server source-ip
+      quit
+    q
+    save
+
+- vendor: huawei
+  before: |
+    hwtacacs server template tac
+      hwtacacs server source-ip source-vlanif 10
+  after: |
+    hwtacacs server template tac
+      hwtacacs server source-ip 20.20.20.20
+  patch: |
+    system-view
+    hwtacacs server template tac
+      hwtacacs server source-ip 20.20.20.20
+      quit
+    q
+    save


### PR DESCRIPTION
Changing the tacacs source-ip on Huawei VRP 5/8 results in an error:
```
│cmd:undo hwtacacs-server source-ip source-vlanif 10
                                    ^
Error:Too many parameters found at '^' position.
```
Configuration example:
```
hwtacacs-server template tac
      hwtacacs-server source-ip source-vlanif 10
```
or 
```
hwtacacs-server template tac
      hwtacacs-server source-ip 20.20.20.20
```