### PR TITLE
[RouterOS] Always use top-level commands for patch

### DIFF
--- a/tests/annet/test_patch/routeros_firewall.yaml
+++ b/tests/annet/test_patch/routeros_firewall.yaml
@@ -1,0 +1,12 @@
+- # test that the same two commands inside different blocks
+  # will not be in conflict with each other
+  vendor: routeros
+  before: |
+  after: |
+    /ipv6 firewall
+     add action=accept chain=input
+    /ip firewall
+     add action=accept chain=input
+  patch: |
+    /ipv6 firewall add action=accept chain=input
+    /ip firewall add action=accept chain=input

--- a/tests/annet/test_patch/routeros_localusers.yaml
+++ b/tests/annet/test_patch/routeros_localusers.yaml
@@ -41,16 +41,13 @@
     set full name=full policy=local,telnet,ssh,ftp,reboot,read,write,policy,test,winbox,password,web,sniff,sensitive,api,romon,dude,tikapp skin=default
     add name=nocmon policy=read,test,api,!local,!telnet,!ssh,!ftp,!reboot,!write,!policy,!winbox,!password,!web,!sniff,!sensitive,!romon,!dude,!tikapp skin=default
   patch: |
-    /file
-    remove [ find name=gg.txt ]
-    print file=user4@Example.ssh_key.txt
-    print file=user5@example.com.ssh_key.txt
-    set user4@Example.ssh_key.txt contents="ssh-dss AAAAAAAA== user4@Example"
-    set user5@example.com.ssh_key.txt contents="ssh-dss AAAABBBB== user5@example.com"
-    /user
-    remove [ find address="" disabled=no group=full name=superuser ]
-    add address="" disabled=no group=full name=user4
-    add address="" disabled=no group=nocmon name=user5
-    /user ssh-keys
-    import public-key-file=user4@Example.ssh_key.txt user=user4
-    import public-key-file=user5@example.com.ssh_key.txt user=user5
+    /file remove [ find name=gg.txt ]
+    /file print file=user4@Example.ssh_key.txt
+    /file print file=user5@example.com.ssh_key.txt
+    /file set user4@Example.ssh_key.txt contents="ssh-dss AAAAAAAA== user4@Example"
+    /file set user5@example.com.ssh_key.txt contents="ssh-dss AAAABBBB== user5@example.com"
+    /user remove [ find address="" disabled=no group=full name=superuser ]
+    /user add address="" disabled=no group=full name=user4
+    /user add address="" disabled=no group=nocmon name=user5
+    /user ssh-keys import public-key-file=user4@Example.ssh_key.txt user=user4
+    /user ssh-keys import public-key-file=user5@example.com.ssh_key.txt user=user5

--- a/tests/annet/test_patch/routeros_single.yaml
+++ b/tests/annet/test_patch/routeros_single.yaml
@@ -1,8 +1,7 @@
 - vendor: RouterOS
   before: ""
   after: |
-    system
-      hostname "test"
+    system identity
+      set name=test
   patch: |
-    /system
-    hostname "test"
+    /system identity set name=test


### PR DESCRIPTION
Previously, annet generated commands with nested context paths. For example:
```routeros
/file
remove [ find name=gg.txt ]
print file=user4@Example.ssh_key.txt
set user4@Example.ssh_key.txt contents="ssh-dss AAAAAAAA== user4@Example"
/user
remove [ find address="" disabled=no group=full name=superuser ]
add address="" disabled=no group=full name=user4
/user ssh-keys
import public-key-file=user4@Example.ssh_key.txt user=user4
```

Now, all commands explicitly use top-level paths:
```routeros
/file remove [ find name=gg.txt ]
/file print file=user4@Example.ssh_key.txt
/file set user4@Example.ssh_key.txt contents="ssh-dss AAAAAAAA== user4@Example"
/user remove [ find address="" disabled=no group=full name=superuser ]
/user add address="" disabled=no group=full name=user4
/user ssh-keys import public-key-file=user4@Example.ssh_key.txt user=user4
```

This change resolves issues when some parts of the patch may be lost because of an erroneous deduplication logic. For instance:
```routeros
/ipv6 firewall add action=accept chain=input
/ip firewall add action=accept chain=input
```
Previously, annet generated:
```routeros
/ipv6
/ipv6 firewall
add action=accept chain=input
/ip
/ip firewall
```
Notice how the second `add action=accept chain=input` command (under `/ip firewall` block) was ommited – annet incorrectly assumed its effect would match the identical command under `/ipv6 firewall` block. By using explicit top-level commands, we ensure all operations are preserved correctly.