### PR TITLE
feature: Per peer family options for the mesh model

### DIFF
--- a/annet/bgp_models.py
+++ b/annet/bgp_models.py
@@ -204,11 +204,29 @@ class PeerOptions:
 
 
 @dataclass
+class PeerFamilyOption:
+    af_loops: Optional[int] = None
+    import_limit: Optional[int] = None
+
+
+@dataclass
+class PeerFamilyOptions:
+    ipv4_unicast: PeerFamilyOption = field(default_factory=PeerFamilyOption)
+    ipv6_unicast: PeerFamilyOption = field(default_factory=PeerFamilyOption)
+    ipv4_vpn_unicast: PeerFamilyOption = field(default_factory=PeerFamilyOption)
+    ipv6_vpn_unicast: PeerFamilyOption = field(default_factory=PeerFamilyOption)
+    ipv4_labeled_unicast: PeerFamilyOption = field(default_factory=PeerFamilyOption)
+    ipv6_labeled_unicast: PeerFamilyOption = field(default_factory=PeerFamilyOption)
+    l2vpn_evpn: PeerFamilyOption = field(default_factory=PeerFamilyOption)
+
+
+@dataclass
 class Peer:
     addr: str
     interface: Optional[str]
     remote_as: ASN
     families: set[Family] = field(default_factory=set)
+    family_options: PeerFamilyOptions = field(default_factory=PeerFamilyOptions)
     description: str = ""
     vrf_name: str = ""
     group_name: str = ""
@@ -264,6 +282,7 @@ class PeerGroup:
     name: str
     remote_as: ASN = ASN(None)
     families: set[Family] = field(default_factory=set)
+    family_options: PeerFamilyOptions = field(default_factory=PeerFamilyOptions)
     internal_name: str = ""
     description: str = ""
     update_source: str = ""

--- a/annet/mesh/basemodel.py
+++ b/annet/mesh/basemodel.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from copy import copy
 from enum import Enum
+from dataclasses import is_dataclass, replace, fields
 from typing import (
     TypeVar, Any, Annotated, get_origin, get_type_hints, get_args, Callable, Union, ClassVar, overload,
 )
@@ -143,13 +144,15 @@ ModelT = TypeVar("ModelT", bound=BaseMeshModel)
 def _merge(a: ModelT, b: BaseMeshModel) -> ModelT:
     result = copy(a)
     for attr_name, merger in a._field_mergers.items():
-        new_value = merger(
-            attr_name,
-            getattr(a, attr_name, Special.NOT_SET),
-            getattr(b, attr_name, Special.NOT_SET),
-        )
-        if new_value is not Special.NOT_SET:
-            setattr(result, attr_name, new_value)
+        aval = getattr(a, attr_name, Special.NOT_SET)
+        bval = getattr(b, attr_name, Special.NOT_SET)
+        if is_dataclass(aval) and is_dataclass(bval):
+            new_dto = merge_dataclass(aval, bval)
+            setattr(result, attr_name, new_dto)
+        else:
+            new_value = merger(attr_name, aval, bval)
+            if new_value is not Special.NOT_SET:
+                setattr(result, attr_name, new_value)
     return result
 
 
@@ -176,6 +179,43 @@ def merge(first: Any, /, *others: Any) -> Any:
     for second in others:
         first = _merge(first, second)
     return first
+
+
+def merge_dataclass(a: Any, b: Any) -> Any:
+    if a.__class__ != b.__class__:
+        raise MergeForbiddenError(
+            f"Dataclasses belonging to different instaces can't be merged:\n"
+            f"Old: {a}\n"
+            f"New: {b}"
+        )
+
+    empty = a.__class__()
+    merged = {}
+    for f in fields(empty):
+        default = getattr(empty, f.name)
+        aval = getattr(a, f.name)
+        bval = getattr(b, f.name)
+        if aval == default:
+            merged[f.name] = bval
+        elif bval == default:
+            merged[f.name] = aval
+        elif aval == bval:
+            merged[f.name] = aval
+        elif is_dataclass(aval) and is_dataclass(bval):
+            merged[f.name] = merge_dataclass(aval, bval)
+        else:
+            raise MergeForbiddenError(
+                f"Dataclasses with non-equal field {f.name} can't be merged:\n"
+                f"Old: {aval}\n"
+                f"New: {bval}"
+            )
+
+    return replace(empty, **merged)
+
+
+def is_dataclass_empty(a: Any) -> bool:
+    empty = a.__class__()
+    return empty == a
 
 
 class KeyDefaultDict(dict):

--- a/annet/mesh/models_converter.py
+++ b/annet/mesh/models_converter.py
@@ -98,4 +98,5 @@ def to_bgp_peer(local: LocalDTO, connected: PeerDTO, connected_hostname: str, in
     result.import_policy = getattr(local, "import_policy", result.import_policy)
     result.export_policy = getattr(local, "export_policy", result.export_policy)
     result.update_source = getattr(local, "update_source", result.update_source)
+    result.family_options = getattr(local, "family_options", result.family_options)
     return result

--- a/annet/mesh/models_converter.py
+++ b/annet/mesh/models_converter.py
@@ -7,7 +7,7 @@ from adaptix import Retort, loader, Chain, name_mapping, as_is_loader
 from .peer_models import DirectPeerDTO, IndirectPeerDTO, VirtualPeerDTO, VirtualLocalDTO
 from ..bgp_models import (
     Aggregate, GlobalOptions, VrfOptions, FamilyOptions, Peer, PeerGroup, ASN, PeerOptions,
-    Redistribute, BFDTimers, L2VpnOptions, VidCollection,
+    Redistribute, BFDTimers, L2VpnOptions, VidCollection, PeerFamilyOptions, PeerFamilyOption
 )
 
 
@@ -56,6 +56,8 @@ retort = Retort(
         loader(FamilyOptions, ObjMapping, Chain.FIRST),
         loader(Aggregate, ObjMapping, Chain.FIRST),
         loader(PeerOptions, ObjMapping, Chain.FIRST),
+        loader(PeerFamilyOptions, ObjMapping, Chain.FIRST),
+        loader(PeerFamilyOption, ObjMapping, Chain.FIRST),
         as_is_loader(Redistribute),
         as_is_loader(BFDTimers),
         name_mapping(PeerOptions, map={

--- a/annet/mesh/peer_models.py
+++ b/annet/mesh/peer_models.py
@@ -1,7 +1,7 @@
 from typing import Literal, Annotated, Union, Optional
 
 from .basemodel import BaseMeshModel, Concat, Unite
-from ..bgp_models import BFDTimers
+from ..bgp_models import BFDTimers, PeerFamilyOptions
 
 FamilyName = Literal["ipv4_unicast", "ipv6_unicast", "ipv4_labeled_unicast", "ipv6_labeled_unicast", "l2vpn_evpn"]
 
@@ -39,6 +39,9 @@ class _OptionsDTO(_SharedOptionsDTO):
     """
     Options which can be set on group of peers or peer itself
     """
+    def __init__(self, **kwargs):
+        kwargs.setdefault("family_options", PeerFamilyOptions())
+        super().__init__(**kwargs)
     unnumbered: bool
     rr_client: bool
     next_hop_self: bool
@@ -77,6 +80,7 @@ class _OptionsDTO(_SharedOptionsDTO):
     soft_reconfiguration_inbound: bool
     not_active: bool
     mtu: int
+    family_options: PeerFamilyOptions
 
 
 class DirectPeerDTO(MeshSession, _OptionsDTO):

--- a/annet/mesh/registry.py
+++ b/annet/mesh/registry.py
@@ -6,6 +6,7 @@ from .match_args import MatchedArgs
 from .device_models import GlobalOptionsDTO
 from .peer_models import MeshSession, IndirectPeerDTO, VirtualLocalDTO, VirtualPeerDTO, DirectPeerDTO
 from .port_processor import PortProcessor, united_ports
+from .basemodel import is_dataclass_empty
 
 
 class DirectPeer(DirectPeerDTO):
@@ -22,7 +23,9 @@ class DirectPeer(DirectPeerDTO):
         self.all_connected_ports = all_connected_ports
 
     def is_empty(self):
-        return self.__dict__.keys() == {"match", "device", "ports", "all_connected_ports"}
+        if not is_dataclass_empty(self.family_options):
+            return False
+        return self.__dict__.keys() == {"match", "device", "ports", "all_connected_ports", "family_options"}
 
 
 class IndirectPeer(IndirectPeerDTO):
@@ -35,7 +38,9 @@ class IndirectPeer(IndirectPeerDTO):
         self.device = device
 
     def is_empty(self):
-        return self.__dict__.keys() == {"match", "device"}
+        if not is_dataclass_empty(self.family_options):
+            return False
+        return self.__dict__.keys() == {"match", "device", "family_options"}
 
 
 class VirtualLocal(VirtualLocalDTO):
@@ -48,7 +53,9 @@ class VirtualLocal(VirtualLocalDTO):
         self.device = device
 
     def is_empty(self):
-        return self.__dict__.keys() == {"match", "device"}
+        if not is_dataclass_empty(self.family_options):
+            return False
+        return self.__dict__.keys() == {"match", "device", "family_options"}
 
 
 class VirtualPeer(VirtualPeerDTO):

--- a/tests/annet/test_mesh/test_basemodel.py
+++ b/tests/annet/test_mesh/test_basemodel.py
@@ -1,10 +1,11 @@
 from typing import Annotated
+from dataclasses import dataclass, field
 
 import pytest
 
 from annet.mesh.basemodel import (
     UseFirst, UseLast, Special, Forbid, ForbidChange, Concat, DictMerge, BaseMeshModel, MergeForbiddenError, merge,
-    Merge,
+    Merge, merge_dataclass, MergeForbiddenError
 )
 
 
@@ -67,3 +68,84 @@ def test_merge_model_default():
     assert merge(A(x=1), A(x=1)) == A(x=1)
     with pytest.raises(MergeForbiddenError):
         merge(A(x=1), A(x=2))
+
+
+def test_merge_dataclass():
+    @dataclass
+    class A:
+        x: int = 123
+        y: str = "YYY"
+
+    @dataclass
+    class B:
+        a: A = field(default_factory=A)
+        b: bool = True
+
+    a1, a2 = A(), A()
+    m = merge_dataclass(a1, a2)
+    assert m.x == 123
+    assert m.y == "YYY"
+
+    a1, a2 = A(x=1), A(y="ZZZ")
+    m = merge_dataclass(a1, a2)
+    assert m.x == 1
+    assert m.y == "ZZZ"
+
+    a1, a2 = A(x=1), A(x=1, y="ZZZ")
+    m = merge_dataclass(a1, a2)
+    assert m.x == 1
+    assert m.y == "ZZZ"
+
+    a1, a2 = A(x=1, y="ZZZ"), A(x=1, y="ZZZ")
+    m = merge_dataclass(a1, a2)
+    assert m.x == 1
+    assert m.y == "ZZZ"
+
+    b1, b2 = B(), B()
+    m = merge_dataclass(b1, b2)
+    assert m.a.x == 123
+    assert m.a.y == "YYY"
+    assert m.b == True
+
+    b1, b2 = B(a=A(x=1)), B(b=False)
+    m = merge_dataclass(b1, b2)
+    assert m.a.x == 1
+    assert m.a.y == "YYY"
+    assert m.b == False
+
+    b1, b2 = B(b=False), B(a=A(x=1))
+    m = merge_dataclass(b1, b2)
+    assert m.a.x == 1
+    assert m.a.y == "YYY"
+    assert m.b == False
+
+    a1, a2 = A(x=1), A(x=2)
+    with pytest.raises(MergeForbiddenError):
+        m = merge_dataclass(a1, a2)
+
+    b1, b2 = B(a=A(x=1)), B(a=A(x=2))
+    with pytest.raises(MergeForbiddenError):
+        m = merge_dataclass(b1, b2)
+
+
+def test_merge_model_with_dataclasses():
+    @dataclass
+    class X:
+        m: int = 0
+        n: int = 0
+
+    class A(BaseMeshModel):
+        x: Annotated[X, Merge]
+
+        def __init__(self, **kwargs):
+            kwargs.setdefault("x", X())
+            super().__init__(**kwargs)
+
+        def __eq__(self, other):
+            return vars(self) == vars(other)
+
+    assert merge(A(), A()) == A()
+    assert merge(A(x=X()), A(x=X())) == A(x=X())
+    assert merge(A(x=X(m=1)), A(x=X(n=2))) == A(x=X(m=1,n=2))
+    with pytest.raises(MergeForbiddenError):
+        merge(A(x=X(m=1)), A(x=X(m=2)))

--- a/tests/annet/test_mesh/test_basemodel.py
+++ b/tests/annet/test_mesh/test_basemodel.py
@@ -149,3 +149,17 @@ def test_merge_model_with_dataclasses():
     assert merge(A(x=X(m=1)), A(x=X(n=2))) == A(x=X(m=1,n=2))
     with pytest.raises(MergeForbiddenError):
         merge(A(x=X(m=1)), A(x=X(m=2)))
+
+
+def test_equal_not_default_dataclass():
+    @dataclass
+    class X:
+        m: int
+
+    class A(BaseMeshModel):
+        x: X | None = None
+
+        def __eq__(self, other):
+            return vars(self) == vars(other)
+
+    assert merge(A(x=X(1)), A(x=X(1))) == A(x=X(1))

--- a/tests/annet/test_mesh/test_executor.py
+++ b/tests/annet/test_mesh/test_executor.py
@@ -58,6 +58,7 @@ def on_direct(local: DirectPeer, neighbor: DirectPeer, session: MeshSession):
     local.addr = "192.168.1.254"
     neighbor.addr = "192.168.1.1"
     local.mtu = 1501
+    local.family_options.ipv4_unicast.af_loops = 44
     neighbor.mtu = 1502
     session.asnum = 12345
     session.bfd_timers = BFDTimers(multiplier=1)
@@ -68,6 +69,7 @@ def on_direct_alt(local: DirectPeer, neighbor: DirectPeer, session: MeshSession)
     local.addr = "192.168.1.254"
     neighbor.addr = "192.168.1.2"
     local.mtu = 1501
+    local.family_options.ipv4_unicast.af_loops = 44
     neighbor.mtu = 1502
     session.asnum = 12345
     session.families = {"ipv4_labeled_unicast"}
@@ -78,6 +80,7 @@ def on_indirect(local: IndirectPeer, neighbor: IndirectPeer, session: MeshSessio
     local.svi = 100
     local.import_limit = 42
     local.import_limit_action = "stub"
+    local.family_options.ipv4_unicast.af_loops = 44
     neighbor.addr = "192.168.2.10"
     local.mtu = 1505
     neighbor.mtu = 1506
@@ -89,6 +92,7 @@ def on_indirect_alt(local: IndirectPeer, neighbor: IndirectPeer, session: MeshSe
     local.addr = "192.168.2.254"
     neighbor.addr = "192.168.2.11"
     local.mtu = 1506
+    local.family_options.ipv4_unicast.af_loops = 44
     neighbor.mtu = 1507
     session.asnum = 12340
     session.families = {"ipv6_unicast"}
@@ -98,6 +102,7 @@ def on_virtual(local: VirtualLocal, virtual: VirtualPeer, session: MeshSession):
     local.svi = 1
     local.addr = "192.168.3.254"
     local.mtu = 1506
+    local.family_options.ipv4_unicast.af_loops = 44
     local.listen_network = ["10.0.0.0/8"]
     virtual.addr = f"192.168.3.{virtual.num}"
     session.asnum = 12340
@@ -250,6 +255,14 @@ def test_storage(registry, storage, device1):
         assert peer.options.local_as == 12340
         assert peer.interface == "Vlan1"
         assert peer.options.listen_network == ["10.0.0.0/8"]
+
+
+def test_peer_group_family_options(registry, storage, device1):
+    r = MeshExecutor(registry, storage)
+    res = r.execute_for(device1)
+
+    peer_direct, peer_direct_alt, peer_indirect, peer_indirect_alt, *virtual = res.peers
+    assert peer_direct.family_options.ipv4_unicast.af_loops == 44
 
 
 @pytest.fixture()


### PR DESCRIPTION
Some bgp knobs can be overriden on peer/group+family basis, allowing to enable limits for only specific family.
The most useful ones are path loops and prefix number limit.

Summary:
  * adds a new field `PeerFamilyOptions` to every peer type
  * adds merge logic for dataclasses in mesh base class

