### PR TITLE
Update of authentication configuration logic for Huawei S-series:

### DIFF
--- a/annet/rulebook/huawei/aaa.py
+++ b/annet/rulebook/huawei/aaa.py
@@ -25,6 +25,13 @@ def user(key, diff, **_):
     yield from added
 
 
+def console_pass(_, diff, **__):
+    # do not delete password, just assign the new one
+    if diff[Op.ADDED]:
+        new_pass_line = diff[Op.ADDED][0]["row"]
+        yield from [(True, new_pass_line, None)]
+
+
 def _added_contains(array: list[dict], lookup_string: str) -> bool:
     for item in array:
         if item["row"].startswith(lookup_string):

--- a/annet/rulebook/texts/huawei.deploy
+++ b/annet/rulebook/texts/huawei.deploy
@@ -39,6 +39,7 @@ save
     dialog: Please input the file name(*.cfg, *.zip, *.dat): ::: vrpcfg.zip
 undo rsa peer-public-key
     dialog: /Do you want to remove the public key named .*\? \[Y/N\]:/ ::: Y
+    dialog: /% Do you really want to remove the public key named .*\? \[y/n\]:/ ::: Y
 undo stelnet server enable
     dialog: Warning: The operation will stop the STelnet server. Do you want to continue? [Y/N]: ::: Y
 undo telnet * server enable
@@ -177,6 +178,7 @@ info-center max-logfile-number *
 
 rsa peer-public-key * 
     dialog: Do you really want to replace it? [Y/N]: ::: Y
+    dialog: /% You already have RSA public key named .*.\r\n% Do you really want to replace it\? \[y/n\]:/ ::: Y
 
 ip binding vpn-instance
     dialog: Warning: This operation will modify the router ID to 0.0.0.0, which may affect the establishment of BGP peer relationships. Continue? [Y/N]: ::: Y
@@ -192,5 +194,8 @@ undo local-aaa-user change-password verify
 
 undo local-user ~
     dialog: Warning: This operation may affect online users, are you sure to change the user privilege level ?[Y/N] ::: Y
+
+hwtacacs-server shared-key cipher *
+    dialog: Warning: The shared-key complexity is low. It is recommended that the password contain at least sixteen characters and be a combination of at least two of the following categories: Uppercase letters <A-Z>; Lowercase letters <a-z>; Numerals <0-9>; Symbols (all characters not defined as letters or numerals), such as !,$,#, and %. Continue? [Y/N]: ::: Y
 
 # vim: set syntax=annrulebook:

--- a/annet/rulebook/texts/huawei.rul
+++ b/annet/rulebook/texts/huawei.rul
@@ -492,6 +492,9 @@ cpu-defend-policy
 slot *
     cpu-defend-policy
 
+user-interface con 0
+    set authentication password cipher * %logic=huawei.aaa.console_pass
+
 description %global
 
 undo ~ %global


### PR DESCRIPTION
  - Replacing console password is done in-place, without removal of the old one
  - TACACS key configuration can spawn a question about its complexity; answer is provided
  - Questions for removal or update of SSH keys on S5352 switches are different; added