### PR TITLE
feat(rbparser): Improve parameter parsing and add %regexp

### DIFF
--- a/annet/rulebook/patching.py
+++ b/annet/rulebook/patching.py
@@ -18,7 +18,6 @@ MULTILINE_DIFF_LOGIC = "common.multiline_diff"
 # =====
 @functools.lru_cache()
 def compile_patching_text(text, vendor):
-
     return _compile_patching(
         tree=syntax.parse_text(text, params_scheme={
             "global": {
@@ -44,6 +43,10 @@ def compile_patching_text(text, vendor):
             "ordered": {
                 "validator": valid_bool,
                 "default": False,
+            },
+            "context": {
+                "validator": str,
+                "default": None,
             },
             "rewrite": {
                 "validator": valid_bool,


### PR DESCRIPTION
### Description

This PR refactors the rulebook parameter parsing to be more robust and extensible.

Key Changes:

*   Improved Parameter Parsing: The regex for parsing parameters (e.g., %param=value) now correctly handles values with spaces.
*   Removed Special Cases: The hardcoded logic for %context has been removed. It's now treated as a standard parameter.
*   New %regexp Parameter: Introduces a %regexp parameter to allow overriding the default matching regex for a rule. This enables more flexible matching, for instance, port link-type hybrid %regexp=port link-type .* will now match any port link-type command.

These changes make the rule syntax more powerful and simplify the parser's implementation.

© Gemini 2.5 Pro