### PR TITLE
add: default read_timeout value

### DIFF
--- a/annet/deploy.py
+++ b/annet/deploy.py
@@ -195,6 +195,8 @@ def fill_cmd_params(rules: OrderedDict, cmd: Command):
         cmd.questions = cmd_params.get("questions", None)
         if cmd.timeout is None:
             cmd.timeout = cmd_params["timeout"]
+        if cmd.read_timeout is None:
+            cmd.read_timeout = cmd.timeout
 
 
 def apply_deploy_rulebook(hw: HardwareView, cmd_paths, do_finalize=True, do_commit=True):


### PR DESCRIPTION
In most cases read_timeout should equal cmd_timeout. Setting it higher is pointless (cmd_timeout triggers first), setting it lower usually breaks user expectations (timeout=90 should mean 90 seconds total).

Users can still set different read_timeout if needed for special cases.

If read_timeout is None, set it to cmd_timeout value.

Requires annetutil/gnetcli_adapter#73