### PR TITLE
Add radius server rule for Huawei

### DIFF
--- a/annet/rulebook/texts/huawei.rul
+++ b/annet/rulebook/texts/huawei.rul
@@ -217,6 +217,9 @@ radius-server template *
     radius-server accounting * *
     radius-server authentication * *
 
+radius server
+radius-server
+
 ssh authentication-type default password
 
 ssh server rsa-key min-length


### PR DESCRIPTION
Add rule to configure radius server for old and new software of Huawei switches.