### PR TITLE
There are no changes in NETBOX ver. 4.4.x which can break annet funct…

### DIFF
--- a/annet/adapters/netbox/provider.py
+++ b/annet/adapters/netbox/provider.py
@@ -22,6 +22,7 @@ def storage_factory(opts: NetboxStorageOpts) -> Storage:
         "4.1": NetboxStorageV41,
         "4.2": NetboxStorageV42,
         "4.3": NetboxStorageV42,
+        "4.4": NetboxStorageV42,
     }
 
     status = None


### PR DESCRIPTION
There are no changes in NETBOX ver. 4.4.x which can break annet functionality.
So NetboxStorageV42 can be used safely