### PR TITLE
feat: annotate connector

### DIFF
--- a/annet/generators/annotate.py
+++ b/annet/generators/annotate.py
@@ -1,0 +1,37 @@
+import abc
+from types import GeneratorType
+
+from annet.connectors import Connector
+
+from .base import BaseGenerator
+
+
+class AbstractAnnotateFormatter(abc.ABC):
+    def __init__(self, gen: BaseGenerator):
+        self.gen = gen
+        self._annotation_module = ".".join(gen.__class__.__module__.split(".")[-2:])
+
+    @abc.abstractmethod
+    def make_annotation(self, running_gen: GeneratorType) -> str:
+        raise NotImplementedError
+
+    def get_running_line(self, running_gen: GeneratorType) -> tuple[str, int]:
+        if not running_gen or not running_gen.gi_frame:
+            return repr(running_gen), -1
+        return self._annotation_module, running_gen.gi_frame.f_lineno
+
+
+class DefaultAnnotateFormatter(AbstractAnnotateFormatter):
+    def make_annotation(self, running_gen: GeneratorType) -> str:
+        return "%s:%d" % self.get_running_line(running_gen)
+
+
+class _AnnotateFormatterConnector(Connector[AbstractAnnotateFormatter]):
+    name = "AnnotateFormatterConnector"
+    ep_name = "annotate_formatter"
+
+    def _get_default(self) -> type[AbstractAnnotateFormatter]:
+        return DefaultAnnotateFormatter
+
+
+annotate_formatter_connector = _AnnotateFormatterConnector()

--- a/annet/generators/base.py
+++ b/annet/generators/base.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 import abc
 import contextlib
+import re
 import textwrap
-from typing import Union, List
+from typing import List, Union
 
 from annet import tracing
-from annet.vendors import tabparser
 from annet.tracing import tracing_connector
+from annet.vendors import tabparser
+
 from .exceptions import InvalidValueFromGenerator
+
+
+NONE_SEARCHER = re.compile(r"\bNone\b")
 
 
 class DefaultBlockIfCondition:
@@ -53,10 +58,14 @@ def _split_and_strip(text):
 # =====
 class BaseGenerator:
     TYPE: str
-    TAGS: List[str]
+    TAGS: List[str] = []
 
     def supports_device(self, device) -> bool:  # pylint: disable=unused-argument
         return True
+
+    @classmethod
+    def get_aliases(cls) -> set[str]:
+        return {cls.__name__, *cls.TAGS}
 
 
 class TreeGenerator(BaseGenerator):

--- a/annet/generators/jsonfragment.py
+++ b/annet/generators/jsonfragment.py
@@ -1,16 +1,10 @@
 from __future__ import annotations
 
 import contextlib
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-    Set,
-    Union,
-)
+from typing import Any, Optional, Union
 
 from annet.storage import Device, Storage
+
 from .base import TreeGenerator, _filter_str
 
 
@@ -18,13 +12,12 @@ class JSONFragment(TreeGenerator):
     """Generates parts of JSON config file."""
 
     TYPE = "JSON_FRAGMENT"
-    TAGS: List[str] = []
 
     def __init__(self, storage: Storage):
         super().__init__()
         self.storage = storage
-        self._json_config: Dict[str, Any] = {}
-        self._config_pointer: List[str] = []
+        self._json_config: dict[str, Any] = {}
+        self._config_pointer: list[str] = []
 
         # if two generators edit same file, commands from generator with greater `reload_prio` will be used
         if not hasattr(self, "reload_prio"):
@@ -36,11 +29,7 @@ class JSONFragment(TreeGenerator):
     def path(self, device: Device) -> Optional[str]:
         raise NotImplementedError("Required PATH for JSON_FRAGMENT generator")
 
-    @classmethod
-    def get_aliases(cls) -> Set[str]:
-        return {cls.__name__, *cls.TAGS}
-
-    def acl(self, device: Device) -> Union[str, List[str]]:
+    def acl(self, device: Device) -> Union[str, list[str]]:
         """
         Restrict the generator to a specified ACL using JSON Pointer syntax.
 
@@ -48,7 +37,7 @@ class JSONFragment(TreeGenerator):
         """
         raise NotImplementedError("Required ACL for JSON_FRAGMENT generator")
 
-    def acl_safe(self, device: Device) -> Union[str, List[str]]:
+    def acl_safe(self, device: Device) -> Union[str, list[str]]:
         """
         Restrict the generator to a specified safe ACL using JSON Pointer syntax.
 

--- a/annet/generators/result.py
+++ b/annet/generators/result.py
@@ -2,19 +2,10 @@ from __future__ import annotations
 
 import textwrap
 from collections import OrderedDict as odict
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Optional,
-    Sequence,
-    Tuple,
-)
+from typing import Any, Callable, Optional, Sequence
 
 from annet.annlib import jsontools
-from annet.lib import (
-    merge_dicts,
-)
+from annet.lib import merge_dicts
 from annet.reference import RefMatcher, RefTracker
 from annet.types import (
     GeneratorEntireResult,
@@ -24,7 +15,7 @@ from annet.types import (
 
 
 def _combine_acl_text(
-        partial_results: Dict[str, GeneratorPartialResult],
+        partial_results: dict[str, GeneratorPartialResult],
         acl_getter: Callable[[GeneratorPartialResult], str]
 ) -> str:
     acl_text = ""
@@ -43,9 +34,9 @@ class RunGeneratorResult:
     """
 
     def __init__(self):
-        self.partial_results: Dict[str, GeneratorPartialResult] = {}
-        self.entire_results: Dict[str, GeneratorEntireResult] = {}
-        self.json_fragment_results: Dict[str, GeneratorJSONFragmentResult] = {}
+        self.partial_results: dict[str, GeneratorPartialResult] = {}
+        self.entire_results: dict[str, GeneratorEntireResult] = {}
+        self.json_fragment_results: dict[str, GeneratorJSONFragmentResult] = {}
         self.ref_track: RefTracker = RefTracker()
         self.ref_matcher: RefMatcher = RefMatcher()
 
@@ -62,14 +53,14 @@ class RunGeneratorResult:
     def add_json_fragment(self, result: GeneratorJSONFragmentResult) -> None:
         self.json_fragment_results[result.name] = result
 
-    def config_tree(self, safe: bool = False) -> Dict[str, Any]:  # OrderedDict
+    def config_tree(self, safe: bool = False) -> dict[str, Any]:  # OrderedDict
         tree = odict()
         for gr in self.partial_results.values():
             config = gr.safe_config if safe else gr.config
             tree = merge_dicts(tree, config)
         return tree
 
-    def new_files(self, safe: bool = False) -> Dict[str, Tuple[str, str]]:
+    def new_files(self, safe: bool = False) -> dict[str, tuple[str, str]]:
         files = {}
         for gr in self.entire_results.values():
             if not safe or gr.is_safe:
@@ -84,14 +75,14 @@ class RunGeneratorResult:
 
     def new_json_fragment_files(
             self,
-            old_files: Dict[str, Optional[str]],
+            old_files: dict[str, Optional[str]],
             use_acl: bool = True,
             safe: bool = False,
             filters: Sequence[str] | None = None,
-    ) -> Dict[str, Tuple[Any, Optional[str]]]:
+    ) -> dict[str, tuple[Any, Optional[str]]]:
         # TODO: safe
-        files: Dict[str, Tuple[Any, Optional[str]]] = {}
-        reload_prios: Dict[str, int] = {}
+        files: dict[str, tuple[Any, Optional[str]]] = {}
+        reload_prios: dict[str, int] = {}
         for generator_result in self.json_fragment_results.values():
             filepath = generator_result.path
             if filepath not in files:
@@ -105,7 +96,7 @@ class RunGeneratorResult:
                     result_acl = generator_result.acl_safe
             else:
                 result_acl = None
-            previous_config: Dict[str, Any] = files[filepath][0]
+            previous_config: dict[str, Any] = files[filepath][0]
             new_fragment = generator_result.config
             new_config = jsontools.apply_json_fragment(
                 previous_config, new_fragment,
@@ -126,7 +117,7 @@ class RunGeneratorResult:
             files[filepath] = (new_config, reload_cmd)
         return files
 
-    def perf_mesures(self) -> Dict[str, Dict[str, int]]:
+    def perf_mesures(self) -> dict[str, dict[str, int]]:
         mesures = {}
         for gr in self.partial_results.values():
             mesures[gr.name] = {"total": gr.perf.total,


### PR DESCRIPTION
### Refactor: Decouple Generator Annotation and Improve Error Handling

This PR refactors the generator subsystem to improve extensibility and error handling.

*   Pluggable Annotation Formatter: Introduces AbstractAnnotateFormatter to decouple config annotation logic from PartialGenerator. This allows for custom annotation styles via entry points.
*   Better Error Handling: Replaces assert on stringified None values with a dedicated InvalidValueFromGenerator exception, providing clearer error messages.
*   Code Consolidation: The get_aliases() method is moved to BaseGenerator to reduce code duplication.
*   Modernization: Adopts the walrus operator (:=) and updates type hints.

© Gemini 2.5 Pro

Example:

```
    class JSONAnnotateFormatter(annet.generators.AbstractAnnotateFormatter):
        def make_annotation(self, running_gen) -> str:
            import json
            a,b = self.get_running_line(running_gen)
            return json.dumps({"module": a, "line": b})

    annet.generators.annotate_formatter_connector.set(JSONAnnotateFormatter)
```

```
(.venv) ozhegov-osx:annushka ozhegov$ ./ann gen -gHostname lab-vla-1s1 --cache-ttl=-1 --annotate
# -------------------- lab-vla-1s1.cfg --------------------
sysname lab-vla-1s1     # {"module": "noc.hostname", "line": 24}
header login information "lab-vla-1s1"  # {"module": "noc.hostname", "line": 26}
```