### PR TITLE
generators: make GeneratorError traceback less verbose

### DIFF
--- a/annet/generators/__init__.py
+++ b/annet/generators/__init__.py
@@ -189,7 +189,7 @@ def _run_partial_generator(gen: "PartialGenerator", run_args: GeneratorPartialRu
             except Exception as err:
                 filename, lineno = gen.get_running_line()
                 logger.error("Generator error in file '%s:%i'", filename, lineno)
-                raise GeneratorError(f"{gen} on {device}") from err
+                raise GeneratorError(f"{gen} on {device.__class__.__name__}(id={device.id}, hostname={device.hostname})") from err
 
             fmtr = registry_connector.get().match(device.hw).make_formatter()
 


### PR DESCRIPTION
Device class is very big and str(device) is insanely verbose. This make any sort of generator error (such as "None" in output) unreadable without scrolling up couple of screens. I think id and hostname should provide enough information for this case irrelevant of data adapter.