### PR TITLE
fix ref tracker

### DIFF
--- a/annet/annlib/patching.py
+++ b/annet/annlib/patching.py
@@ -224,7 +224,7 @@ class Orderer:
             fmtr = CommonFormatter()
             rules = fmtr.join(rules)
         rb = compile_ordering_text(rules, self.vendor)
-        self.rb = self.rb + rb
+        self.rb = rb + self.rb
 
     def get_order(
         self,


### PR DESCRIPTION
#467 reversed the order of references and definitions from the ref tracker.
This PR fixes that.