### PR TITLE
[feat] Custom diff logic for RouterOS user commands

### DIFF
--- a/annet/rulebook/routeros/user.py
+++ b/annet/rulebook/routeros/user.py
@@ -20,7 +20,7 @@ def normalize_user_line(line: str) -> str:
     return normalized.strip()
 
 
-def user_diff(old: odict, new: odict, diff_pre: odict, _pops: tuple[Op, ...] = (Op.AFFECTED,)) -> list[DiffItem]:
+def diff(old: odict, new: odict, diff_pre: odict, _pops: tuple[Op, ...] = (Op.AFFECTED,)) -> list[DiffItem]:
     """Custom diff logic for RouterOS user commands."""
     diff_indexed = []
 

--- a/annet/rulebook/texts/routeros.rul
+++ b/annet/rulebook/texts/routeros.rul
@@ -13,7 +13,7 @@
 
 
 user
-    add ~ %diff_logic=routeros.user_diff.user_diff
+    add ~ %diff_logic=routeros.user.diff
     ~
     group
         add ~

--- a/tests/annet/test_patch/routeros_user_diff.yaml
+++ b/tests/annet/test_patch/routeros_user_diff.yaml
@@ -1,0 +1,17 @@
+- vendor: routeros
+  before: |
+    /user
+    add address="" comment="oldhash123" disabled=no group=full name=admin password=oldpass
+    add address="" comment="hash456" disabled=no group=full name=user1 password=pass1
+    add address="" comment="hash789" disabled=no group=read name=user2 password=pass2
+    add address="" comment="hashremove" disabled=no group=write name=toremove password=oldpass
+  after: |
+    /user
+    add address="" comment="oldhash123" disabled=no group=full name=admin password=oldpass
+    add address="" comment="newhash456" disabled=no group=full name=user1 password=newpass1
+    add address="" comment="hash789" disabled=no group=read name=user2 password=pass2
+    add address="" comment="hashnew" disabled=no group=full name=newuser password=newpass
+  patch: |
+    /user remove [ find address="" comment="hashremove" disabled=no group=write name=toremove ]
+    /user add address="" comment="newhash456" disabled=no group=full name=user1 password=newpass1
+    /user add address="" comment="hashnew" disabled=no group=full name=newuser password=newpass


### PR DESCRIPTION
**Proposal**

Custom diff logic for RouterOS user commands

**Problem**

RouterOS doesn't export passwords in config, causing permanent diffs when generators include password= parameter.

**Solution**
Add custom diff_logic that compares users by password hash in comment field instead of full command line.

**Benefits**
- Idempotent user generation, 
- shows diffs only when passwords actually change