### PR TITLE
add requests-cache in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ yarl>=1.8.2
 adaptix==3.0.0b7
 dataclass-rest==0.4
 ordered-set>=4.1.0
+requests-cache>=1.2.1


### PR DESCRIPTION
Fixed Missing Import for requests_cache in PR #453

During the installation process, an error was encountered due to a missing dependency. The module requests_cache was imported in the code but not included in the project's requirements.

```
src/annet/annet/adapters/netbox/common/storage_base.py", line 8, in <module>
from requests_cache import CachedSession, SQLiteCache
ModuleNotFoundError: No module named 'requests_cache'
```
**Solution:**
Added requests-cache to the project's requirements file to ensure the module is available during installation. This resolves the ModuleNotFoundError and ensures the application runs correctly.