### PR TITLE
Fix iteration over patch

### DIFF
--- a/annet/rulebook/texts/huawei.rul
+++ b/annet/rulebook/texts/huawei.rul
@@ -280,7 +280,7 @@ interface */Tunnel.+/
     mpls te path
     mpls te tunnel-id
 
-interface *                             %logic=huawei.iface.permanent 
+interface *                             %logic=huawei.iface.permanent
     %if hw.Quidway:
     mac-address trap notification
     %else:
@@ -377,7 +377,7 @@ xpl ~
     ~              %rewrite %global
 
 bgp path-attribute attr-set *
-bgp path-attribute * 
+bgp path-attribute *
 
 bgp %logic=huawei.bgp.undo_commit
     private-4-byte-as

--- a/tests/annet/test_patch/huawei_xpl.yaml
+++ b/tests/annet/test_patch/huawei_xpl.yaml
@@ -228,3 +228,89 @@
       end-filter
     q
     save
+- vendor: Huawei
+  before: |
+    xpl route-filter XXX
+      if as-path in XXX_AS_FILTERS then
+        apply local-preference 10
+    xpl as-path-list XXX_AS_FILTERS
+      origin '123'
+  after: |
+    xpl route-filter XXX
+  patch: |+
+    system-view
+    undo xpl as-path-list XXX_AS_FILTERS
+    xpl route-filter XXX
+      end-filter
+    q
+    save
+- vendor: Huawei
+  before: |
+    xpl route-filter XXX
+  after: |
+    xpl route-filter XXX
+      if as-path in XXX_AS_FILTERS then
+        apply local-preference 10
+    xpl as-path-list XXX_AS_FILTERS
+      origin '123'
+  patch: |+
+    system-view
+    xpl route-filter XXX
+      if as-path in XXX_AS_FILTERS then
+        apply local-preference 10
+      endif
+      end-filter
+    xpl as-path-list XXX_AS_FILTERS
+      origin '123'
+      end-list
+    q
+    save
+- vendor: Huawei
+  before: |
+    xpl route-filter XXX
+      if as-path in XXX_AS_FILTERS then
+        apply local-preference 10
+    xpl as-path-list XXX_AS_FILTERS
+      origin '123'
+  after: |
+    xpl route-filter XXX
+      if as-path in XXX_AS_FILTERS then
+        apply local-preference 100
+    xpl as-path-list XXX_AS_FILTERS
+      origin '123'
+  patch: |+
+    system-view
+    xpl route-filter XXX
+      if as-path in XXX_AS_FILTERS then
+        apply local-preference 100
+      endif
+      end-filter
+    q
+    save
+- vendor: Huawei
+  before: |
+    xpl route-filter XXX
+      if as-path in XXX_AS_FILTERS then
+        apply local-preference 10
+    xpl as-path-list XXX_AS_FILTERS
+      origin '123'
+  after: |
+    xpl route-filter XXX
+      if as-path in XXX_AS_FILTERS then
+        apply local-preference 10
+      if as-path in YYY_AS_FILTERS then
+        apply local-preference 20
+    xpl as-path-list XXX_AS_FILTERS
+      origin '123'
+  patch: |+
+    system-view
+    xpl route-filter XXX
+      if as-path in XXX_AS_FILTERS then
+        apply local-preference 10
+      endif
+      if as-path in YYY_AS_FILTERS then
+        apply local-preference 20
+      endif
+      end-filter
+    q
+    save


### PR DESCRIPTION
#467 introduced a bug in logic of iteration over patch tree: if custom logic removes all children, then the block completely disappears.

This PR fixes that: now we check the presence of children after the custom logic, not before.
