### PR TITLE
feat: fail if filter-acl excludes some %ordered parts

### DIFF
--- a/annet/gen.py
+++ b/annet/gen.py
@@ -25,7 +25,7 @@ from typing import (
 import tabulate
 from contextlog import get_logger
 
-from annet import generators, implicit, patching, tracing
+from annet import generators, implicit, patching, rulebook, tracing
 from annet.annlib import jsontools
 from annet.annlib.rbparser.acl import compile_acl_text
 from annet.cli_args import DeployOptions, GenOptions, ShowGenOptions
@@ -226,12 +226,15 @@ def _old_new_per_device(ctx: OldNewDeviceContext, device: Device, filterer: Filt
 
         filter_acl_rules = build_filter_acl(filterer, device, ctx.stdin, ctx.args, ctx.config)
         if filter_acl_rules is not None:
-            old = old and patching.apply_acl(old, filter_acl_rules, fatal_acl=False)
+            rb = rulebook.get_rulebook(device.hw)
+            old = old and patching.apply_acl(old, filter_acl_rules, fatal_acl=False, forbid_ordered=True, rb=rb)
             new = patching.apply_acl(
                 new,
                 filter_acl_rules,
                 fatal_acl=False,
                 with_annotations=ctx.add_annotations,
+                forbid_ordered=True,
+                rb=rb,
             )
     else:  # vendor == pc
         try:

--- a/annet/rulebook/patching.py
+++ b/annet/rulebook/patching.py
@@ -114,6 +114,7 @@ def _compile_patching(tree, reverse_prefix, vendor):
                     "parent": attrs["params"]["parent"] or bool(attrs["children"]),
                     "force_commit": attrs["params"]["force_commit"],
                     "ignore_case": attrs["params"]["ignore_case"],
+                    "ordered": attrs["params"]["ordered"],
                     "context": attrs["context"],
                 },
                 "children": None,

--- a/tests/annet/test_filter_acl.py
+++ b/tests/annet/test_filter_acl.py
@@ -1,7 +1,11 @@
 import textwrap
 
+import pytest
+
 import annet.annlib.filter_acl
-from annet.vendors import registry_connector
+import annet.annlib.patching
+from annet.rulebook.patching import compile_patching_text
+from annet.vendors import registry_connector, tabparser
 
 
 def test_filter_diff():
@@ -30,3 +34,62 @@ def test_filter_diff():
     -   foo bar
     """).strip()
     )
+
+
+def test_ordered_and_filter_acl():
+    vendor = "juniper"
+
+    config_text = textwrap.dedent("""
+      policy-options
+        policy-statement SOME_POLICY
+          term SOME_TERM
+            from
+              protocol direct
+              interface lo0.0
+            then
+              community add SOME_COMMUNITY
+              next-hop self
+              accept
+          term DENY
+            then reject
+    """).strip()
+    config = tabparser.parse_to_tree(
+        text=config_text,
+        splitter=registry_connector.get().match(vendor).make_formatter().split,
+    )
+
+    rb_text = textwrap.dedent("""
+      policy-options
+        policy-statement *
+          term *               %ordered
+            from               %logic=common.undo_redo
+              ~
+            then               %logic=common.undo_redo
+              community ~      %ordered
+              ~
+            ~                  %global
+          ~                    %global
+    """).strip()
+    rb = {"patching": compile_patching_text(rb_text, vendor)}
+
+    # one term is removed, it is not okay
+    acl_text = textwrap.dedent("""
+      policy-options
+        policy-statement SOME_POLICY
+          term SOME_TERM
+    """).strip()
+    acl = annet.annlib.filter_acl.make_acl(acl_text, vendor)
+
+    with pytest.raises(annet.annlib.patching.AclExcludesOrderedError):
+        annet.annlib.patching.apply_acl(config, acl, forbid_ordered=True, rb=rb)
+
+    # all terms are removed, it is okay
+    acl_text = textwrap.dedent("""
+      policy-options
+        policy-statement SOME_POLICY
+          term *
+    """).strip()
+    acl = annet.annlib.filter_acl.make_acl(acl_text, vendor)
+
+    # runs with no exception
+    _ = annet.annlib.patching.apply_acl(config, acl, forbid_ordered=True, rb=rb)


### PR DESCRIPTION
When a config section is marked as `%ordered`, the order is critical. The current logic (`ORDERED_PATCH_LOGIC`) handles this by removing all commands in the block and re-adding them.

However, if `filter-acl` is active and excludes _some_ ordered parts, we risk deleting the entire block while only restoring a subset of children. This results in a corrupted configuration.

This patch raises an explicit error in this case.