### PR TITLE
add `requests>=2.32.5` to `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ yarl>=1.8.2
 adaptix==3.0.0b7
 dataclass-rest==0.4
 ordered-set>=4.1.0
+requests>=2.32.5


### PR DESCRIPTION
`annet` does depends on requests, as can seen here: https://github.com/search?q=repo%3Aannetutil%2Fannet+language%3APython+%22from+requests+%22&type=code but this dependency is not listed in `requirements.txt`.

This results in failure at runtime:
```py
$ annet diff 10.1.0.1
Traceback (most recent call last):
  File ".../venv/bin/annet", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File ".../venv/lib/python3.12/site-packages/annet/annlib/lib.py", line 326, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File ".../venv/lib/python3.12/site-packages/annet/annet.py", line 34, in main
    raise e
  File ".../venv/lib/python3.12/site-packages/annet/annet.py", line 26, in main
    return parser.dispatch(pre_call=annet.init, add_help_command=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../venv/lib/python3.12/site-packages/annet/argparse.py", line 363, in dispatch
    values.append(arg.construct_from(ns))
                  ^^^^^^^^^^^^^^^^^^^^^^
  File ".../venv/lib/python3.12/site-packages/annet/argparse.py", line 183, in construct_from
    return cls(**kwargs)
           ^^^^^^^^^^^^^
  File ".../venv/lib/python3.12/site-packages/annet/cli_args.py", line 426, in __init__
    super().__init__(*args, **kwargs)
  File ".../venv/lib/python3.12/site-packages/annet/cli_args.py", line 322, in __init__
    storage, _ = get_storage()
                 ^^^^^^^^^^^^^
  File ".../venv/lib/python3.12/site-packages/annet/storage.py", line 178, in get_storage
    connectors = storage_connector.get_all()
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../venv/lib/python3.12/site-packages/annet/connectors.py", line 51, in get_all
    self._classes = self._entry_point or [self._get_default()]
                    ^^^^^^^^^^^^^^^^^
  File ".../lib/python3.12/functools.py", line 998, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File ".../venv/lib/python3.12/site-packages/annet/connectors.py", line 28, in _entry_point
    ep = load_entry_point(self.ep_group, self.ep_name)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../venv/lib/python3.12/site-packages/annet/connectors.py", line 90, in load_entry_point
    return [item.load() for item in ep]
            ^^^^^^^^^^^
  File ".../lib/python3.12/importlib/metadata/__init__.py", line 205, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File ".../venv/lib/python3.12/site-packages/annet/adapters/netbox/provider.py", line 9, in <module>
    from .common.status_client import NetboxStatusClient
  File ".../venv/lib/python3.12/site-packages/annet/adapters/netbox/common/status_client.py", line 9, in <module>
    from .client import BaseNetboxClient
  File ".../venv/lib/python3.12/site-packages/annet/adapters/netbox/common/client.py", line 5, in <module>
    from dataclass_rest.http.requests import RequestsClient
  File ".../venv/lib/python3.12/site-packages/dataclass_rest/http/requests.py", line 5, in <module>
    from requests import Session, Response, RequestException
ModuleNotFoundError: No module named 'requests'
```

`requests 2.32.5` is the latest release up to this point, available for `python>=3.9`, so there should be no problem in restricting the version like that. https://pypi.org/project/requests/