### PR TITLE
Netbox v4.5 support

### DIFF
--- a/annet/adapters/netbox/provider.py
+++ b/annet/adapters/netbox/provider.py
@@ -24,6 +24,7 @@ def storage_factory(opts: NetboxStorageOpts) -> Storage:
         "4.2": NetboxStorageV42,
         "4.3": NetboxStorageV42,
         "4.4": NetboxStorageV42,
+        "4.5": NetboxStorageV42,
     }
 
     status = None


### PR DESCRIPTION
We can safely use NetboxStorageV42 for NETBOX v4.5.x