### PR TITLE
Fix BGP indentation for B4COM 2K series switches

### DIFF
--- a/annet/vendors/tabparser.py
+++ b/annet/vendors/tabparser.py
@@ -420,7 +420,7 @@ class B4comFormatter(BlockExitFormatter):
                 continue
 
             if exit_af_re.match(line):
-                result.append(" " + line)
+                result.append(line)
                 inside_af = False
                 continue
 


### PR DESCRIPTION
On b4com 4k series, BGP output is returned without indentation, and a tabparser function normalizes/fixes indentation:
https://github.com/annetutil/annet/blob/main/annet/vendors/tabparser.py#L392
On b4com 2k series, the output is already properly indented, and that normalization breaks the parser.

```bash
# b4com 2k - original raw output
!
router bgp ...
 neighbor ...
 !
 address-family ipv6 unicast
  neighbor ...
 exit-address-family
!

# b4com 2k - after tabparser
!
router bgp ...
 neighbor ...
 !
 address-family ipv6 unicast
   neighbor ...
  exit-address-family # this raises ParserError("Invalid top indentation: line %d: %s" % (number, line))
!

# b4com 2k - after tabparser fixed
!
router bgp ...
 neighbor ...
 !
 address-family ipv6 unicast
   neighbor ...
 exit-address-family
!
```

```bash
> annet diff -g bgp mlf01
[23:11:03]   ERROR MainProcess - /Users/karajomok/gits/annet-mws/.venv/lib/python3.14/site-packages/annet/annet.py:32 - Traceback (most recent call last):
...
  File "/Users/karajomok/gits/annet-mws/.venv/lib/python3.14/site-packages/annet/vendors/tabparser.py", line 856, in parse_to_tree
    for stack in _stacked(splitter(text), tuple(comments)):
                 ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/karajomok/gits/annet-mws/.venv/lib/python3.14/site-packages/annet/vendors/tabparser.py", line 884, in _stacked
    for level, line in _stripped_indents(lines, comments):
                       ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/karajomok/gits/annet-mws/.venv/lib/python3.14/site-packages/annet/vendors/tabparser.py", line 915, in _stripped_indents
    raise ParserError("Invalid top indentation: line %d: %s" % (number, line))
annet.vendors.tabparser.ParserError: Invalid top indentation: line 548: exit-address-family
 --
```