### PR TITLE
feat: enhance show current with generator ACL and interface filtering

### DIFF
--- a/annet/cli.py
+++ b/annet/cli.py
@@ -15,12 +15,12 @@ import yaml
 from contextlog import get_logger
 from valkit.python import valid_logging_level
 
-from annet import api, cli_args, filtering, generators
+from annet import api, cli_args, filtering, generators, patching
 from annet.api import Deployer, collapse_texts
 from annet.argparse import ArgParser, subcommand
 from annet.deploy import get_deployer
 from annet.diff import gen_sort_diff
-from annet.gen import CurrentState, Loader, get_current_state, old_raw
+from annet.gen import Loader, format_config_blocks, get_current_state, old_new
 from annet.lib import do_async, get_context_path, repair_context_file
 from annet.output import OutputDriver, output_driver_connector
 from annet.storage import Device, get_storage
@@ -41,32 +41,6 @@ def list_subcommands():
     return globals().copy()
 
 
-def _gen_current_items(
-    config,
-    stdin,
-    loader: Loader,
-    output_driver: OutputDriver,
-    gen_args: cli_args.GenOptions,
-    current_state: CurrentState,
-) -> Iterable[Tuple[str, str, bool]]:
-    for device, result in old_raw(
-        args=gen_args,
-        loader=loader,
-        config=config,
-        current_state=current_state,
-        stdin=stdin,
-    ):
-        if device.hw.vendor != "pc":
-            destname = output_driver.cfg_file_names(device)[0]
-            yield (destname, result, False)
-        else:
-            for entire_path, entire_data in sorted(result.items(), key=operator.itemgetter(0)):
-                if entire_data is None:
-                    entire_data = ""
-                destname = output_driver.entire_config_dest_path(device, entire_path)
-                yield (destname, entire_data, False)
-
-
 @contextmanager
 def get_loader(gen_args: cli_args.GenOptions, args: cli_args.QueryOptionsBase):
     exit_stack = ExitStack()
@@ -84,18 +58,19 @@ def show():
     pass
 
 
-@subcommand(cli_args.QueryOptions, cli_args.opt_config, cli_args.FileOutOptions, parent=show)
-def show_current(args: cli_args.QueryOptions, config, arg_out: cli_args.FileOutOptions) -> None:
-    """Show current devices' configuration"""
-    gen_args = cli_args.GenOptions(args, no_acl=True)
+@subcommand(cli_args.ShowCurrentOptions, parent=show)
+def show_current(args: cli_args.ShowCurrentOptions) -> None:
+    """Show current devices' configuration, optionally filtered by generator ACL (-g) and interfaces (-i)"""
+    args.no_acl = not (args.acl or args.allowed_gens or args.filter_ifaces)
+    filterer = filtering.filterer_connector.get()
     output_driver = output_driver_connector.get()
-    with get_loader(gen_args, args) as loader:
+    with get_loader(args, args) as loader:
         if not loader.devices:
             get_logger().error("No devices found for %s", args.query)
 
         current_state = do_async(
             get_current_state(
-                config,
+                args.config,
                 loader.devices,
                 loader.resolve_gens(loader.devices),
                 do_files_download=True,
@@ -103,15 +78,32 @@ def show_current(args: cli_args.QueryOptions, config, arg_out: cli_args.FileOutO
             new_thread=True,
         )
 
-        items = _gen_current_items(
-            loader=loader,
-            output_driver=output_driver,
-            gen_args=gen_args,
-            stdin=args.stdin(config=config),
-            config=config,
-            current_state=current_state,
-        )
-        output_driver.write_output(arg_out, items, len(loader.devices))
+        def items() -> Iterable[Tuple[str, str, bool]]:
+            for res in old_new(
+                args,
+                config=args.config,
+                loader=loader,
+                filterer=filterer,
+                current_state=current_state,
+                no_new=True,
+                add_implicit=False,
+                do_files_download=True,
+            ):
+                if res.err:
+                    raise res.err
+                device = res.device
+                if not device.is_pc():
+                    if res.old:
+                        orderer = patching.Orderer.from_hw(device.hw)
+                        old_text = format_config_blocks(orderer.order_config(res.old), device.hw, args.indent)
+                        yield output_driver.cfg_file_names(device)[0], old_text, False
+                else:
+                    for entire_path, entire_data in sorted(res.old_files.items()):
+                        if entire_data is None:
+                            entire_data = ""
+                        yield output_driver.entire_config_dest_path(device, entire_path), entire_data, False
+
+        output_driver.write_output(args, items(), len(loader.devices))
 
 
 @subcommand(cli_args.QueryOptions, cli_args.FileOutOptions, parent=show)

--- a/annet/cli_args.py
+++ b/annet/cli_args.py
@@ -103,6 +103,8 @@ opt_generators_context = Arg("--generators_context", type=str, default=None, hel
 
 opt_no_acl = Arg("--no-acl", default=False, help="Disable ACL for config generation")
 
+opt_acl = Arg("--acl", default=False, help="Apply generator ACL to filter output (implied by -g and -i)")
+
 opt_no_acl_exclusive = Arg(
     "--no-acl-exclusive", default=False, help="Check that ACLs of the executed generators do not intersect"
 )
@@ -415,6 +417,11 @@ class ShowGenOptions(GenOptions, FileOutOptions):
     indent = opt_indent
     annotate = opt_annotate
     show_hosts_progress = opt_show_hosts_progress
+
+
+class ShowCurrentOptions(ShowGenOptions):
+    config = opt_config
+    acl = opt_acl
 
 
 class ShowDiffOptions(DiffOptions, FileOutOptions):

--- a/annet/gen.py
+++ b/annet/gen.py
@@ -26,10 +26,9 @@ import tabulate
 from contextlog import get_logger
 
 from annet import generators, implicit, patching, rulebook, tracing
-from annet.annlib import jsontools
 from annet.annlib.rbparser.acl import compile_acl_text
-from annet.cli_args import DeployOptions, GenOptions, ShowGenOptions
-from annet.deploy import get_fetcher, scrub_config
+from annet.cli_args import GenOptions, ShowGenOptions
+from annet.deploy import get_fetcher
 from annet.filtering import Filterer
 from annet.generators import (
     BaseGenerator,
@@ -420,50 +419,6 @@ def old_new(
             raise GeneratorError from err
         if result is not None:
             yield result
-
-
-@tracing.function
-def old_raw(
-    args: GenOptions,
-    loader: Loader,
-    config: str,
-    current_state: "CurrentState",
-    stdin=None,
-) -> Iterable[Tuple[Device, Union[str, Dict[str, str]]]]:
-    device_gens = loader.resolve_gens(loader.devices)
-    if stdin is None:
-        stdin = args.stdin(filter_acl=args.filter_acl, config=config)
-    ctx = OldNewDeviceContext(
-        config=config,
-        args=args,
-        downloaded_files=split_downloaded_files_multi_device(
-            current_state.downloaded_files, device_gens, loader.devices
-        ),
-        failed_files=current_state.failed_files,
-        running=current_state.running,
-        failed_running=current_state.failed_running,
-        stdin=stdin,
-        do_files_download=True,
-        device_count=len(loader.devices),
-        no_new=True,
-        add_annotations=False,
-        add_implicit=False,
-        gens=DeviceGenerators(),
-        fetched_packages={},
-        failed_packages={},
-        do_print_perf=True,
-    )
-    for device in loader.devices:
-        if not device.is_pc():
-            config = _old_new_get_config_cli(ctx, device)
-            config = scrub_config(config, device.breed)
-            yield device, config
-        else:
-            files = _old_new_get_config_files(ctx, device)
-            if files.entire_files:
-                yield device, files.entire_files
-            if files.json_fragment_files:
-                yield device, {path: jsontools.format_json(data) for path, data in files.json_fragment_files.items()}
 
 
 @tracing.function


### PR DESCRIPTION
## New flags

| Flag | Behaviour |
|---|---|
| *(none)* | Unchanged — returns full running config |
| `--acl` | Applies all generator ACLs — scopes output to config sections managed by annet |
| `-g <tag>` | Implies `--acl`, limits output to generators matching the tag |
| `-i <iface>` | Implies `--acl`, limits output to the specified interface(s) |

## Example workflow

Generate desired config and fetch the matching slice of current config for a single interface:

```bash
annet gen          -g interface -i Ethernet50 --dest generated/  router1.example.com
annet show current -g interface -i Ethernet50 --dest current/    router1.example.com
```

Produce a patch (commands to apply) and a rollback (commands to revert):

```bash
annet file-patch --hw Arista current/ generated/   # patch
annet file-patch --hw Arista generated/ current/   # rollback
```

## Implementation notes

`old_raw` (used by the previous `show current`) fetched config as raw text with no generator involvement. This PR replaces it with `old_new(..., no_new=True)`, which runs the same fetch + ACL filtering pipeline already used by `annet gen` and `annet patch`.