### PR TITLE
fix: add RouterOS implicit config for /tool mac-server ping set enabled=yes

### DIFF
--- a/annet/implicit.py
+++ b/annet/implicit.py
@@ -9,7 +9,7 @@ def config(config_tree, rules):
         matched_lines = [line for line in config_tree.keys() if rule["regexp"].match(line)]
         if rule["type"] != "ignore":
             if not any(matched_lines) and row not in config_tree:
-                implicit_config_tree[row] = odict()
+                implicit_config_tree[row] = config(odict(), rule["children"])
         for line in matched_lines:
             implicit_config_tree[line] = config(config_tree[line], rule["children"])
     return implicit_config_tree
@@ -201,6 +201,13 @@ def _implicit_tree(device):
                 system mtu routing 1500
                 system mtu jumbo 9000
             """
+    elif device.hw.RouterOS:
+        text = """
+            tool
+                mac-server
+                    ping
+                        set enabled=yes %regexp=set enabled=.*
+        """
 
     return parse_text(text)
 

--- a/tests/annet/test_implicit.py
+++ b/tests/annet/test_implicit.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict as odict
+from unittest import mock
 
 import pytest
 
@@ -9,6 +10,7 @@ from .. import make_hw_stub
 
 
 VENDOR = "huawei"
+VENDOR_ROS = "routeros"
 
 
 @pytest.fixture
@@ -60,3 +62,36 @@ def test_subcommand(config, implicit_rules):
             ("added_command", odict()),
         ]
     )
+
+
+# ====== RouterOS tests ======
+
+
+@pytest.fixture
+def ros_empty_config():
+    formatter = registry_connector.get().match(make_hw_stub(VENDOR_ROS)).make_formatter()
+    return tabparser.parse_to_tree("", splitter=formatter.split)
+
+
+@pytest.fixture
+def ros_config_enabled_no():
+    formatter = registry_connector.get().match(make_hw_stub(VENDOR_ROS)).make_formatter()
+    return tabparser.parse_to_tree(
+        "/tool mac-server ping\nset enabled=no",
+        splitter=formatter.split,
+    )
+
+
+def test_ros_implicit_adds_default(ros_empty_config):
+    """If set enabled is not specified — implicit adds set enabled=yes"""
+    rules = implicit.compile_rules(mock.Mock(hw=make_hw_stub(VENDOR_ROS)))
+    result = implicit.config(ros_empty_config, rules)
+    assert result["tool"]["mac-server"]["ping"]["set enabled=yes"] == odict()
+
+
+def test_ros_implicit_no_override_when_disabled(ros_config_enabled_no):
+    """If set enabled=no — implicit does NOT add set enabled=yes"""
+    rules = implicit.compile_rules(mock.Mock(hw=make_hw_stub(VENDOR_ROS)))
+    result = implicit.config(ros_config_enabled_no, rules)
+    ping = result.get("tool", {}).get("mac-server", {}).get("ping", {})
+    assert "set enabled=yes" not in ping


### PR DESCRIPTION
When reading RouterOS config without verbose flag, 'set enabled=yes' is not shown (it's the default value). This caused an eternal diff when the generator produced this line.

Changes:
- Add RouterOS block to _implicit_tree() with rule for /tool mac-server ping set enabled=yes using %regexp=set enabled=.* so that if 'set enabled=no' is explicitly set in config, the implicit default is NOT added (diff is shown correctly)
- Fix implicit.config() to recursively apply child rules when adding a new implicit row (previously odict() was used instead of recursive call)
- Add tests for both cases: empty config and config with enabled=no