### PR TITLE
adding SNR vendor

### DIFF
--- a/annet/annlib/netdev/devdb/data/devdb.json
+++ b/annet/annlib/netdev/devdb/data/devdb.json
@@ -206,5 +206,10 @@
     "B4com.CS4100": "^[Bb]4com B4T-CS41.*",
     "B4com.CS4132U": "^[Bb]4com B4T-CS4132U.*",
     "B4com.CS4148Q": "^[Bb]4com B4T-CS4148Q.*",
-    "B4com.CS4164U": "^[Bb]4com B4T-CS4164U.*"
+    "B4com.CS4164U": "^[Bb]4com B4T-CS4164U.*",
+
+    "SNR": "^SNR",
+    "SNR.S5110G": "[-\\s]S5110G",
+    "SNR.S5210G": "[-\\s]S5210G",
+    "SNR.S5310G": "[-\\s]S5310G"
 }

--- a/annet/rulebook/texts/snr.order
+++ b/annet/rulebook/texts/snr.order
@@ -1,0 +1,52 @@
+# В этом файле определяется порядок команд, в котором их следует подавать на устройство.
+# - Если порядок команды не важен - ее можно не писать сюда совсем.
+# - Если команда начинается с undo и прописан параметр %order_reverse - команда считается
+#   обратной, но занимает место между прямыми там, где указано.
+
+hostname
+
+spanning-tree
+
+feature
+no feature %order_reverse
+
+no ip domain-lookup
+
+set lldp system-name
+lldp ip address
+
+snmp-server enable
+snmp-server
+    snmp-server view
+    snmp-server community
+snmp-server configuration
+    snmp-server view
+    snmp-server community
+
+username
+
+vlan database
+    vlan
+
+interface */vlan\d+/
+interface *
+    switchport mode
+    switchport trunk native vlan
+    switchport trunk allowed vlan
+    switchport access vlan
+    switchport hybrid native vlan
+    switchport hybrid allowed vlan
+    set lldp enable
+    lldp tlv
+    ip address
+    ipv6 enable
+    ipv6 address
+    ~
+
+ip route
+ipv6 route
+
+line
+    login
+
+end

--- a/annet/rulebook/texts/snr.rul
+++ b/annet/rulebook/texts/snr.rul
@@ -1,0 +1,61 @@
+# Операторы:
+#   *  Один аргумент в undo
+#   ~  Несколько аргументов (минимум один) в undo
+#
+# Параметры:
+#   %global         Команда действует на любом уровне ниже
+#   %logic=...      Кастомная функция обработки правила
+#   %diff_logic=... Кастомная функция построения диффа.
+#                   данная функция работает для подблоков (в отличие от %logic)
+#   %comment=...    Добавить коммент после строки который будет видно с опцией patch --add-comments
+#                   Сделано в основном для того чтобы генерировать специальные команды для наливки
+# -----
+
+hostname *
+
+spanning-tree mode
+
+feature ~
+no feature ~
+
+no ip domain-lookup
+
+set lldp system-name *
+lldp ip address *
+
+snmp-server enable ~
+snmp-server ~
+snmp-server configuration
+    snmp-server view ~
+    snmp-server community ~
+
+username * role * password *
+
+vlan database
+    vlan ~ state enable
+
+interface * %logic=annet.rulebook.common.permanent
+    switchport mode
+    switchport trunk allowed vlan
+    switchport trunk native vlan
+    switchport access vlan
+    switchport hybrid native vlan
+    switchport hybrid allowed vlan ~
+    set lldp enable ~
+    lldp tlv ~
+    ip address ~
+    ipv6 enable
+    ipv6 address ~
+
+ip route ~
+ipv6 route ~
+
+line ~
+    login
+
+end
+
+no ~ %global
+~ %global
+
+# vim: set syntax=annrulebook:

--- a/annet/vendors/__init__.py
+++ b/annet/vendors/__init__.py
@@ -18,6 +18,7 @@ from .library import (
     pc,
     ribbon,
     routeros,
+    snr,
 )
 from .registry import Registry, registry
 

--- a/annet/vendors/library/snr.py
+++ b/annet/vendors/library/snr.py
@@ -1,0 +1,41 @@
+from annet.annlib.command import Command, CommandList
+from annet.annlib.netdev.views.hardware import HardwareView
+from annet.vendors.base import AbstractVendor
+from annet.vendors.registry import registry
+from annet.vendors.tabparser import SNRFormatter
+
+
+@registry.register
+class SNRVendor(AbstractVendor):
+    NAME = "snr"
+
+    def apply(self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str) -> tuple[CommandList, CommandList]:
+        before, after = CommandList(), CommandList()
+
+        before.add_cmd(Command("conf t"))
+        after.add_cmd(Command("exit"))
+        if do_finalize:
+            after.add_cmd(Command("copy running-config startup-config", timeout=40))
+
+        return before, after
+
+    def match(self) -> list[str]:
+        return ["SNR"]
+
+    @property
+    def reverse(self) -> str:
+        return "no"
+
+    @property
+    def hardware(self) -> HardwareView:
+        return HardwareView("SNR")
+
+    def svi_name(self, num: int) -> str:
+        return f"vlan{num}"
+
+    def make_formatter(self, **kwargs) -> SNRFormatter:
+        return SNRFormatter(**kwargs)
+
+    @property
+    def exit(self) -> str:
+        return "exit"

--- a/annet/vendors/tabparser.py
+++ b/annet/vendors/tabparser.py
@@ -847,6 +847,14 @@ class RosFormatter(CommonFormatter):
         return commands
 
 
+class SNRFormatter(BlockExitFormatter):
+    def __init__(self, indent="  "):
+        super().__init__("exit", indent)
+
+    def split(self, text):
+        return self.split_remove_spaces(text)
+
+
 # ====
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -58,6 +58,7 @@ def make_hw_stub(vendor):
             "optixtrans": "Huawei DC",
             "b4com": "B4com",
             "h3c": "H3C",
+            "snr": "SNR",
         }[vendor],
         None,
     )


### PR DESCRIPTION
Adding the SNR vendor to Annet (https://snr.global). The configuration is very similar to the Cisco configuration.
- implemented AbstractVendor interface for SNR (SNRVendor)
- added SNRFormatter for SNR (stub)
- added SNR to devdb.json
- added rulebooks for SNR
