### PR TITLE
chore: remove global live_configs

### DIFF
--- a/annet/api/__init__.py
+++ b/annet/api/__init__.py
@@ -285,22 +285,34 @@ def gen(args: cli_args.ShowGenOptions, loader: ann_gen.Loader):
 
 def patch(args: cli_args.ShowPatchOptions, loader: ann_gen.Loader):
     """Сгенерировать патч для устройств"""
-    if args.config == "running":
-        fetcher = annet.deploy.get_fetcher()
-        ann_gen.live_configs = annet.lib.do_async(fetcher.fetch(loader.devices, processes=args.parallel))
+    current_state = annet.lib.do_async(
+        ann_gen.get_current_state(
+            args.config,
+            loader.devices,
+            loader.resolve_gens(loader.devices),
+            do_files_download=True,
+            processes=args.parallel,
+        ),
+        new_thread=True,
+    )
     stdin = args.stdin(filter_acl=args.filter_acl, config=args.config)
 
     filterer = filtering.filterer_connector.get()
-    pool = Parallel(_patch_worker, args, stdin, loader, filterer).tune_args(args)
+    pool = Parallel(_patch_worker, args, stdin, loader, filterer, current_state).tune_args(args)
     if args.show_hosts_progress:
         pool.add_callback(PoolProgressLogger(loader.device_fqdns))
     return pool.run(loader.device_ids, args.tolerate_fails, args.strict_exit_code)
 
 
 def _patch_worker(
-    device_id, args: cli_args.ShowPatchOptions, stdin, loader: ann_gen.Loader, filterer: filtering.Filterer
+    device_id,
+    args: cli_args.ShowPatchOptions,
+    stdin,
+    loader: ann_gen.Loader,
+    filterer: filtering.Filterer,
+    current_state: ann_gen.CurrentState,
 ):
-    for res, _, patch_tree in res_diff_patch(device_id, args, stdin, loader, filterer):
+    for res, _, patch_tree in res_diff_patch(device_id, args, stdin, loader, filterer, current_state):
         old_files = res.old_files
         new_files = res.get_new_files(args.acl_safe)
         new_json_fragment_files = res.get_new_file_fragments(args.acl_safe)
@@ -334,12 +346,14 @@ def res_diff_patch(
     stdin,
     loader: ann_gen.Loader,
     filterer: filtering.Filterer,
+    current_state: ann_gen.CurrentState,
 ) -> Iterable[Tuple[OldNewResult, Dict, Dict]]:
     for res in ann_gen.old_new(
         args,
         config=args.config,
         loader=loader,
         filterer=filterer,
+        current_state=current_state,
         stdin=stdin,
         device_ids=[device_id],
         no_new=args.clear,
@@ -364,16 +378,21 @@ def diff(
     args: cli_args.DiffOptions, loader: ann_gen.Loader, device_ids: List[Any]
 ) -> tuple[Mapping[Device, Union[Diff, PCDiff]], Mapping[Device, Exception]]:
     """Сгенерировать дифф для устройств"""
-    if args.config == "running":
-        fetcher = annet.deploy.get_fetcher()
-        ann_gen.live_configs = annet.lib.do_async(
-            fetcher.fetch([device for device in loader.devices if device.id in device_ids], processes=args.parallel),
-            new_thread=True,
-        )
+    devices = [device for device in loader.devices if device.id in device_ids]
+    current_state = annet.lib.do_async(
+        ann_gen.get_current_state(
+            args.config,
+            devices,
+            loader.resolve_gens(devices),
+            do_files_download=True,
+            processes=args.parallel,
+        ),
+        new_thread=True,
+    )
     stdin = args.stdin(filter_acl=args.filter_acl, config=None)
 
     filterer = filtering.filterer_connector.get()
-    pool = Parallel(ann_diff.worker, args, stdin, loader, filterer).tune_args(args)
+    pool = Parallel(ann_diff.worker, args, stdin, loader, filterer, current_state).tune_args(args)
     if args.show_hosts_progress:
         fqdns = {k: v for k, v in loader.device_fqdns.items() if k in device_ids}
         pool.add_callback(PoolProgressLogger(fqdns))
@@ -656,9 +675,6 @@ class Deployer:
         if not diff_args.query:
             return
 
-        # clear cache
-        ann_gen.live_configs = None
-
         # collect new diffs for devices on which we had successfully uploaded something
         success_device_ids = []
         for host, hres in result.results.items():
@@ -706,10 +722,9 @@ def deploy(
     loader: ann_gen.Loader,
     deployer: Deployer,
     filterer: Filterer,
-    fetcher: Fetcher,
     deploy_driver: DeployDriver,
 ) -> ExitCode:
-    return annet.lib.do_async(adeploy(args, loader, deployer, filterer, fetcher, deploy_driver))
+    return annet.lib.do_async(adeploy(args, loader, deployer, filterer, deploy_driver))
 
 
 async def adeploy(
@@ -717,13 +732,17 @@ async def adeploy(
     loader: ann_gen.Loader,
     deployer: Deployer,
     filterer: Filterer,
-    fetcher: Fetcher,
     deploy_driver: DeployDriver,
 ) -> ExitCode:
     """Сгенерировать конфиг для устройств и задеплоить его"""
     ret: ExitCode = 0
-    ann_gen.live_configs = await fetcher.fetch(
-        devices=loader.devices, processes=args.parallel, max_slots=args.max_slots
+    current_state = await ann_gen.get_current_state(
+        "running",
+        loader.devices,
+        loader.resolve_gens(loader.devices),
+        do_files_download=True,
+        processes=args.parallel,
+        max_slots=args.max_slots,
     )
 
     device_ids = [d.id for d in loader.devices]
@@ -736,6 +755,7 @@ async def adeploy(
         do_files_download=True,
         device_ids=device_ids,
         filterer=filterer,
+        current_state=current_state,
     ):
         # Меняем exit code если хоть один device ловил exception
         if res.err is not None:

--- a/annet/cli.py
+++ b/annet/cli.py
@@ -18,10 +18,10 @@ from valkit.python import valid_logging_level
 from annet import api, cli_args, filtering, generators
 from annet.api import Deployer, collapse_texts
 from annet.argparse import ArgParser, subcommand
-from annet.deploy import get_deployer, get_fetcher
+from annet.deploy import get_deployer
 from annet.diff import gen_sort_diff
-from annet.gen import Loader, old_raw
-from annet.lib import get_context_path, repair_context_file
+from annet.gen import CurrentState, Loader, get_current_state, old_raw
+from annet.lib import do_async, get_context_path, repair_context_file
 from annet.output import OutputDriver, output_driver_connector
 from annet.storage import Device, get_storage
 
@@ -47,14 +47,14 @@ def _gen_current_items(
     loader: Loader,
     output_driver: OutputDriver,
     gen_args: cli_args.GenOptions,
+    current_state: CurrentState,
 ) -> Iterable[Tuple[str, str, bool]]:
     for device, result in old_raw(
         args=gen_args,
         loader=loader,
         config=config,
+        current_state=current_state,
         stdin=stdin,
-        do_files_download=True,
-        use_mesh=False,
     ):
         if device.hw.vendor != "pc":
             destname = output_driver.cfg_file_names(device)[0]
@@ -93,12 +93,23 @@ def show_current(args: cli_args.QueryOptions, config, arg_out: cli_args.FileOutO
         if not loader.devices:
             get_logger().error("No devices found for %s", args.query)
 
+        current_state = do_async(
+            get_current_state(
+                config,
+                loader.devices,
+                loader.resolve_gens(loader.devices),
+                do_files_download=True,
+            ),
+            new_thread=True,
+        )
+
         items = _gen_current_items(
             loader=loader,
             output_driver=output_driver,
             gen_args=gen_args,
             stdin=args.stdin(config=config),
             config=config,
+            current_state=current_state,
         )
         output_driver.write_output(arg_out, items, len(loader.devices))
 
@@ -249,7 +260,6 @@ def deploy(args: cli_args.DeployOptions):
 
     deployer = Deployer(args)
     filterer = filtering.filterer_connector.get()
-    fetcher = get_fetcher()
     deploy_driver = get_deployer()
 
     with get_loader(args, args) as loader:
@@ -259,7 +269,6 @@ def deploy(args: cli_args.DeployOptions):
             deployer=deployer,
             deploy_driver=deploy_driver,
             filterer=filterer,
-            fetcher=fetcher,
         )
 
 

--- a/annet/diff.py
+++ b/annet/diff.py
@@ -24,7 +24,7 @@ from annet.storage import Device
 from annet.types import Diff, PCDiff, PCDiffFile
 from annet.vendors import registry_connector, tabparser
 
-from .gen import Loader, old_new
+from .gen import CurrentState, Loader, old_new
 
 
 def _diff_files(hw, old_files, new_files):
@@ -77,6 +77,7 @@ def worker(
     stdin,
     loader: Loader,
     filterer: filtering.Filterer,
+    current_state: CurrentState,
 ) -> Union[Diff, PCDiff, None]:
     for res in old_new(
         args,
@@ -86,6 +87,7 @@ def worker(
         do_files_download=True,
         device_ids=[device_id],
         filterer=filterer,
+        current_state=current_state,
         stdin=stdin,
     ):
         old = res.get_old(args.acl_safe)

--- a/annet/gen.py
+++ b/annet/gen.py
@@ -52,8 +52,6 @@ from annet.vendors import registry_connector, tabparser
 # Значение такое же, как для аналогичной константы в ЧК.
 ALL_GENS = "_all_gens"
 
-live_configs = None
-
 
 @dataclasses.dataclass
 class DeviceGenerators:
@@ -369,6 +367,7 @@ def old_new(
     config: str,
     loader: "Loader",
     filterer: Filterer,
+    current_state: "CurrentState",
     add_implicit=True,
     add_annotations=False,
     stdin=None,
@@ -383,8 +382,6 @@ def old_new(
         devices = [loader.get_device(device_id) for device_id in device_ids]
 
     gens = loader.resolve_gens(devices)
-    running, failed_running = _old_resolve_running(config, devices)
-    downloaded_files, failed_files = _old_resolve_files(config, devices, gens, do_files_download)
 
     if stdin is None:
         stdin = args.stdin(filter_acl=args.filter_acl, config=config)
@@ -399,10 +396,10 @@ def old_new(
     ctx = OldNewDeviceContext(
         config=config,
         args=args,
-        downloaded_files=split_downloaded_files_multi_device(downloaded_files, gens, devices),
-        failed_files=failed_files,
-        running=running,
-        failed_running=failed_running,
+        downloaded_files=split_downloaded_files_multi_device(current_state.downloaded_files, gens, devices),
+        failed_files=current_state.failed_files,
+        running=current_state.running,
+        failed_running=current_state.failed_running,
         no_new=no_new,
         stdin=stdin,
         add_annotations=add_annotations,
@@ -429,25 +426,24 @@ def old_new(
 def old_raw(
     args: GenOptions,
     loader: Loader,
-    config,
+    config: str,
+    current_state: "CurrentState",
     stdin=None,
-    do_files_download=False,
-    use_mesh=True,
 ) -> Iterable[Tuple[Device, Union[str, Dict[str, str]]]]:
     device_gens = loader.resolve_gens(loader.devices)
-    running, failed_running = _old_resolve_running(config, loader.devices)
-    downloaded_files, failed_files = _old_resolve_files(config, loader.devices, device_gens, do_files_download)
     if stdin is None:
         stdin = args.stdin(filter_acl=args.filter_acl, config=config)
     ctx = OldNewDeviceContext(
         config=config,
         args=args,
-        downloaded_files=split_downloaded_files_multi_device(downloaded_files, device_gens, loader.devices),
-        failed_files=failed_files,
-        running=running,
-        failed_running=failed_running,
+        downloaded_files=split_downloaded_files_multi_device(
+            current_state.downloaded_files, device_gens, loader.devices
+        ),
+        failed_files=current_state.failed_files,
+        running=current_state.running,
+        failed_running=current_state.failed_running,
         stdin=stdin,
-        do_files_download=do_files_download,
+        do_files_download=True,
         device_count=len(loader.devices),
         no_new=True,
         add_annotations=False,
@@ -743,38 +739,6 @@ def _old_resolve_gens(args: GenOptions, storage: Storage, devices: Iterable[Devi
     return per_device_gens
 
 
-@tracing.function
-def _old_resolve_running(config: str, devices: List[Device]) -> Tuple[Dict[Device, str], Dict[Device, Exception]]:
-    running, failed_running = {}, {}
-    if config == "running":
-        global live_configs  # pylint: disable=global-statement
-        if live_configs is None:
-            # предварительно прочесть все конфиги прямо по ssh
-            fetcher = get_fetcher()
-            running, failed_running = do_async(fetcher.fetch(devices), new_thread=True)
-        else:
-            running, failed_running = live_configs  # pylint: disable=unpacking-non-sequence
-    return running, failed_running
-
-
-@tracing.function
-def _old_resolve_files(
-    config: str,
-    devices: List[Device],
-    gens: DeviceGenerators,
-    do_files_download: bool,
-) -> Tuple[Dict[Device, Dict[str, Optional[str]]], Dict[Device, Exception]]:
-    downloaded_files, failed_files = {}, {}
-    if do_files_download and config == "running":
-        files_to_download = _get_files_to_download(devices, gens)
-        devices_with_files = [device for device in devices if device in files_to_download]
-        if devices_with_files:
-            fetcher = get_fetcher()
-            fetch_coro = fetcher.fetch(devices_with_files, files_to_download=files_to_download)
-            downloaded_files, failed_files = do_async(fetch_coro, new_thread=True)
-    return downloaded_files, failed_files
-
-
 class Loader:
     def __init__(
         self,
@@ -832,3 +796,48 @@ class Loader:
 
     def iter_all_gens(self) -> Iterator[BaseGenerator]:
         return self._gens.iter_gens()
+
+
+@dataclasses.dataclass
+class CurrentState:
+    running: dict[Device, str] = dataclasses.field(default_factory=dict)
+    failed_running: dict[Device, Exception] = dataclasses.field(default_factory=dict)
+    downloaded_files: dict[Device, dict[str, str | None]] = dataclasses.field(default_factory=dict)
+    failed_files: dict[Device, Exception] = dataclasses.field(default_factory=dict)
+
+
+async def get_current_state(
+    config: str,
+    devices: List[Device],
+    gens: DeviceGenerators,
+    do_files_download: bool,
+    processes: int = 1,
+    max_slots: int = 0,
+) -> CurrentState:
+    if config != "running":
+        return CurrentState()
+
+    fetcher = get_fetcher()
+    running, failed_running = await fetcher.fetch(
+        devices,
+        processes=processes,
+        max_slots=max_slots,
+    )
+    downloaded_files, failed_files = {}, {}
+    if do_files_download:
+        files_to_download = _get_files_to_download(devices, gens)
+        devices_with_files = [device for device in devices if device in files_to_download]
+        if devices_with_files:
+            downloaded_files, failed_files = await fetcher.fetch(
+                devices_with_files,
+                files_to_download=files_to_download,
+                processes=processes,
+                max_slots=max_slots,
+            )
+
+    return CurrentState(
+        running=running,
+        failed_running=failed_running,
+        downloaded_files=downloaded_files,
+        failed_files=failed_files,
+    )


### PR DESCRIPTION
It's ugly and sometimes prevent a proper interpreter shutdown.