### PR TITLE
Inheritance patch rulebooks

### DIFF
--- a/annet/annlib/rbparser/ordering.py
+++ b/annet/annlib/rbparser/ordering.py
@@ -3,38 +3,13 @@ from __future__ import annotations
 import functools
 import re
 from collections.abc import Iterator
-from typing import Any, TypedDict
 
 from valkit.common import valid_bool, valid_string_list
 
+from annet.rulebook.types import CompiledTree, _CompiledOrderingAttrs
 from annet.vendors import registry_connector
 
 from . import syntax
-
-
-# =====
-# 'global' is a keyword, so we cant use normal TypedDict declaration
-_CompiledOrderingAttrs = TypedDict(
-    "_CompiledOrderingAttrs",
-    {
-        "direct_regexp": re.Pattern[str],
-        "reverse_regexp": re.Pattern[str],
-        "order_reverse": bool,
-        "global": bool,  # TODO: rename to something else so that it is not a keyword
-        "scope": list[str] | None,
-        "raw_rule": str,
-        "context": Any,
-        "split": bool,
-    },
-)
-
-
-class _CompiledOrderingItem(TypedDict):
-    attrs: _CompiledOrderingAttrs
-    children: CompiledTree
-
-
-CompiledTree = list[tuple[str, _CompiledOrderingItem]]
 
 
 @functools.lru_cache()

--- a/annet/annlib/rbparser/syntax.py
+++ b/annet/annlib/rbparser/syntax.py
@@ -7,6 +7,7 @@ from collections.abc import Iterator
 from typing import Any, TypedDict, cast
 
 from annet.annlib import lib
+from annet.rulebook.types import RawParams, RawRow, Row
 from annet.vendors import tabparser
 
 
@@ -160,3 +161,20 @@ def match_context(ifcontext, context):
 def _parse_context(context, row):
     name, value = row.strip().split(":")
     return lib.merge_dicts(context, {name: value})
+
+
+def get_row_and_raw_params(raw_row: RawRow) -> tuple[Row, RawParams]:
+    """Parses a raw rule string, returning the rule string without params and the raw params"""
+    params = {}
+    row, *raw_params = re.split(r"(?:^|\s)%(?=[a-zA-Z_]\w*)", raw_row)
+    for param in raw_params:
+        name, _, value = param.partition("=")
+        params[name.strip()] = value.strip()
+    row = re.sub(r"\s+", " ", row.strip())
+    return row, params
+
+
+def get_row_with_params(row: Row, params: RawParams) -> RawRow:
+    """Joins a rule string without params and raw params, returning the raw rule string"""
+    params_line: str = " ".join([f"%{k}={v}" if v else f"%{k}" for k, v in params.items() if k != "not_inherit"])
+    return f"{row} {params_line}" if params_line else row

--- a/annet/rulebook/__init__.py
+++ b/annet/rulebook/__init__.py
@@ -103,7 +103,7 @@ class DefaultRulebookProvider(RulebookProvider):
         """Walks inheritance chain of rulebooks: gets texts → compiles → merges (if required)"""
         child_rulebook_text = self._get_rulebook_text(rulebook_path, extension, hw)
         inherit_from, child_rulebook_text = self._split_text_from_inherit_from_param(child_rulebook_text)
-        child_rulebook = compile_patching_text(child_rulebook_text, vendor)
+        child_rulebook = self.compile_rulebooks[extension](child_rulebook_text, vendor)
 
         if inherit_from is None:
             return child_rulebook

--- a/annet/rulebook/__init__.py
+++ b/annet/rulebook/__init__.py
@@ -99,7 +99,7 @@ class DefaultRulebookProvider(RulebookProvider):
         }
         return self._rulebook_cache[hw]
 
-    def _get_rulebook_by_extension(self, rulebook_path: str, vendor: str, extension: Exception, hw) -> PatchRulebook:
+    def _get_rulebook_by_extension(self, rulebook_path: str, vendor: str, extension: Extension, hw) -> PatchRulebook:
         """Walks inheritance chain of rulebooks: gets texts → compiles → merges (if required)"""
         child_rulebook_text = self._get_rulebook_text(rulebook_path, extension, hw)
         inherit_from, child_rulebook_text = self._split_text_from_inherit_from_param(child_rulebook_text)

--- a/annet/rulebook/__init__.py
+++ b/annet/rulebook/__init__.py
@@ -2,14 +2,18 @@ import re
 import sys
 from abc import ABC
 from importlib import resources
-from typing import Any, Dict, OrderedDict, TypedDict
+from typing import Callable
+
+from valkit.python import valid_object_path
 
 from annet.annlib.lib import mako_render
-from annet.annlib.rbparser.ordering import CompiledTree, compile_ordering_text
+from annet.annlib.rbparser.ordering import compile_ordering_text
 from annet.annlib.rbparser.platform import VENDOR_ALIASES
 from annet.connectors import CachedConnector
 from annet.rulebook.deploying import compile_deploying_text
-from annet.rulebook.patching import compile_patching_text
+from annet.rulebook.exceptions import RulebookSyntaxError
+from annet.rulebook.patching import compile_patching_text, merge_patch_rulebooks, parse_rulebook_to_text
+from annet.rulebook.types import Extension, PatchingText, PatchRulebook, Rulebook
 from annet.vendors import registry_connector
 
 
@@ -19,19 +23,6 @@ if sys.version_info >= (3, 12):
     RULEBOOK_READ_EXCEPTIONS = (FileNotFoundError, TraversalError)
 else:
     RULEBOOK_READ_EXCEPTIONS = (FileNotFoundError,)
-
-
-class RulebookTexts(TypedDict):
-    patching: str
-    ordering: str
-    deploying: str
-
-
-class Rulebook(TypedDict):
-    patching: Dict[str, OrderedDict[str, Any]]
-    ordering: CompiledTree
-    deploying: OrderedDict[str, Any]
-    texts: RulebookTexts
 
 
 class RulebookProvider(ABC):
@@ -53,21 +44,35 @@ def get_rulebook(hw) -> Rulebook:
 
 class DefaultRulebookProvider(RulebookProvider):
     rulebook_module = "annet.rulebook.texts"
+    merge_rulebooks = {
+        "rul": merge_patch_rulebooks,
+    }
+    compile_rulebooks: dict[Extension, Callable] = {
+        "rul": compile_patching_text,
+    }
 
     def __init__(self):
         self._rulebook_cache = {}
         self._render_rul_cache = {}
         self._escaped_rul_cache = {}
+        self._rulebook_text_cache = {}
 
     def get_rulebook(self, hw) -> Rulebook:
         if hw in self._rulebook_cache:
             return self._rulebook_cache[hw]
 
-        assert hw.vendor in registry_connector.get(), "Unknown vendor: %s" % (hw.vendor)
-        rul_vendor_name = VENDOR_ALIASES.get(hw.vendor, hw.vendor)
+        vendor = hw.vendor
+        assert vendor in registry_connector.get(), "Unknown vendor: %s" % (vendor)
+        rul_vendor_name = VENDOR_ALIASES.get(vendor, vendor)
 
-        patching_text = self._render_rul(rul_vendor_name + ".rul", hw)
-        patching = compile_patching_text(patching_text, rul_vendor_name)
+        patching = self._get_rulebook_by_extension(
+            # The first rulebook should be named exactly the same as hw.vendor
+            rulebook_path=".".join((self.rulebook_module, rul_vendor_name)),
+            vendor=rul_vendor_name,
+            extension="rul",
+            hw=hw,
+        )
+        patching_text = parse_rulebook_to_text(patching)
 
         try:
             ordering_text = self._render_rul(hw.vendor + ".order", hw)
@@ -93,6 +98,72 @@ class DefaultRulebookProvider(RulebookProvider):
             },
         }
         return self._rulebook_cache[hw]
+
+    def _get_rulebook_by_extension(self, rulebook_path: str, vendor: str, extension: Exception, hw) -> PatchRulebook:
+        """Walks inheritance chain of rulebooks: gets texts → compiles → merges (if required)"""
+        child_rulebook_text = self._get_rulebook_text(rulebook_path, extension, hw)
+        inherit_from, child_rulebook_text = self._split_text_from_inherit_from_param(child_rulebook_text)
+        child_rulebook = compile_patching_text(child_rulebook_text, vendor)
+
+        if inherit_from is None:
+            return child_rulebook
+
+        parent_rulebook_path = self._parse_inherit_from_param(inherit_from)
+        parent_rulebook = self._get_rulebook_by_extension(
+            rulebook_path=parent_rulebook_path,
+            vendor=vendor,
+            extension=extension,
+            hw=hw,
+        )
+
+        return self.merge_rulebooks[extension](parent_rulebook, child_rulebook, vendor)
+
+    def _split_text_from_inherit_from_param(self, rulebook_text: str) -> tuple[str | None, str]:
+        """Split the %inherit_from param from the rulebook text"""
+        count_inherit_from_param = len(re.findall(r"%inherit_from", rulebook_text))
+        if count_inherit_from_param == 0:
+            inherit_from = None
+        elif count_inherit_from_param > 1:
+            raise RulebookSyntaxError(r"The rulebook must contain a single %inherit_from param.")
+        elif not rulebook_text.startswith(r"%inherit_from="):
+            raise RulebookSyntaxError(r"%inherit_from param must be located at the start of the file.")
+        else:
+            lines = rulebook_text.split("\n")
+            inherit_from, rulebook_text = lines[0], "\n".join(lines[1:])
+        return inherit_from, rulebook_text
+
+    def _parse_inherit_from_param(self, param: str) -> tuple[str, str]:
+        """Parses the %inherit_from param"""
+        parts = param.split("=")
+        if len(parts) != 2:
+            raise RulebookSyntaxError(r"The %inherit_from param must follow '%inherit_from={path}' format")
+        path = parts[1]
+        self.check_rulebook_path(path)
+        return path
+
+    def check_rulebook_path(self, rulebook_path):
+        """Validates the Python path to a rulebook"""
+        if not valid_object_path(rulebook_path):
+            raise ValueError(f"Invalid rulebook path '{rulebook_path}'. The path must follow the 'module.name' format.")
+
+    def _get_rulebook_text(self, rulebook_path: str, extension: str, hw) -> PatchingText:
+        """Gets the rulebook text"""
+        key = (rulebook_path, extension, hw)
+        if key not in self._rulebook_text_cache:
+            raw_text = self._get_raw_rulebook_text(rulebook_path, extension)
+            escaped_mako_text = self._escape_mako(raw_text)
+            rendered_text = mako_render(escaped_mako_text, hw=hw)
+            self._rulebook_text_cache[key] = re.sub(r"\n+", "\n", rendered_text.strip("\n"))
+        return self._rulebook_text_cache[key]
+
+    def _get_raw_rulebook_text(self, rulebook_path: str, extension: str):
+        """Gets the raw rulebook text"""
+        self.check_rulebook_path(rulebook_path)
+        module, name = rulebook_path.rsplit(".", 1)
+        try:
+            return resources.files(module).joinpath(f"{name}.{extension}").read_text(encoding="utf-8")
+        except RULEBOOK_READ_EXCEPTIONS as err:
+            raise FileNotFoundError(f'Unable to find rulebook "{name}" in "{self.rulebook_module}" module') from err
 
     def _render_rul(self, name, hw):
         key = (name, hw)

--- a/annet/rulebook/exceptions.py
+++ b/annet/rulebook/exceptions.py
@@ -1,0 +1,4 @@
+class RulebookSyntaxError(Exception):
+    """Raised when rulebook syntax is invalid"""
+
+    pass

--- a/annet/rulebook/patching.py
+++ b/annet/rulebook/patching.py
@@ -1,75 +1,127 @@
 import functools
 import re
+import warnings
 from collections import OrderedDict as odict
+from typing import Generator, Literal
 
 from valkit.common import valid_bool, valid_string_list
 from valkit.python import valid_object_path
 
 from annet.annlib.rbparser import platform, syntax
+from annet.rulebook.exceptions import RulebookSyntaxError
+from annet.rulebook.types import (
+    Params,
+    PatchIgnoreRuleAttrs,
+    PatchingText,
+    PatchNormalRuleAttrs,
+    PatchPreMerge,
+    PatchPreMergeData,
+    PatchRule,
+    PatchRuleAttrs,
+    PatchRulebook,
+    RawParams,
+    RawRow,
+    Row,
+    Scope,
+    Type,
+)
 from annet.vendors import registry_connector
 
 from .common import import_rulebook_function
 
 
+# ===LOGIC_PATHS===
 DEFAULT_PATCH_LOGIC = "annet.rulebook.common.default"
 ORDERED_PATCH_LOGIC = "annet.rulebook.common.ordered"
 REWRITE_PATCH_LOGIC = "annet.rulebook.common.rewrite"
 REWRITE_DIFF_LOGIC = "annet.rulebook.common.rewrite_diff"
 MULTILINE_DIFF_LOGIC = "annet.rulebook.common.multiline_diff"
 
+# ===SCOPE===
+SCOPE: Literal["scope"] = "scope"
+LOCAL: Literal["local"] = "local"
+GLOBAL: Literal["global"] = "global"
 
-# =====
+# ===PARAMS===
+PARAMS: Literal["params"] = "params"
+LOGIC: Literal["logic"] = "logic"
+DIFF_LOGIC: Literal["diff_logic"] = "diff_logic"
+COMMENT: Literal["comment"] = "comment"
+MULTILINE: Literal["multiline"] = "multiline"
+ORDERED: Literal["ordered"] = "ordered"
+CONTEXT: Literal["context"] = "context"
+REWRITE: Literal["rewrite"] = "rewrite"
+PARENT: Literal["parent"] = "parent"
+FORCE_COMMIT: Literal["force_commit"] = "force_commit"
+IGNORE_CASE: Literal["ignore_case"] = "ignore_case"
+ROW: Literal["row"] = "row"
+NOT_INHERIT: Literal["not_inherit"] = "not_inherit"
+
+# ===RULE===
+RULES: Literal["rules"] = "rules"
+TYPE: Literal["type"] = "type"
+NORMAL: Literal["normal"] = "normal"
+IGNORE: Literal["ignore"] = "ignore"
+ATTRS: Literal["attrs"] = "attrs"
+CHILDREN: Literal["children"] = "children"
+
+
+def get_params_scheme(vendor):
+    """Returning the params scheme"""
+    return {
+        GLOBAL: {
+            "validator": valid_bool,
+            "default": False,
+        },
+        LOGIC: {
+            "validator": valid_object_path,
+            "default": DEFAULT_PATCH_LOGIC,
+        },
+        DIFF_LOGIC: {
+            "validator": valid_object_path,
+            "default": registry_connector.get()[vendor].diff(False),
+        },
+        COMMENT: {
+            "validator": valid_string_list,
+            "default": [],
+        },
+        MULTILINE: {
+            "validator": valid_bool,
+            "default": False,
+        },
+        ORDERED: {
+            "validator": valid_bool,
+            "default": False,
+        },
+        CONTEXT: {
+            "validator": str,
+            "default": None,
+        },
+        REWRITE: {
+            "validator": valid_bool,
+            "default": False,
+        },
+        PARENT: {
+            "validator": valid_bool,
+            "default": False,
+        },
+        FORCE_COMMIT: {
+            "validator": valid_bool,
+            "default": False,
+        },
+        IGNORE_CASE: {
+            "validator": valid_bool,
+            "default": False,
+        },
+    }
+
+
 @functools.lru_cache()
-def compile_patching_text(text, vendor):
+def compile_patching_text(text: PatchingText, vendor) -> PatchRulebook:
     return _compile_patching(
         tree=syntax.parse_text(
             text,
-            params_scheme={
-                "global": {
-                    "validator": valid_bool,
-                    "default": False,
-                },
-                "logic": {
-                    "validator": valid_object_path,
-                    "default": DEFAULT_PATCH_LOGIC,
-                },
-                "diff_logic": {
-                    "validator": valid_object_path,
-                    "default": registry_connector.get()[vendor].diff(False),
-                },
-                "comment": {
-                    "validator": valid_string_list,
-                    "default": [],
-                },
-                "multiline": {
-                    "validator": valid_bool,
-                    "default": False,
-                },
-                "ordered": {
-                    "validator": valid_bool,
-                    "default": False,
-                },
-                "context": {
-                    "validator": str,
-                    "default": None,
-                },
-                "rewrite": {
-                    "validator": valid_bool,
-                    "default": False,
-                },
-                "parent": {
-                    "validator": valid_bool,
-                    "default": False,
-                },
-                "force_commit": {
-                    "validator": valid_bool,
-                    "default": False,
-                },
-                "ignore_case": {
-                    "validator": valid_bool,
-                    "default": False,
-                },
-            },
+            params_scheme=get_params_scheme(vendor),
         ),
         reverse_prefix=registry_connector.get()[vendor].reverse,
         vendor=vendor,
@@ -77,51 +129,55 @@ def compile_patching_text(text, vendor):
 
 
 # =====
-def _compile_patching(tree, reverse_prefix, vendor):
-    rules = {"local": odict(), "global": odict()}
+def _compile_patching(tree, reverse_prefix, vendor) -> PatchRulebook:
+    rules = _create_empty_rulebook()
     for raw_rule, attrs in tree.items():
         regexp = _attrs_to_regexp(attrs)
         attrs = _regexp_to_attrs(regexp, attrs)
-        if attrs["type"] == "ignore":
-            rule = {
-                "type": attrs["type"],
-                "attrs": {
-                    "regexp": regexp,
-                    "diff_logic": import_rulebook_function(attrs["params"]["diff_logic"]),
-                    "parent": bool(attrs["children"]),
-                    "context": attrs["context"],
-                },
-                "children": {"global": {}, "local": {}},
-            }
+        if attrs[TYPE] == IGNORE:
+            rule = PatchRule(
+                type=attrs[TYPE],
+                attrs=PatchIgnoreRuleAttrs(
+                    regexp=regexp,
+                    diff_logic=import_rulebook_function(attrs[PARAMS][DIFF_LOGIC]),
+                    parent=bool(attrs[CHILDREN]),
+                    context=attrs[CONTEXT],
+                ),
+                children=_create_empty_rulebook(),
+            )
         else:
-            if attrs["params"]["ordered"]:
-                attrs["params"]["diff_logic"] = registry_connector.get()[vendor].diff(True)
-                attrs["params"]["logic"] = ORDERED_PATCH_LOGIC
-            elif attrs["params"]["rewrite"]:
-                attrs["params"]["diff_logic"] = REWRITE_DIFF_LOGIC
-                attrs["params"]["logic"] = REWRITE_PATCH_LOGIC
-            elif attrs["params"]["multiline"]:
-                attrs["params"]["diff_logic"] = MULTILINE_DIFF_LOGIC
-            rule = {
-                "type": attrs["type"],
-                "attrs": {
-                    "logic": import_rulebook_function(attrs["params"]["logic"]),
-                    "diff_logic": import_rulebook_function(attrs["params"]["diff_logic"]),
-                    "regexp": regexp,
-                    "reverse": _make_reverse(attrs["row"], reverse_prefix, flags=regexp.flags),
-                    "comment": attrs["params"]["comment"],
-                    "multiline": attrs["params"]["multiline"],
-                    "parent": attrs["params"]["parent"] or bool(attrs["children"]),
-                    "force_commit": attrs["params"]["force_commit"],
-                    "ignore_case": attrs["params"]["ignore_case"],
-                    "ordered": attrs["params"]["ordered"],
-                    "context": attrs["context"],
-                },
-                "children": None,
-            }
-            if not attrs["params"]["global"]:
-                rule["children"] = _compile_patching(attrs["children"], reverse_prefix, vendor)
-        rules["global" if attrs["params"]["global"] else "local"][raw_rule] = rule
+            _validate_params_compatibility(attrs[PARAMS], raw_rule, vendor)
+
+            if attrs[PARAMS][ORDERED]:
+                attrs[PARAMS][DIFF_LOGIC] = registry_connector.get()[vendor].diff(True)
+                attrs[PARAMS][LOGIC] = ORDERED_PATCH_LOGIC
+            elif attrs[PARAMS][REWRITE]:
+                attrs[PARAMS][DIFF_LOGIC] = REWRITE_DIFF_LOGIC
+                attrs[PARAMS][LOGIC] = REWRITE_PATCH_LOGIC
+            elif attrs[PARAMS][MULTILINE]:
+                attrs[PARAMS][DIFF_LOGIC] = MULTILINE_DIFF_LOGIC
+            rule = PatchRule(
+                type=attrs[TYPE],
+                attrs=PatchNormalRuleAttrs(
+                    **{
+                        "logic": import_rulebook_function(attrs[PARAMS][LOGIC]),
+                        "diff_logic": import_rulebook_function(attrs[PARAMS][DIFF_LOGIC]),
+                        "regexp": regexp,
+                        "reverse": _make_reverse(attrs[ROW], reverse_prefix, flags=regexp.flags),
+                        "comment": attrs[PARAMS][COMMENT],
+                        "multiline": attrs[PARAMS][MULTILINE],
+                        "parent": attrs[PARAMS][PARENT] or bool(attrs[CHILDREN]),
+                        "force_commit": attrs[PARAMS][FORCE_COMMIT],
+                        "ignore_case": attrs[PARAMS][IGNORE_CASE],
+                        "ordered": attrs[PARAMS][ORDERED],
+                        "context": attrs[CONTEXT],
+                    }
+                ),
+                children=None,
+            )
+            if not attrs[PARAMS][GLOBAL]:
+                rule[CHILDREN] = _compile_patching(attrs[CHILDREN], reverse_prefix, vendor)
+        rules[GLOBAL if attrs[PARAMS][GLOBAL] else LOCAL][raw_rule] = rule
     return rules
 
 
@@ -142,12 +198,283 @@ def _make_reverse(row, reverse_prefix, flags=0):
 
 def _attrs_to_regexp(attrs):
     flags = 0
-    ignore_case = attrs["params"]["ignore_case"]
+    ignore_case = attrs[PARAMS][IGNORE_CASE]
     if ignore_case:
         flags |= re.IGNORECASE
-    return syntax.compile_row_regexp(attrs["row"], flags=flags)
+    return syntax.compile_row_regexp(attrs[ROW], flags=flags)
 
 
 def _regexp_to_attrs(regexp, attrs):
-    attrs["params"]["ignore_case"] = bool(regexp.flags & re.IGNORECASE)
+    attrs[PARAMS][IGNORE_CASE] = bool(regexp.flags & re.IGNORECASE)
     return attrs
+
+
+def merge_patch_rulebooks(parent_rulebook: PatchRulebook, child_rulebook: PatchRulebook, vendor) -> PatchRulebook:
+    """Merges the parent rulebook with the child rulebook"""
+    child_pre_merge = _get_pre_merge(child_rulebook)
+    parent_pre_merge = _get_pre_merge(parent_rulebook)
+
+    merged_rulebook = _create_empty_rulebook()
+
+    for row in uniq_local_global_rules(parent_pre_merge, child_pre_merge):
+        parent_data = parent_pre_merge.get(row, None)
+        child_data = child_pre_merge.get(row, None)
+
+        if child_data is None:
+            # for mypy (In this case, parend_data cannot be None)
+            assert parent_data is not None
+            _add_parent_to_merge_rulebook(merged_rulebook, parent_data, row, vendor)
+
+        elif NOT_INHERIT in child_data[PARAMS] or parent_data is None:
+            _add_child_to_merge_rulebook(merged_rulebook, child_data, row, vendor)
+
+        else:
+            child_rules = child_data["rules"]
+            child_params = child_data["params"]
+            child_scope = child_data["scope"]
+            parent_rules = parent_data["rules"]
+            parent_params = parent_data["params"]
+            parent_scope = parent_data["scope"]
+
+            merged_scope = get_merged_scope(parent_scope, child_scope, child_params)
+            merged_row = get_merged_row(parent_params, child_params, row, vendor)
+            merged_rule = get_merged_rule(parent_rules, child_rules, child_params, merged_scope, row, vendor)
+
+            merged_rulebook[merged_scope][merged_row] = merged_rule
+
+    return merged_rulebook
+
+
+def _add_child_to_merge_rulebook(
+    merged_rulebook: PatchRulebook, child_data: PatchPreMergeData, row: Row, vendor
+) -> None:
+    """Add child rule to merged_rulebook"""
+    if NOT_INHERIT in child_data[PARAMS]:
+        if GLOBAL in child_data[PARAMS]:
+            raise RulebookSyntaxError(r"Usage of %not_inherit param together with %global param is not allowed.")
+        elif _is_empty_rulebook(child_data[RULES][CHILDREN]):
+            return None
+    cutted_params = cut_default_params(child_data[PARAMS], vendor)
+    row_with_params = syntax.get_row_with_params(row, cutted_params)
+    merged_rulebook[child_data[SCOPE]][row_with_params] = child_data[RULES]
+
+
+def _add_parent_to_merge_rulebook(
+    merged_rulebook: PatchRulebook, parent_data: PatchPreMergeData, row: Row, vendor
+) -> None:
+    """Add parent rule to merged_rulebook"""
+    cutted_params = cut_default_params(parent_data[PARAMS], vendor)
+    row_with_params = syntax.get_row_with_params(row, cutted_params)
+    merged_rulebook[parent_data[SCOPE]][row_with_params] = parent_data[RULES]
+
+
+def _create_empty_rulebook() -> PatchRulebook:
+    """Create empty patch rulebook"""
+    return {LOCAL: odict(), GLOBAL: odict()}
+
+
+def _is_empty_rulebook(rulebook: PatchRulebook | None) -> bool:
+    """Validate patch rulebook is empty"""
+    if rulebook is None:
+        return True
+    return not rulebook[LOCAL] and not rulebook[GLOBAL]
+
+
+def _ensure_rulebook(rulebook: PatchRulebook | None = None) -> PatchRulebook:
+    """
+    Ensures patch rulebook has valid structure; returns empty patch rulebook if None
+    """
+    if rulebook is None:
+        return _create_empty_rulebook()
+    return rulebook
+
+
+def _get_pre_merge(rulebook: PatchRulebook) -> PatchPreMerge:
+    """Created pre_merge object for merge rulebook"""
+    pre_merge = {}
+    for scope in (LOCAL, GLOBAL):
+        for raw_row, rules in rulebook[scope].items():
+            row, params = syntax.get_row_and_raw_params(raw_row)
+            pre_merge[row] = PatchPreMergeData(
+                rules=rules,
+                params=params,
+                scope=scope,
+            )
+    return PatchPreMerge(**pre_merge)
+
+
+def uniq_local_global_rules(
+    parent_pre_merge: PatchPreMerge, children_pre_merge: PatchPreMerge
+) -> Generator[Row, None, None]:
+    """Returns each rule from parent_pre_merge and children_pre_merge exactly once"""
+    seen = set()
+    for pre_merge in [parent_pre_merge, children_pre_merge]:
+        for row in pre_merge.keys():
+            if row not in seen:
+                seen.add(row)
+                yield row
+
+
+def get_merged_params(parent_params: RawParams, child_params: RawParams) -> RawParams:
+    """Merges parent_params and child_params"""
+    params = parent_params.copy()
+    params.update(child_params)
+    return params
+
+
+def cut_default_params(params: RawParams, vendor) -> RawParams:
+    """Returns a copy params without params set to default values"""
+    result_param = {}
+    params_scheme = get_params_scheme(vendor)
+    for name, value in params.items():
+        if name not in params_scheme:
+            continue
+        validator = params_scheme[name]["validator"]
+        default = params_scheme[name]["default"]
+        if validator(value if value != "" else "1") == default:
+            continue
+        result_param[name] = value
+    return result_param
+
+
+def get_merged_row(parent_params: RawParams, child_params: RawParams, row: Row, vendor) -> RawRow:
+    """Concatenates the rule string with the merged raw params"""
+    merged_params = get_merged_params(
+        parent_params,
+        child_params,
+    )
+    _validate_merged_params_compatibility(merged_params, row)
+    cutted_params = cut_default_params(merged_params, vendor)
+    return syntax.get_row_with_params(row, cutted_params)
+
+
+def get_merged_scope(parent_scope: Scope, child_scope: Scope, child_params: RawParams) -> Scope:
+    """Merges parent_scope and child_scope"""
+    return parent_scope if child_params.get(GLOBAL) is None else child_scope
+
+
+def get_merged_rule(
+    parent_rules: PatchRule, child_rules: PatchRule, child_params: RawParams, scope: Scope, row: Row, vendor
+) -> PatchRule:
+    """Merges parent_rules and child_rules"""
+    merged_type = child_rules[TYPE]
+
+    if scope == GLOBAL:
+        merged_children = None
+        if not _is_empty_rulebook(child_rules[CHILDREN]) or not _is_empty_rulebook(parent_rules[CHILDREN]):
+            warnings.warn(f"Global rule '{row}' has child rules - ignoring child rules.")
+    else:
+        parent_children = parent_rules[CHILDREN]
+        child_children = child_rules[CHILDREN]
+        merged_children = merge_patch_rulebooks(
+            _ensure_rulebook(parent_children), _ensure_rulebook(child_children), vendor
+        )
+
+    merged_attrs = _merge_attrs(
+        parent_rules[ATTRS],
+        child_rules[ATTRS],
+        child_params,
+        row,
+        merged_type,
+    )
+    if (parent_rules[ATTRS][PARENT] or child_rules[ATTRS][PARENT]) and merged_type == IGNORE:
+        merged_attrs[PARENT] = True
+    elif not _is_empty_rulebook(merged_children) and scope == LOCAL:
+        merged_attrs[PARENT] = True
+    else:
+        merged_attrs[PARENT] = False
+
+    return PatchRule(
+        **{
+            TYPE: merged_type,
+            CHILDREN: merged_children,
+            ATTRS: merged_attrs,
+        }
+    )
+
+
+def _merge_attrs(
+    parent_attrs: PatchRuleAttrs, child_attrs: PatchRuleAttrs, child_params: RawParams, row: Row, rule_type: Type
+) -> PatchRuleAttrs:
+    """Merges parent_attrs and child_attrs"""
+    merged_attrs = parent_attrs.copy()
+
+    _validate_context_compatibility(parent_attrs, child_attrs, row)
+
+    for param in child_params.keys():
+        if param in child_attrs:
+            # A dynamic key cannot be recognized by mypy as a string literal
+            merged_attrs[param] = child_attrs[param]  # type: ignore[literal-required]
+
+    if rule_type == IGNORE:
+        return merged_attrs
+
+    # After the checks above, merged_attrs, child_attrs, and parent_attrs
+    # are guaranteed to be of type PatchNormalRuleAttrs
+    if ORDERED in child_params:
+        merged_attrs[LOGIC] = child_attrs[LOGIC]  # type: ignore[typeddict-item]
+        merged_attrs[DIFF_LOGIC] = child_attrs[DIFF_LOGIC]  # type: ignore[typeddict-item]
+    elif REWRITE in child_params:
+        merged_attrs[LOGIC] = child_attrs[LOGIC]  # type: ignore[typeddict-item]
+        merged_attrs[DIFF_LOGIC] = child_attrs[DIFF_LOGIC]  # type: ignore[typeddict-item]
+    elif MULTILINE in child_params:
+        merged_attrs[DIFF_LOGIC] = child_attrs[DIFF_LOGIC]  # type: ignore[typeddict-item]
+
+    return merged_attrs
+
+
+def _validate_params_compatibility(params: Params, row: str, vendor) -> None:
+    """Checks compatibility of ordered/rewrite/multiline params with logic/diff_logic params at compile time"""
+    used_default_logic_path = params[LOGIC] == DEFAULT_PATCH_LOGIC
+    used_default_diff_logic_path = params[DIFF_LOGIC] == registry_connector.get()[vendor].diff(False)
+
+    conflicts = [
+        (ORDERED, (used_default_logic_path, used_default_diff_logic_path), (LOGIC, DIFF_LOGIC)),
+        (REWRITE, (used_default_logic_path, used_default_diff_logic_path), (LOGIC, DIFF_LOGIC)),
+        (MULTILINE, (used_default_diff_logic_path,), (DIFF_LOGIC,)),
+    ]
+    for param, checks, conflicting_params in conflicts:
+        if params[ORDERED] and not all(checks):
+            raise RulebookSyntaxError(
+                f"Compilation error for rule '{row}'. "
+                f"Param '%{param}' cannot be used together with params ({', '.join(conflicting_params)})."
+            )
+
+
+def _validate_merged_params_compatibility(params: RawParams, row: str) -> None:
+    """Checks compatibility of ordered/rewrite/multiline params with logic/diff_logic params at merge time"""
+    conflicts = [
+        (ORDERED, (LOGIC, DIFF_LOGIC)),
+        (REWRITE, (LOGIC, DIFF_LOGIC)),
+        (MULTILINE, (DIFF_LOGIC,)),
+    ]
+    for param, conflicting_params in conflicts:
+        if param not in params:
+            return None
+        elif any(conflict_param in params for conflict_param in conflicting_params):
+            raise RulebookSyntaxError(
+                f"Merge error for rule '{row}'. "
+                f"Param '%{param}' cannot be used together with params ({', '.join(conflicting_params)})."
+            )
+
+
+def _validate_context_compatibility(parent_attrs: PatchRuleAttrs, child_attrs: PatchRuleAttrs, row: Row):
+    """Checks compatibility of rule contexts"""
+    if parent_attrs[CONTEXT] != child_attrs[CONTEXT]:
+        raise RulebookSyntaxError(
+            f"Merge error for rule '{row}'. Rule contexts must match in parent and child rulebooks."
+        )
+
+
+def parse_rulebook_to_text(rulebook: PatchRulebook, level=0) -> PatchingText:
+    """Parses the rulebook into a text format"""
+    lines = []
+    for scope in [rulebook[LOCAL], rulebook[GLOBAL]]:
+        for row, data in scope.items():
+            lines.append(f"{'    ' * level}{row}")
+            children = data.get(CHILDREN)
+            if children is not None and not _is_empty_rulebook(children):
+                children_lines = parse_rulebook_to_text(children, level + 1)
+                if children_lines:
+                    lines.append(children_lines)
+    return "\n".join(lines)

--- a/annet/rulebook/patching.py
+++ b/annet/rulebook/patching.py
@@ -434,7 +434,7 @@ def _validate_params_compatibility(params: Params, row: str, vendor) -> None:
         (MULTILINE, (used_default_diff_logic_path,), (DIFF_LOGIC,)),
     ]
     for param, checks, conflicting_params in conflicts:
-        if params[ORDERED] and not all(checks):
+        if params[param] and not all(checks):
             raise RulebookSyntaxError(
                 f"Compilation error for rule '{row}'. "
                 f"Param '%{param}' cannot be used together with params ({', '.join(conflicting_params)})."
@@ -450,7 +450,7 @@ def _validate_merged_params_compatibility(params: RawParams, row: str) -> None:
     ]
     for param, conflicting_params in conflicts:
         if param not in params:
-            return None
+            continue
         elif any(conflict_param in params for conflict_param in conflicting_params):
             raise RulebookSyntaxError(
                 f"Merge error for rule '{row}'. "

--- a/annet/rulebook/types.py
+++ b/annet/rulebook/types.py
@@ -1,0 +1,115 @@
+from typing import Any, Callable, Literal, OrderedDict, Pattern, TypeAlias, TypedDict, Union
+
+
+# ===RULEBOOK===
+
+
+class Rulebook(TypedDict):
+    patching: "PatchRulebook"
+    ordering: "CompiledTree"
+    deploying: OrderedDict[str, Any]
+    texts: "RulebookTexts"
+
+
+class RulebookTexts(TypedDict):
+    patching: "PatchingText"
+    ordering: str
+    deploying: str
+
+
+Extension: TypeAlias = Literal["rul", "order", "deploy"]
+
+
+# ===PATCH_RULEBOOK===
+
+
+PatchRulebook = TypedDict(
+    "PatchRulebook",
+    {
+        "local": OrderedDict["RawRow", "PatchRule"],
+        "global": OrderedDict["RawRow", "PatchRule"],
+    },
+)
+
+
+class PatchRule(TypedDict):
+    type: "Type"
+    children: Union["PatchRulebook", None]
+    attrs: "PatchRuleAttrs"
+
+
+class PatchIgnoreRuleAttrs(TypedDict):
+    regexp: Pattern
+    diff_logic: Callable
+    parent: bool
+    context: dict[str, str]
+
+
+class PatchNormalRuleAttrs(TypedDict):
+    logic: Callable
+    diff_logic: Callable
+    regexp: Pattern
+    reverse: str
+    comment: list[str]
+    multiline: bool
+    parent: bool
+    force_commit: bool
+    ignore_case: bool
+    ordered: bool
+    context: dict[str, str]
+
+
+PatchRuleAttrs: TypeAlias = PatchNormalRuleAttrs | PatchIgnoreRuleAttrs
+
+
+PatchingText: TypeAlias = str
+
+
+# Rule row without params
+Row: TypeAlias = str
+# Rule row with params
+RawRow: TypeAlias = str
+Scope: TypeAlias = Literal["local", "global"]
+Type: TypeAlias = Literal["normal", "ignore"]
+# Rule params validated and converted to required types
+Params: TypeAlias = dict[str, Any]
+# Rule params not validated and not converted to required types
+RawParams: TypeAlias = dict[str, str]
+
+ParamsScheme: TypeAlias = dict[str, dict[str, Any]]
+
+
+PatchPreMerge: TypeAlias = dict[Row, "PatchPreMergeData"]
+
+
+class PatchPreMergeData(TypedDict):
+    rules: PatchRule
+    params: RawParams
+    scope: Scope
+
+
+# ===ORDER_RULEBOOK===
+
+
+CompiledTree: TypeAlias = list[tuple[str, "_CompiledOrderingItem"]]
+
+
+class _CompiledOrderingItem(TypedDict):
+    attrs: "_CompiledOrderingAttrs"
+    children: "CompiledTree"
+
+
+# 'global' is a keyword, so we cant use normal TypedDict declaration
+_CompiledOrderingAttrs = TypedDict(
+    "_CompiledOrderingAttrs",
+    {
+        "direct_regexp": Pattern[str],
+        "reverse_regexp": Pattern[str],
+        "order_reverse": bool,
+        "global": bool,  # TODO: rename to something else so that it is not a keyword
+        "scope": list[str] | None,
+        "raw_rule": str,
+        "context": Any,
+        "split": bool,
+    },
+)

--- a/tests/annet/conftest.py
+++ b/tests/annet/conftest.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 
 from annet.hardware import AnnetHardwareProvider, hardware_connector

--- a/tests/annet/test_inherit/__init__.py
+++ b/tests/annet/test_inherit/__init__.py
@@ -1,0 +1,56 @@
+from annet.annlib.rbparser.syntax import get_row_and_raw_params
+from annet.lib import uniq
+from tests.annet.patch_data import get_samples
+
+
+class TestRulebookNotFoundError(Exception):
+    pass
+
+
+def check_rulebook_equal(getting_rb, expected_rb):
+    getting_data = get_rulebook_data(getting_rb)
+    expected_data = get_rulebook_data(expected_rb)
+    for row in uniq(getting_data.keys(), expected_data.keys()):
+        assert row in getting_data and row in expected_data, f"Rule '{row}': rule missing in one of the rulebooks."
+        assert getting_data[row]["scope"] == expected_data[row]["scope"], f"Rule '{row}': scopes do not match."
+        assert getting_data[row]["params"] == expected_data[row]["params"], f"Rule '{row}': params do not match."
+        assert getting_data[row]["rules"]["type"] == expected_data[row]["rules"]["type"], (
+            f"Rule '{row}': type do not match."
+        )
+        assert getting_data[row]["rules"]["attrs"] == expected_data[row]["rules"]["attrs"], (
+            f"Rule '{row}': attrs do not match."
+        )
+        inherited_children = expected_data[row]["rules"]["children"]
+        expected_children = expected_data[row]["rules"]["children"]
+        assert type(inherited_children) == type(expected_children), f"Rule '{row}': children types do not match."
+        if inherited_children is None:
+            continue
+        check_rulebook_equal(inherited_children, expected_children)
+
+
+def get_rulebook_data(rulebook):
+    data = {}
+    for scope in ["local", "global"]:
+        for raw_row, rules in rulebook[scope].items():
+            row, params = get_row_and_raw_params(raw_row)
+            data[row] = {
+                "params": params,
+                "rules": rules,
+                "scope": scope,
+            }
+    return data
+
+
+def get_tests_data(test_dir):
+    for file, data in get_samples(test_dir):
+        for test_case, rulebooks in data.items():
+            yield file, test_case, rulebooks
+
+
+def mock_get_raw_rulebook_text(rulebooks):
+    def get_rulebook(rulebook_path: str, extension: str):
+        if rulebook_path not in rulebooks:
+            raise TestRulebookNotFoundError(f"Mock file not found: {rulebook_path}")
+        return rulebooks[rulebook_path]
+
+    return get_rulebook

--- a/tests/annet/test_inherit/conftest.py
+++ b/tests/annet/test_inherit/conftest.py
@@ -1,0 +1,18 @@
+from unittest import mock
+
+import pytest
+
+from tests.annet.test_inherit import TestRulebookNotFoundError, mock_get_raw_rulebook_text
+
+
+@pytest.fixture
+def mock_rulebooks(request):
+    """Fixture for mock rulebooks"""
+    file, test_case, rulebooks = request.param
+    mock_obj = mock_get_raw_rulebook_text(rulebooks)
+
+    with mock.patch("annet.rulebook.DefaultRulebookProvider._get_raw_rulebook_text", side_effect=mock_obj):
+        try:
+            yield {"file": file, "test_case": test_case}
+        except TestRulebookNotFoundError as err:
+            raise TestRulebookNotFoundError(f"Rulebook not found in file '{file}', test case '{test_case}'.") from err

--- a/tests/annet/test_inherit/fake_logic.py
+++ b/tests/annet/test_inherit/fake_logic.py
@@ -1,0 +1,14 @@
+def fake_logic1():
+    pass
+
+
+def fake_logic2():
+    pass
+
+
+def fake_diff_logic1():
+    pass
+
+
+def fake_diff_logic2():
+    pass

--- a/tests/annet/test_inherit/test_patching/test_merge.py
+++ b/tests/annet/test_inherit/test_patching/test_merge.py
@@ -1,0 +1,22 @@
+import pytest
+
+from annet.rulebook import DefaultRulebookProvider
+from tests import make_hw_stub
+from tests.annet.test_inherit import check_rulebook_equal, get_tests_data
+
+
+@pytest.mark.parametrize(
+    "mock_rulebooks",
+    get_tests_data("annet/test_inherit/test_patching/test_merge"),
+    ids=lambda val: f"file={val[0]}, case={val[1]}",
+    indirect=True,
+)
+def test_merge(mock_rulebooks):
+    rb_provider = DefaultRulebookProvider()
+    hw = make_hw_stub("juniper")
+    vendor = hw.vendor
+    inherited_rb = rb_provider._get_rulebook_by_extension(rulebook_path="child", extension="rul", hw=hw, vendor=vendor)
+    expected_rb = inherited_rb = rb_provider._get_rulebook_by_extension(
+        rulebook_path="expected", extension="rul", hw=hw, vendor=vendor
+    )
+    check_rulebook_equal(inherited_rb, expected_rb)

--- a/tests/annet/test_inherit/test_patching/test_merge/test_common.yaml
+++ b/tests/annet/test_inherit/test_patching/test_merge/test_common.yaml
@@ -1,0 +1,65 @@
+test_case_1:
+  child: | 
+    %inherit_from=parent
+    
+    rule 1
+      sub rule 2
+      sub rule 3
+          some rule
+  parent: |
+    rule 1
+      sub rule 1
+  expected: |
+    rule 1
+      sub rule 1
+      sub rule 2
+      sub rule 3
+          some rule
+
+test_case_2:
+  child: | 
+    %inherit_from=parent
+    
+    rule 1
+      sub rule 1
+      sub rule 2
+  parent: |
+  expected: |
+    rule 1
+      sub rule 1
+      sub rule 2
+
+test_case_3:
+  child: | 
+    %inherit_from=parent
+    
+    rule 1
+      sub rule 1
+          some 2
+      sub rule 2
+  parent: |
+    rule 1
+      sub rule 1
+          some 1
+  expected: |
+    rule 1
+      sub rule 1
+          some 1
+          some 2
+      sub rule 2
+
+test_case_4:
+  child: | 
+    %inherit_from=parent
+  parent: |
+    rule 1
+      sub rule 1
+  expected: |
+    rule 1
+      sub rule 1
+
+test_case_5:
+  child: | 
+    %inherit_from=parent
+  parent: |
+  expected: |

--- a/tests/annet/test_inherit/test_patching/test_merge/test_context.yaml
+++ b/tests/annet/test_inherit/test_patching/test_merge/test_context.yaml
@@ -1,0 +1,52 @@
+test_case_1:
+  child: |
+    %inherit_from=parent
+
+    %context=block:some
+    rule 1
+        sub rule 2
+
+    rule 2
+        sub rule 2
+  parent: |
+    %context=block:some
+    rule 1
+        sub rule 1
+
+    rule 2
+        sub rule 1
+  expected: |
+    %context=block:some
+    rule 1
+        sub rule 1
+        sub rule 2
+
+    rule 2
+        sub rule 1
+        sub rule 2
+test_case_2:
+  child: |
+    %inherit_from=parent
+
+    rule 1
+        sub rule 2
+    
+    %context=block:some
+    rule 2
+        sub rule 2
+  parent: |
+    rule 1
+        sub rule 1
+    
+    %context=block:some
+    rule 2
+        sub rule 1
+  expected: |
+    rule 1
+        sub rule 1
+        sub rule 2
+    
+    %context=block:some
+    rule 2
+        sub rule 1
+        sub rule 2

--- a/tests/annet/test_inherit/test_patching/test_merge/test_cut_default_params.yaml
+++ b/tests/annet/test_inherit/test_patching/test_merge/test_cut_default_params.yaml
@@ -1,0 +1,35 @@
+test_case_1:
+  child: |
+    %inherit_from=parent
+    rule 1 %global=0
+  parent: |
+    rule 1 %global
+  expected: |
+    rule 1
+
+test_case_2:
+  child: |
+    %inherit_from=parent
+    rule 1 %logic=annet.rulebook.common.default
+  parent: |
+    rule 1
+  expected: |
+    rule 1
+
+test_case_3:
+  child: |
+    %inherit_from=parent
+    rule 1 %multiline=0
+  parent: |
+    rule 1 %ordered=0
+  expected: |
+    rule 1
+
+test_case_4:
+  child: |
+    %inherit_from=parent
+    rule 1 %rewrite=0
+  parent: |
+    rule 1 %ordered=0
+  expected: |
+    rule 1

--- a/tests/annet/test_inherit/test_patching/test_merge/test_global.yaml
+++ b/tests/annet/test_inherit/test_patching/test_merge/test_global.yaml
@@ -1,0 +1,42 @@
+test_case_1:
+  child: |
+    %inherit_from=parent
+
+    rule 1 %global=0
+        sub rule 1
+  parent: |
+    rule 1 %global
+  expected: |
+    rule 1
+        sub rule 1
+test_case_2:
+  child: |
+    %inherit_from=parent
+
+    rule 1 %global
+  parent: |
+    rule 1 %diff_logic=tests.annet.test_inherit.fake_logic.fake_diff_logic2
+        sub rule 1
+  expected: |
+    rule 1 %diff_logic=tests.annet.test_inherit.fake_logic.fake_diff_logic2 %global
+
+test_case_3:
+  child: |
+    %inherit_from=parent
+
+    rule 1
+        sub rule 1
+  parent: |
+    rule 1 %global
+  expected: |
+    rule 1 %global
+test_case_4:
+  child: |
+    %inherit_from=parent
+
+    rule 1 %global
+  parent: |
+    rule 1
+        sub rule 1
+  expected: |
+    rule 1 %global

--- a/tests/annet/test_inherit/test_patching/test_merge/test_ignore_type.yaml
+++ b/tests/annet/test_inherit/test_patching/test_merge/test_ignore_type.yaml
@@ -1,0 +1,32 @@
+test_case_1:
+  child: |
+    %inherit_from=parent
+    !rule 1
+        sub rule 1
+  parent: |
+    rule 2
+        sub rule 1
+  expected: |
+    !rule 1
+        sub rule 1
+    rule 2
+        sub rule 1
+# Actually, '!rule 1' will have no children in the final rulebook because it's an 'ignore' type rule
+# If you specify in 'expected':
+#     !rule 1
+#         anything
+# The test will still pass
+# The result will be:
+#     !rule 1             {"attrs": {"parent": true, ...}, ...} 
+test_case_2:
+  child: |
+    %inherit_from=parent
+    !rule 1
+        sub rule 1
+  parent: |
+    !rule 1
+        sub rule 2
+  expected: |
+    !rule 1
+        sub rule 1
+        sub rule 2

--- a/tests/annet/test_inherit/test_patching/test_merge/test_not_inherit.yaml
+++ b/tests/annet/test_inherit/test_patching/test_merge/test_not_inherit.yaml
@@ -1,0 +1,74 @@
+test_case_1:
+  child: | 
+    %inherit_from=parent
+    
+    rule 1 %not_inherit
+    rule 2
+        sub rule 2
+  parent: |
+    rule 1
+        sub rule 1
+    rule 2
+        sub rule 1
+  expected: |
+    rule 2
+        sub rule 1
+        sub rule 2
+
+test_case_2:
+  child: |
+    %inherit_from=parent
+
+    rule 1 %not_inherit
+        child rule 1
+  parent: |
+    rule 1
+        parent rule 1
+  expected: |
+    rule 1
+        child rule 1
+
+test_case_3:
+  child: |
+    %inherit_from=parent
+
+    rule 1
+        sub rule 1 %not_inherit
+  parent: |
+    rule 1
+        sub rule 1
+        sub rule 2
+  expected: |
+    rule 1
+        sub rule 2
+
+test_case_4:
+  child: |
+    %inherit_from=parent
+
+    rule 2 %not_inherit
+    
+    rule 3
+  parent: |
+    rule 1
+  expected: |
+    rule 1
+
+    rule 3
+  
+test_case_5:
+  child: |
+    %inherit_from=parent
+
+    rule 2 %not_inherit
+        child rule 1
+    rule 3
+  parent: |
+    rule 1
+  expected: |
+    rule 1
+
+    rule 2
+        child rule 1
+
+    rule 3

--- a/tests/annet/test_inherit/test_patching/test_merge/test_override_params.yaml
+++ b/tests/annet/test_inherit/test_patching/test_merge/test_override_params.yaml
@@ -1,0 +1,40 @@
+test_case_1:
+  child: |
+    %inherit_from=parent
+
+    rule 1 %logic=tests.annet.test_inherit.fake_logic.fake_logic1
+  parent: |
+    rule 1 %logic=tests.annet.test_inherit.fake_logic.fake_logic2
+  expected: |
+    rule 1 %logic=tests.annet.test_inherit.fake_logic.fake_logic1
+
+test_case_2:
+  child: |
+    %inherit_from=parent
+
+    rule 1 %diff_logic=tests.annet.test_inherit.fake_logic.fake_diff_logic2
+  parent: |
+    rule 1 %logic=tests.annet.test_inherit.fake_logic.fake_logic1
+  expected: |
+    rule 1 %diff_logic=tests.annet.test_inherit.fake_logic.fake_diff_logic2 %logic=tests.annet.test_inherit.fake_logic.fake_logic1
+
+test_case_3:
+  child: |
+    %inherit_from=parent
+
+    rule 1 %cant_delete=0
+  parent: |
+    rule 1 %ordered %cant_delete=1
+
+  expected: |
+    rule 1 %ordered
+
+test_case_4:
+  child: |
+    %inherit_from=parent
+
+    rule 1
+  parent: |
+    rule 1 %logic=tests.annet.test_inherit.fake_logic.fake_logic2
+  expected: |
+    rule 1 %logic=tests.annet.test_inherit.fake_logic.fake_logic2

--- a/tests/annet/test_inherit/test_patching/test_parse_text/test_text.rul
+++ b/tests/annet/test_inherit/test_patching/test_parse_text/test_text.rul
@@ -1,0 +1,432 @@
+clock daylight-saving-time
+clock timezone
+
+header login
+header shell
+sysname
+
+info-center filter-id bymodule-alias * *
+info-center loghost source
+info-center loghost ipv6 * vpn-instance *
+info-center loghost ipv6 *
+info-center loghost * vpn-instance *
+info-center loghost *
+info-center source * channel *
+info-center * channel
+info-center max-logfile-number
+info-center * size
+info-center timestamp log
+
+rsa local-key-pair create
+
+ecc local-key-pair create
+
+port split mode mode3 slot 1
+
+assign forward ipv6 longer-mask resource *
+
+port mode 200GE interface *
+
+undo dhcp enable
+
+dhcp enable
+dhcp snooping enable
+dhcp snooping user-bind http
+
+ntp server disable
+ntp ipv6 server disable
+ntp unicast-server domain *
+ntp unicast-server ipv6 *
+ntp unicast-server *
+ntp-service unicast-server ipv6 *
+ntp-service unicast-server *
+ntp ~
+dns snooping ttl delay-time
+dns ~
+
+bfd *
+    ~
+
+bfd
+    ~
+
+observe-port *
+
+drop-profile *
+    color *
+    ecn weight
+    ecn
+
+qos local-precedence-queue-map *
+
+qos group %logic=annet.rulebook.huawei.misc.undo_children
+    ~
+
+diffserv domain *
+    8021p-inbound *
+    ip-dscp-inbound *
+    ip-dscp-outbound * *
+    mpls-exp-inbound *
+    mpls-exp-outbound *
+
+system tcam acl template * all
+system tcam acl template *
+    ~ %global
+system tcam acl
+
+vlan reserved ~
+
+vlan batch  %diff_logic=annet.rulebook.huawei.vlandb.vlan_diff %logic=annet.rulebook.huawei.vlandb.multi
+
+vlan */\d+/ %diff_logic=annet.rulebook.huawei.vlandb.vlan_diff
+    name
+
+vlan pool *
+    vlan * %logic=annet.rulebook.huawei.vlandb.multi
+
+stp mode
+stp bpdu-protection
+stp enable
+stp region-configuration
+    region-name
+    instance * %logic=annet.rulebook.huawei.vlandb.single
+
+acl port-pool *
+    ~ %global
+acl ip-pool *
+    ~ %global
+acl ipv6-pool *
+    ~ %global
+
+acl */(name|number)/ *
+    rule * description
+    rule * %logic=annet.rulebook.huawei.misc.undo_redo
+acl ipv6 */(name|number)/ *
+    rule * description
+    rule * %logic=annet.rulebook.huawei.misc.undo_redo
+
+*/(ftp|FTP|ssh|telnet)/ server acl
+*/(ftp|FTP|ssh|telnet)/ ipv6 server acl
+*/(ftp|FTP)/ acl
+*/(ftp|FTP)/ ipv6 acl
+*/(ftp|FTP)/ server enable
+*/(ftp|FTP)/ server source all-interface
+*/(ftp|FTP)/ server-source
+*/(ftp|FTP)/ server
+*/(ftp|FTP)/ ipv6 server enable
+*/(ftp|FTP)/ ipv6 server source all-interface
+*/(ftp|FTP)/ ipv6 server-source
+*/(ftp|FTP)/ ipv6 server
+ssh client key-exchange
+ssh client hmac
+ssh client cipher
+ssh server key-exchange
+ssh server dh-exchange
+ssh server cipher
+ssh server hmac
+ssh server publickey
+
+ftp client source %logic=annet.rulebook.huawei.misc.undo_redo
+
+ip vpn-instance *
+    ipv6-family
+        route-distinguisher *
+        export route-policy
+
+ip */(ip|ipv6)/-prefix * %logic=annet.rulebook.huawei.misc.prefix_list
+ip as-path-filter * index *
+ip community-filter * * index *
+ip extcommunity-filter * * index *
+
+mpls lsr-id
+mpls ldp remote-peer *
+
+explicit-path *
+    next hop * %ordered
+
+traffic classifier *        %logic=annet.rulebook.huawei.misc.classifier
+    if-match mpls-exp
+    if-match dscp
+    if-match ipv6 acl name *
+    if-match acl name *
+
+traffic behavior *
+    remark 8021p
+    remark dscp
+    car *
+
+traffic policy *
+
+*/[rd]sa/ peer-public-key * %multiline
+
+aaa
+    undo local-user policy security-enhance
+    undo user-password complexity-check
+    task-group *
+        task *
+    local-user * ftp-directory
+    local-user * privilege level                   %diff_logic=annet.rulebook.huawei.aaa.local_user_diff %logic=annet.rulebook.huawei.aaa.user
+    local-user * level                             %diff_logic=annet.rulebook.huawei.aaa.local_user_diff
+    local-user *                                   %diff_logic=annet.rulebook.huawei.aaa.local_user_diff %logic=annet.rulebook.huawei.aaa.user
+    */(accounting|authentication|authorization)/-scheme *
+        */(accounting|authentication|authorization)/-mode
+
+    domain default
+        */(accounting|authentication|authorization)/-scheme * %logic=annet.rulebook.huawei.aaa.domain
+        !radius-server default
+        radius-server * %logic=annet.rulebook.generic.misc.remove_last_param
+        hwtacacs-server * %logic=annet.rulebook.generic.misc.remove_last_param
+
+    domain *
+        */(accounting|authentication|authorization)/-scheme * %logic=annet.rulebook.huawei.aaa.domain
+        radius-server * %logic=annet.rulebook.generic.misc.remove_last_param
+        hwtacacs-server * %logic=annet.rulebook.generic.misc.remove_last_param
+    ~ %global
+
+hwtacacs-server template *
+    hwtacacs-server shared-key
+    hwtacacs-server source-ip
+
+hwtacacs server template *
+    hwtacacs server shared-key
+    hwtacacs server source-ip
+
+!radius-server template default
+
+radius-server template *
+    radius-server accounting * *
+    radius-server authentication * *
+
+ssh authentication-type default password
+
+ssh server rsa-key min-length
+undo ssh server rsa-key min-length
+ssh user * authentication-type
+ssh user * service-type
+ssh user * assign *
+ssh user *
+
+snmp-agent protocol source-status all-interface
+snmp-agent protocol ipv6 *
+
+ipv6 icmp * send disable %logic=annet.rulebook.huawei.misc.clear_instead_undo
+
+stelnet ~ %logic=annet.rulebook.huawei.misc.stelnet
+
+user-interface maximum-vty
+
+user-interface ~
+    protocol inbound
+    idle-timeout
+    acl ~           %logic=annet.rulebook.huawei.misc.vty_acl_undo
+    screen-length
+    user privilege level
+    authentication-mode
+
+tunnel-policy *
+    tunnel select-seq
+
+sflow collector *
+
+*/(ip|ipv6)/ netstream timeout active
+*/(ip|ipv6)/ netstream timeout inactive
+*/(ip|ipv6)/ netstream export index-switch
+*/(ip|ipv6)/ netstream mpls-aware
+*/(ip|ipv6)/ netstream sampler ~		%logic=annet.rulebook.huawei.misc.netstream_undo
+*/(ip|ipv6)/ netstream export source ipv6
+*/(ip|ipv6)/ netstream export source
+*/(ip|ipv6)/ netstream export version
+*/(ip|ipv6)/ netstream export template timeout-rate
+*/(ip|ipv6)/ netstream export template option timeout-rate
+
+!interface */(Vlanif1$|NULL)/
+interface */Tunnel.+/
+    mpls te igp metric
+    ip address unnumbered
+    tunnel-protocol
+    destination
+    mpls te signalled tunnel-name
+    mpls te reserved-for-binding
+    mpls te path metric-type
+    mpls te path
+    mpls te tunnel-id
+
+interface *                             %logic=annet.rulebook.huawei.iface.permanent
+    mtu                                 %logic=annet.rulebook.huawei.misc.undo_redo
+    undo portswitch
+    ip binding ~                        %diff_logic=annet.rulebook.huawei.iface.binding_change
+    ip ~                                %diff_logic=annet.rulebook.huawei.iface.binding_change
+    jumboframe enable
+    stp bpdu-filter
+    port-isolate enable ~
+    port default vlan
+    ipv6 enable                         %diff_logic=annet.rulebook.huawei.iface.binding_change
+    ipv6 mtu                            %logic=annet.rulebook.huawei.misc.undo_redo %diff_logic=annet.rulebook.huawei.iface.binding_change
+    ipv6 nd ra prefix *                 %diff_logic=annet.rulebook.huawei.iface.binding_change
+    ipv6 nd ra min-interval             %ignore_case %diff_logic=annet.rulebook.huawei.iface.binding_change
+    ipv6 nd ra max-interval             %ignore_case %diff_logic=annet.rulebook.huawei.iface.binding_change
+    ipv6 nd ra router-lifetime          %ignore_case %diff_logic=annet.rulebook.huawei.iface.binding_change
+    ipv6 neighbor *                     %diff_logic=annet.rulebook.huawei.iface.binding_change
+    ipv6 ~                              %diff_logic=annet.rulebook.huawei.iface.binding_change
+    dhcpv6 ~
+    port link-type
+    port trunk pvid vlan
+    port trunk allow-pass vlan %logic=annet.rulebook.huawei.vlandb.multi_all
+    undo port trunk allow-pass ~
+    port hybrid pvid vlan
+    port hybrid tagged vlan %logic=annet.rulebook.huawei.vlandb.multi_all
+    port hybrid untagged vlan %logic=annet.rulebook.huawei.vlandb.multi_all
+    undo port hybrid vlan ~
+    port mode *
+    eth-trunk                  %logic=annet.rulebook.huawei.misc.undo_redo
+    mode
+    lldp admin-status
+    qos queue * drr weight
+    qos queue * drr wred
+    qos queue * wfq weight
+    qos queue * wred
+    qos queue * shaping
+    qos schedule-profile
+    port-queue ~                %logic=annet.rulebook.huawei.misc.port_queue
+    sflow sampling ~
+    damping time
+    isis enable
+    isis circuit-level
+    isis circuit-type
+    isis timer lsp-throttle
+    isis cost
+    ospf cost
+    ospf network-type
+    authentication-profile
+    set flow-stat interval
+    least active-linknumber
+    lacp timeout
+    storm-control enable ~
+    storm control enable ~
+    storm-control *
+    storm control *
+    mpls ldp transport-address
+    trust upstream
+
+bridge-domain *
+        vxlan vni *
+
+route-policy * (?:permit|deny) node * %logic=annet.rulebook.huawei.misc.rp_node
+    if-match cost
+    if-match protocol
+    apply community
+    apply as-path
+    apply as-path
+    apply cost
+    apply cost-type
+    apply local-preference
+    goto next-node
+
+xpl ~
+    ~              %rewrite %global
+
+bgp path-attribute attr-set *
+bgp path-attribute *
+
+bgp %logic=annet.rulebook.huawei.bgp.undo_commit
+    private-4-byte-as
+    router-id
+
+    group *
+
+    peer * description
+    peer * tcp-mss
+    peer * bfd enable
+    peer * bfd %logic=annet.rulebook.huawei.bgp.bfd
+    peer *  %logic=annet.rulebook.huawei.bgp.peer
+
+    maximum load-balancing */eibgp|ebgp|ibgp|ingress-lsp/
+    maximum load-balancing
+
+    */ipv[46]-family/ ~
+        router-id
+        group *
+        bestroute add-path
+        peer * description
+        peer * tcp-mss
+        peer * bfd enable
+        peer * route-limit
+        peer * advertise add-path
+        peer * bfd %logic=annet.rulebook.huawei.bgp.bfd
+        peer *  %logic=annet.rulebook.huawei.bgp.peer
+
+        maximum load-balancing */eibgp|ebgp|ibgp|ingress-lsp|transit-lsp/
+        maximum load-balancing
+        import-route direct
+        import-route static
+
+
+ip community-filter ~
+ospf *
+    stub-router     %logic=annet.rulebook.huawei.misc.undo_redo
+    area *
+        mpls-te
+
+isis *
+    set-overload *
+
+error-down auto-recovery cause link-flap
+
+configuration file auto-save backup-to-server server
+configuration file auto-save
+
+
+set save-configuration backup-to-server *
+set save-configuration *
+
+ip route-static default-bfd
+ipv6 route-static default-bfd
+
+ip route-static ~    %logic=annet.rulebook.huawei.misc.static
+ipv6 route-static ~  %logic=annet.rulebook.huawei.misc.static
+
+!snmp-agent local-engineid *
+snmp-agent protocol vpn-instance
+snmp-agent protocol get-bulk timeout
+snmp-agent sys-info version %logic=annet.rulebook.huawei.misc.snmpagent_sysinfo_version
+snmp-agent sys-info *
+snmp-agent mib-view ~
+snmp-agent community complexity-check ~
+snmp-agent community * cipher *
+snmp-agent community read ~
+
+snmp-agent target-host host-name *
+snmp-agent target-host trap address udp-domain * params securityname cipher *
+snmp-agent target-host trap address udp-domain * vpn-instance (?:.+) params securityname cipher *
+snmp-agent target-host trap ipv6 address udp-domain * params securityname cipher *
+snmp-agent target-host trap ipv6 address udp-domain * vpn-instance * params securityname cipher *
+
+snmp-agent target-host trap address udp-domain * params securityname *
+snmp-agent trap source
+snmp-agent packet max-size
+snmp-agent protocol source-interface %logic=annet.rulebook.huawei.misc.undo_redo
+snmp-agent ~
+ifindex constant
+
+grpc
+    grpc server %logic=annet.rulebook.huawei.misc.undo_children
+    grpc server ipv6 %logic=annet.rulebook.huawei.misc.undo_children
+
+pce-client
+    connect-server *
+        preference
+    timer state-timeout *
+
+cpu-defend policy *
+cpu-defend-policy * global
+cpu-defend-policy
+slot *
+    cpu-defend-policy
+
+user-interface con 0
+    set authentication password cipher
+
+description %global
+
+undo ~ %global
+~ %global

--- a/tests/annet/test_inherit/test_patching/test_text.py
+++ b/tests/annet/test_inherit/test_patching/test_text.py
@@ -1,0 +1,21 @@
+from annet.rulebook import DefaultRulebookProvider
+from annet.rulebook.patching import compile_patching_text, parse_rulebook_to_text
+from tests import make_hw_stub
+from tests.annet.test_inherit import check_rulebook_equal
+
+
+def test_text():
+    rb_provider = DefaultRulebookProvider()
+
+    hw = make_hw_stub("juniper")
+    vendor = hw.vendor
+
+    expected_rb = rb_provider._get_rulebook_by_extension(
+        rulebook_path="tests.annet.test_inherit.test_patching.test_parse_text.test_text",
+        extension="rul",
+        hw=hw,
+        vendor=vendor,
+    )
+    rulebook_text = parse_rulebook_to_text(expected_rb)
+    compiled_rb = compile_patching_text(rulebook_text, vendor)
+    check_rulebook_equal(expected_rb, compiled_rb)


### PR DESCRIPTION
feat: add patch rulebook inheritance

DefaultRulebookProvider:
- Implemented methods for traversing the rulebook inheritance chain
- Added method to retrieve the next rulebook for merging
- Introduced helper methods for inheritance operations
- Refactored rulebook text retrieval methods (minor redesign)

annet.rulebook.patching:
- Added core functionality for merging patch rulebooks
- Moved commonly used string literals into constants
- Extracted params_scheme into a dedicated function
- Added utility functions for merging individual components of patch rulebooks
- Implemented conflict detection for incompatible parameter combinations
- Added parser for patch rulebook text format
- Added functions for patch rulebook creation, checking for empty, and ensure

annet.annlib.rbparser:
- Added function to extract rule from parameters (without validation/type casting)
- Added reverse function for reassembling rule with parameters

annet.rulebook.types:
- Introduced type definitions for patch rulebooks and merge operations
- Relocated order rulebook type definitions to annet.rulebook.types