### PR TITLE
feat: suport Aruba "aruos" breed glue in netbox adapter's get_breed()

### DIFF
--- a/annet/adapters/netbox/common/manufacturer.py
+++ b/annet/adapters/netbox/common/manufacturer.py
@@ -44,4 +44,6 @@ def get_breed(manufacturer: str, model: str):
         return "moxa"
     elif hw.PC:
         return "pc"
+    elif hw.Aruba:
+        return "aruos"
     return ""


### PR DESCRIPTION
The glue is nessesary mainly for gnetcli and its adapter to work.

https://github.com/annetutil/gnetcli/pull/211

https://github.com/annetutil/gnetcli_adapter/pull/77