### PR TITLE
Refactor: Add rule field to patching structures and fix Juniper comment processor

### DIFF
--- a/annet/annlib/patching.py
+++ b/annet/annlib/patching.py
@@ -563,6 +563,7 @@ def make_pre(diff: Diff, _parent_match=None) -> dict[str, Any]:
             # правило __MULTILINE_BODY__.
             match = {
                 "raw_rule": "__MULTILINE_BODY__",
+                "rule": "__MULTILINE_BODY__",
                 "key": row,
                 "attrs": {
                     "comment": [],
@@ -576,6 +577,7 @@ def make_pre(diff: Diff, _parent_match=None) -> dict[str, Any]:
 
         if raw_rule not in pre:
             pre[raw_rule] = {
+                "rule": match["rule"],
                 "attrs": match["attrs"],
                 "items": odict(),
             }
@@ -627,6 +629,7 @@ class _DiffItem(TypedDict):
 
 
 class _Pre(TypedDict):
+    rule: str
     attrs: _PreAttrs
     items: odict[tuple[str, ...], dict[Op, list[_DiffItem]]]
 
@@ -680,7 +683,7 @@ def _iterate_over_patch(
                         keys=(key,),
                         attrs=attrs.copy(),
                         direct=direct,
-                        rules=(raw_rule,),
+                        rules=(content["rule"],),
                     )
 
                 else:
@@ -700,7 +703,7 @@ def _iterate_over_patch(
                             keys=(key,),
                             attrs=attrs.copy(),
                             direct=direct,
-                            rules=(raw_rule,),
+                            rules=(content["rule"],),
                         )
                     for sub_row in children:
                         # block, has children -> emit only children
@@ -709,7 +712,7 @@ def _iterate_over_patch(
                             keys=(key, *sub_row["keys"]),
                             attrs=sub_row["attrs"],
                             direct=sub_row["direct"],
-                            rules=(raw_rule, *sub_row["rules"]),
+                            rules=(content["rule"], *sub_row["rules"]),
                         )
 
 
@@ -883,10 +886,9 @@ def match_row_to_acl(row, rules, exclusive=False):
 
 
 def _match_row_to_rules(row, rules):
-    matches = _find_rules_matches(row, rules)
-    if matches:
+    if matches := _find_rules_matches(row, rules):
         return _select_match(matches, rules)
-    return (None, None)
+    return None, None
 
 
 def _find_acl_matches(row, rules):
@@ -925,12 +927,14 @@ def _find_acl_matches(row, rules):
 def _find_rules_matches(row, rules):
     matches = []
     for (raw_rule, rule), is_global in _rules_local_global(rules):
-        match = rule["attrs"]["regexp"].match(row)
-        if match:
+        if match := rule["attrs"]["regexp"].match(row):
             if rule["type"] == "ignore":
                 return []
-            matches.append(((rule, (not is_global)), {"raw_rule": raw_rule, "key": match.groups()}))
-            #                       ^^^ is_cr_allowed
+            matches.append(
+                ((rule, (not is_global)), {"raw_rule": raw_rule, "rule": rule["rule"], "key": match.groups()})
+                #       ^^^ is_cr_allowed
+            )
+
     return matches
 
 

--- a/annet/rulebook/juniper/__init__.py
+++ b/annet/rulebook/juniper/__init__.py
@@ -11,12 +11,12 @@ from annet.vendors.tabparser import JuniperFormatter
 def comment_processor(item: common.DiffItem):
     if item.op in (Op.REMOVED, Op.ADDED) and item.row.startswith(JuniperFormatter.Comment.begin):
         comment = JuniperFormatter.Comment.loads(item.row)
+        formatted_comment = f"{JuniperFormatter.Comment.begin} {comment.row} {JuniperFormatter.Comment.end}"
 
         item.diff_pre["attrs"]["context"]["comment"] = True
         item.diff_pre["attrs"]["context"]["row"] = comment.row
-        item.diff_pre["key"] = item.diff_pre["raw_rule"] = (
-            f"{JuniperFormatter.Comment.begin} {comment.row} {JuniperFormatter.Comment.end}"
-        )
+        item.diff_pre["raw_rule"] = item.diff_pre["rule"] = formatted_comment
+        item.diff_pre["key"] = (formatted_comment,)
 
         return common.DiffItem(
             item.op,

--- a/annet/rulebook/patching.py
+++ b/annet/rulebook/patching.py
@@ -59,6 +59,7 @@ NOT_INHERIT: Literal["not_inherit"] = "not_inherit"
 
 # ===RULE===
 RULES: Literal["rules"] = "rules"
+RULE: Literal["rule"] = "rule"
 TYPE: Literal["type"] = "type"
 NORMAL: Literal["normal"] = "normal"
 IGNORE: Literal["ignore"] = "ignore"
@@ -137,6 +138,7 @@ def _compile_patching(tree, reverse_prefix, vendor) -> PatchRulebook:
         if attrs[TYPE] == IGNORE:
             rule = PatchRule(
                 type=attrs[TYPE],
+                rule=attrs[ROW],
                 attrs=PatchIgnoreRuleAttrs(
                     regexp=regexp,
                     diff_logic=import_rulebook_function(attrs[PARAMS][DIFF_LOGIC]),
@@ -158,6 +160,7 @@ def _compile_patching(tree, reverse_prefix, vendor) -> PatchRulebook:
                 attrs[PARAMS][DIFF_LOGIC] = MULTILINE_DIFF_LOGIC
             rule = PatchRule(
                 type=attrs[TYPE],
+                rule=attrs[ROW],
                 attrs=PatchNormalRuleAttrs(
                     **{
                         "logic": import_rulebook_function(attrs[PARAMS][LOGIC]),
@@ -358,6 +361,7 @@ def get_merged_rule(
 ) -> PatchRule:
     """Merges parent_rules and child_rules"""
     merged_type = child_rules[TYPE]
+    merged_rule = child_rules[RULE]
 
     if scope == GLOBAL:
         merged_children = None
@@ -387,6 +391,7 @@ def get_merged_rule(
     return PatchRule(
         **{
             TYPE: merged_type,
+            RULE: merged_rule,
             CHILDREN: merged_children,
             ATTRS: merged_attrs,
         }

--- a/annet/rulebook/types.py
+++ b/annet/rulebook/types.py
@@ -34,6 +34,7 @@ PatchRulebook = TypedDict(
 
 class PatchRule(TypedDict):
     type: "Type"
+    rule: str
     children: Union["PatchRulebook", None]
     attrs: "PatchRuleAttrs"
 

--- a/tests/annet/test_diff.py
+++ b/tests/annet/test_diff.py
@@ -207,7 +207,7 @@ def str2diff(raw_diff: str) -> Diff:
             diff_ops[op],
             line,
             [],
-            {"raw_rule": line, "key": 33, "attrs": {"multiline": False}},
+            {"raw_rule": line, "rule": line, "key": 33, "attrs": {"multiline": False}},
         )
         if level == 0:
             res.append(diffline)

--- a/tests/annet/test_patching.py
+++ b/tests/annet/test_patching.py
@@ -1,3 +1,4 @@
+import re
 from collections import OrderedDict as odict
 from textwrap import dedent
 
@@ -26,8 +27,6 @@ def reversed_tree(config_tree):
 
 @pytest.fixture
 def rb(request):
-    import re
-
     return {
         "patching": {
             "local": odict(),
@@ -46,6 +45,7 @@ def rb(request):
                             },
                             "children": {"global": odict(), "local": odict()},
                             "type": "normal",
+                            "rule": "~",
                         },
                     ),
                 ]
@@ -88,6 +88,7 @@ def _make_match(rb, *key):
     return {
         "attrs": rb["patching"]["global"]["~"]["attrs"],
         "raw_rule": "~",
+        "rule": "~",
         "key": key,
     }
 


### PR DESCRIPTION
This PR introduces the tracking of the original rule string (rule) alongside raw_rule within the patching and rulebook logic, making the original rule text easily accessible for processing. It also includes fixes for the Juniper rulebook.

Key Changes:

Rulebook & Patching Data Structures: Added the rule field to PatchRule and _Pre type hints, and updated _compile_patching to store the original rule row.

Annlib Patching Logic:

Updated make_pre and _find_rules_matches to populate the rule attribute.

Replaced raw_rule with content["rule"] during patch iteration (_iterate_over_patch), ensuring the original rule correctly propagates to child sub-rows.

Applied the walrus operator (:=) in _match_row_to_rules and _find_rules_matches for conciseness.

Juniper Comments Fix: Updated the comment_processor in annet.rulebook.juniper to ensure diff_pre["key"] is stored correctly as a tuple (preventing unintended string-iteration behavior) and initialized both raw_rule and rule.

Tests: Updated test_diff.py and test_patching.py payloads to include the new rule field.