### PR TITLE
feat: %cant_delete modifier for JSONFragment generator ACLs

### DIFF
--- a/annet/annlib/jsontools.py
+++ b/annet/annlib/jsontools.py
@@ -72,9 +72,7 @@ def apply_json_fragment(
                 except jsonpointer.JsonPointerException:
                     existing = None
                 if isinstance(existing, dict):
-                    merged = dict(existing)
-                    merged.update(new_value)
-                    new_value = merged
+                    new_value = existing | new_value
             _pointer_set(pointer, full_new_config, new_value)
 
         if acl_item.cant_delete:

--- a/annet/annlib/jsontools.py
+++ b/annet/annlib/jsontools.py
@@ -1,6 +1,7 @@
 """Support JSON patch (RFC 6902) and JSON Pointer (RFC 6901) with globs."""
 
 import copy
+import dataclasses
 import fnmatch
 import json
 from collections.abc import Mapping, Sequence
@@ -13,7 +14,21 @@ import jsonpointer
 from ordered_set import OrderedSet
 
 
-EVERYTHING_ACL: Final = "/*"
+@dataclasses.dataclass(frozen=True)
+class JsonFragmentAcl:
+    """ACL entry for a JSONFragment generator.
+
+    `pointer` is a JSON Pointer glob (see `resolve_json_pointers`).
+    `cant_delete=True` means: keys under this scope that are missing from the
+    new fragment must be preserved in the merged config (analogous to the
+    `%cant_delete` modifier on partial-generator ACLs).
+    """
+
+    pointer: str
+    cant_delete: bool = False
+
+
+EVERYTHING_ACL: Final = JsonFragmentAcl("/*")
 
 
 def format_json(data: Any, stable: bool = False) -> str:
@@ -25,7 +40,7 @@ def apply_json_fragment(
     old: Dict[str, Any],
     new_fragment: Dict[str, Any],
     *,
-    acl: Sequence[str] | None = None,
+    acl: Sequence[JsonFragmentAcl] | None = None,
     filters: Sequence[str] | None = None,
 ) -> Dict[str, Any]:
     """
@@ -38,15 +53,32 @@ def apply_json_fragment(
         acl = [EVERYTHING_ACL]
     full_new_config = copy.deepcopy(old)
     for acl_item in acl:
-        new_pointers = _resolve_json_pointers(acl_item, new_fragment)
-        old_pointers = _resolve_json_pointers(acl_item, full_new_config)
+        new_pointers = resolve_json_pointers(acl_item.pointer, new_fragment)
+        old_pointers = resolve_json_pointers(acl_item.pointer, full_new_config)
         if filters is not None:
             new_pointers = _apply_filters_to_json_pointers(new_pointers, filters, content=new_fragment)
             old_pointers = _apply_filters_to_json_pointers(old_pointers, filters, content=full_new_config)
 
         for pointer in new_pointers:
             new_value = pointer.get(new_fragment)
+            if acl_item.cant_delete and isinstance(new_value, dict):
+                # Under a cant_delete acl multiple generators can share the
+                # same pointer-target (e.g. different sub-fields of a VLAN).
+                # Shallow-update sub-keys so each generator's contribution
+                # is preserved; sub-keys that the generator owns are still
+                # fully replaced (no list merging etc).
+                try:
+                    existing = pointer.get(full_new_config)
+                except jsonpointer.JsonPointerException:
+                    existing = None
+                if isinstance(existing, dict):
+                    merged = dict(existing)
+                    merged.update(new_value)
+                    new_value = merged
             _pointer_set(pointer, full_new_config, new_value)
+
+        if acl_item.cant_delete:
+            continue
 
         # delete matched parts in old config whicn are not present in the new
         paths = {p.path for p in new_pointers}
@@ -133,7 +165,7 @@ def apply_patch(content: Optional[bytes], patch_bytes: bytes) -> bytes:
     return new_contents
 
 
-def _resolve_json_pointers(pattern: str, content: dict[str, Any]) -> list[jsonpointer.JsonPointer]:
+def resolve_json_pointers(pattern: str, content: dict[str, Any]) -> list[jsonpointer.JsonPointer]:
     """
     Resolve globbed json pointer pattern to a list of actual pointers, existing in the document.
 
@@ -236,7 +268,7 @@ def _apply_filters_to_json_pointers(
                 deeper_pattern = "".join(
                     (f"/{jsonpointer.escape(part)}" for part in filter_parts[len(pointer_parts) :])
                 )
-                ret.update(map(pointer.join, _resolve_json_pointers(deeper_pattern, deeper_doc)))
+                ret.update(map(pointer.join, resolve_json_pointers(deeper_pattern, deeper_doc)))
             else:
                 ret.add(pointer)
     return ret

--- a/annet/annlib/rbparser/syntax.py
+++ b/annet/annlib/rbparser/syntax.py
@@ -96,7 +96,7 @@ def _parse_tree_with_params(raw_tree: tabparser.SimpleTree, scheme, context: dic
     if context is None:
         context = {}
     for raw_rule, children in raw_tree:
-        (row, params) = _parse_raw_rule(raw_rule, scheme)
+        (row, params) = parse_raw_rule(raw_rule, scheme)
         row_type = "normal"
 
         if row.startswith("!"):
@@ -123,7 +123,7 @@ def _parse_tree_with_params(raw_tree: tabparser.SimpleTree, scheme, context: dic
     return tree
 
 
-def _parse_raw_rule(raw_rule: str, scheme) -> tuple[str, dict[str, str]]:
+def parse_raw_rule(raw_rule: str, scheme) -> tuple[str, dict[str, str]]:
     params: dict[str, str] = {}
 
     row, *params_raw = re.split(r"(?:^|\s)%(?=[a-zA-Z_]\w*)", raw_rule)

--- a/annet/generators/__init__.py
+++ b/annet/generators/__init__.py
@@ -10,9 +10,12 @@ from collections import OrderedDict as odict
 from typing import FrozenSet, Iterable, List, Optional, Union
 
 from contextlog import get_logger
+from valkit.common import valid_bool
 
 from annet import patching, tracing
+from annet.annlib.jsontools import JsonFragmentAcl
 from annet.annlib.rbparser.acl import compile_acl_text
+from annet.annlib.rbparser.syntax import parse_raw_rule
 from annet.cli_args import GenSelectOptions, ShowGeneratorsOptions
 from annet.lib import get_context
 from annet.storage import Device
@@ -334,6 +337,21 @@ def _make_generator_ctx(gen):
     return "%s.[%s]" % (gen.__module__, gen.__class__.__name__)
 
 
+_JSON_FRAGMENT_ACL_PARAMS_SCHEME = {
+    "cant_delete": {"validator": valid_bool, "default": False},
+}
+
+
+def _normalize_json_fragment_acl(acl: str | list[str]) -> list[JsonFragmentAcl]:
+    if not isinstance(acl, list):
+        acl = [acl]
+    result: list[JsonFragmentAcl] = []
+    for raw in acl:
+        pointer, params = parse_raw_rule(raw, _JSON_FRAGMENT_ACL_PARAMS_SCHEME)
+        result.append(JsonFragmentAcl(pointer=pointer, cant_delete=params["cant_delete"]))
+    return result
+
+
 def _run_json_fragment_generator(
     gen: "JSONFragment",
     device: "Device",
@@ -353,14 +371,8 @@ def _run_json_fragment_generator(
         safe_acl_item_or_list_of_items = gen.acl_safe(device)
         if not acl_item_or_list_of_items:
             raise RuntimeError("json fragment generator should return non-empty acl")
-        if isinstance(acl_item_or_list_of_items, list):
-            acl = acl_item_or_list_of_items
-        else:
-            acl = [acl_item_or_list_of_items]
-        if isinstance(safe_acl_item_or_list_of_items, list):
-            acl_safe = safe_acl_item_or_list_of_items
-        else:
-            acl_safe = [safe_acl_item_or_list_of_items]
+        acl = _normalize_json_fragment_acl(acl_item_or_list_of_items)
+        acl_safe = _normalize_json_fragment_acl(safe_acl_item_or_list_of_items)
 
         logger.info("Generating JSON_FRAGMENT ...")
 

--- a/annet/generators/result.py
+++ b/annet/generators/result.py
@@ -5,6 +5,7 @@ from collections import OrderedDict as odict
 from typing import Any, Callable, Optional, Sequence
 
 from annet.annlib import jsontools
+from annet.annlib.jsontools import JsonFragmentAcl
 from annet.lib import merge_dicts
 from annet.reference import RefMatcher, RefTracker
 from annet.types import (
@@ -81,6 +82,10 @@ class RunGeneratorResult:
         # TODO: safe
         files: dict[str, tuple[Any, Optional[str]]] = {}
         reload_prios: dict[str, int] = {}
+        # Pass 1: per-generator merge. apply_json_fragment skips deletions for
+        # cant_delete acl items — those are resolved in Pass 2 after we've seen
+        # every generator that touches the file.
+        cant_delete_state: dict[str, tuple[Any, list[tuple[JsonFragmentAcl, dict[str, Any]]]]] = {}
         for generator_result in self.json_fragment_results.values():
             filepath = generator_result.path
             if filepath not in files:
@@ -88,10 +93,9 @@ class RunGeneratorResult:
                     files[filepath] = (old_files[filepath], None)
                 else:
                     files[filepath] = ({}, None)
+                cant_delete_state.setdefault(filepath, (files[filepath][0], []))
             if use_acl:
-                result_acl = generator_result.acl
-                if safe:
-                    result_acl = generator_result.acl_safe
+                result_acl = generator_result.acl_safe if safe else generator_result.acl
             else:
                 result_acl = None
             previous_config: dict[str, Any] = files[filepath][0]
@@ -102,6 +106,11 @@ class RunGeneratorResult:
                 acl=result_acl,
                 filters=filters,
             )
+            if result_acl is not None:
+                _, contributions = cant_delete_state[filepath]
+                for acl_item in result_acl:
+                    if acl_item.cant_delete:
+                        contributions.append((acl_item, new_fragment))
             if jsontools.format_json(new_config) == jsontools.format_json(previous_config):
                 # config is not changed, deprioritize reload_cmd
                 reload_prio = 0
@@ -114,6 +123,27 @@ class RunGeneratorResult:
                 reload_cmd = generator_result.reload
                 reload_prios[filepath] = reload_prio
             files[filepath] = (new_config, reload_cmd)
+
+        # Pass 2: under each cant_delete acl, drop pointers that no generator
+        # for this file emitted in its new fragment.
+        for filepath, (old_config, contributions) in cant_delete_state.items():
+            if not contributions or not isinstance(old_config, dict):
+                continue
+            merged_config, reload_cmd = files[filepath]
+            for acl_item, _ in contributions:
+                emitted: set[str] = set()
+                for other_acl, other_fragment in contributions:
+                    if other_acl != acl_item:
+                        continue
+                    for ptr in jsontools.resolve_json_pointers(acl_item.pointer, other_fragment):
+                        emitted.add(ptr.path)
+                for old_ptr in jsontools.resolve_json_pointers(acl_item.pointer, old_config):
+                    if old_ptr.path in emitted:
+                        continue
+                    parent, key = old_ptr.to_last(merged_config)
+                    if isinstance(parent, dict) and isinstance(key, str):
+                        parent.pop(key, None)
+            files[filepath] = (merged_config, reload_cmd)
         return files
 
     def perf_mesures(self) -> dict[str, dict[str, int]]:

--- a/annet/types.py
+++ b/annet/types.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from typing import Any, Dict, List, MutableMapping, NamedTuple, Optional, Tuple, TypeAlias, Union
 
+from annet.annlib.jsontools import JsonFragmentAcl
 from annet.annlib.types import Op  # pylint: disable=unused-import
 from annet.storage import Device, Storage
 
@@ -125,8 +126,8 @@ class GeneratorJSONFragmentResult:
         name: str,
         tags: List[str],
         path: str,
-        acl: List[str],
-        acl_safe: List[str],
+        acl: List[JsonFragmentAcl],
+        acl_safe: List[JsonFragmentAcl],
         config: Dict[str, Any],
         reload: str,
         perf: GeneratorPerf,

--- a/tests/annet/test_jsonfragments.py
+++ b/tests/annet/test_jsonfragments.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 
 import annet.diff
+from annet.annlib.jsontools import JsonFragmentAcl
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.generators.result import RunGeneratorResult
 from annet.types import GeneratorJSONFragmentResult, GeneratorPerf
@@ -236,8 +237,15 @@ def test_new_json_fragment_files():
             name="interfaces",
             tags=["interfaces"],
             path="/etc/sonic/config_db.json",
-            acl=["/INTERFACE", "/BREAKOUT_CFG", "/VLAN_INTERFACE"],
-            acl_safe=["/INTERFACE/*/description", "/VLAN_INTERFACE/*/description"],
+            acl=[
+                JsonFragmentAcl("/INTERFACE"),
+                JsonFragmentAcl("/BREAKOUT_CFG"),
+                JsonFragmentAcl("/VLAN_INTERFACE"),
+            ],
+            acl_safe=[
+                JsonFragmentAcl("/INTERFACE/*/description"),
+                JsonFragmentAcl("/VLAN_INTERFACE/*/description"),
+            ],
             config=config,
             reload="sonic-reload",
             perf=GeneratorPerf(1.0, None, None),
@@ -423,7 +431,7 @@ def test_new_json_fragment_files_append_list():
             name="acl_table",
             tags=["acl_table"],
             path="/etc/sonic/config_db.json",
-            acl=["/ACL_TABLE"],
+            acl=[JsonFragmentAcl("/ACL_TABLE")],
             acl_safe=[],
             config=config,
             reload="sonic-reload",
@@ -481,3 +489,178 @@ def test_new_json_fragment_files_append_list():
             "sonic-reload",
         ),
     }
+
+
+def test_apply_json_fragment_cant_delete_preserves_missing_keys():
+    from annet.annlib.jsontools import apply_json_fragment
+
+    old = {"FEATURE": {"a": {"v": 1}, "b": {"v": 2}}}
+    new_fragment: dict[str, Any] = {"FEATURE": {}}
+
+    deleted = apply_json_fragment(old, new_fragment, acl=[JsonFragmentAcl("/FEATURE/*")])
+    assert deleted == {"FEATURE": {}}
+
+    preserved = apply_json_fragment(old, new_fragment, acl=[JsonFragmentAcl("/FEATURE/*", cant_delete=True)])
+    assert preserved == {"FEATURE": {"a": {"v": 1}, "b": {"v": 2}}}
+
+
+def test_apply_json_fragment_cant_delete_overwrites_present_keys():
+    from annet.annlib.jsontools import apply_json_fragment
+
+    old = {"FEATURE": {"a": {"v": 1}, "b": {"v": 2}}}
+    new_fragment = {"FEATURE": {"a": {"v": 99}}}
+
+    result = apply_json_fragment(old, new_fragment, acl=[JsonFragmentAcl("/FEATURE/*", cant_delete=True)])
+    assert result == {"FEATURE": {"a": {"v": 99}, "b": {"v": 2}}}
+
+
+def test_apply_json_fragment_mixed_cant_delete_acls():
+    from annet.annlib.jsontools import apply_json_fragment
+
+    old = {
+        "PROTECTED": {"keep": 1, "also_keep": 2},
+        "REGULAR": {"a": 1, "b": 2},
+    }
+    new_fragment: dict[str, Any] = {"PROTECTED": {}, "REGULAR": {"a": 1}}
+
+    result = apply_json_fragment(
+        old,
+        new_fragment,
+        acl=[
+            JsonFragmentAcl("/PROTECTED/*", cant_delete=True),
+            JsonFragmentAcl("/REGULAR/*"),
+        ],
+    )
+    assert result == {
+        "PROTECTED": {"keep": 1, "also_keep": 2},
+        "REGULAR": {"a": 1},
+    }
+
+
+def _make_json_fragment_result(
+    name: str,
+    *,
+    path: str,
+    acl: list,
+    config: dict,
+    acl_safe: list | None = None,
+) -> GeneratorJSONFragmentResult:
+    return GeneratorJSONFragmentResult(
+        name=name,
+        tags=[name],
+        path=path,
+        acl=acl,
+        acl_safe=acl_safe if acl_safe is not None else [],
+        config=config,
+        reload="reload",
+        perf=GeneratorPerf(1.0, None, None),
+        reload_prio=100,
+    )
+
+
+def test_cross_generator_cant_delete_drops_keys_no_one_emits():
+    """Two generators share `/VLAN/Vlan*` with cant_delete=True; a vlan that
+    nobody returns must be deleted, while keys at least one generator returned
+    keep their other generators' fields intact.
+    """
+    path = "/etc/sonic/config_db.json"
+    old_files = {
+        path: {
+            "VLAN": {
+                "Vlan333": {"dhcpv6_servers": ["2a02:6b8::1"], "vlanid": "333"},
+                "Vlan605": {"vlanid": "605"},
+            }
+        }
+    }
+
+    res = RunGeneratorResult()
+    res.add_json_fragment(
+        _make_json_fragment_result(
+            "l3_tor",
+            path=path,
+            acl=[JsonFragmentAcl("/VLAN/Vlan*", cant_delete=True)],
+            config={"VLAN": {"Vlan333": {"dhcpv6_servers": ["2a02:6b8::1"]}}},
+        )
+    )
+    res.add_json_fragment(
+        _make_json_fragment_result(
+            "vlans",
+            path=path,
+            acl=[JsonFragmentAcl("/VLAN/Vlan*", cant_delete=True)],
+            config={"VLAN": {"Vlan333": {"vlanid": "333"}}},
+        )
+    )
+
+    files = res.new_json_fragment_files(old_files)
+    merged, _ = files[path]
+    assert merged == {
+        "VLAN": {
+            "Vlan333": {"dhcpv6_servers": ["2a02:6b8::1"], "vlanid": "333"},
+        }
+    }
+
+
+def test_cross_generator_cant_delete_preserves_subtree_when_at_least_one_emits():
+    """If at least one generator emits Vlan605, the other generators' missing
+    sub-fields under that key are preserved (cant_delete protects the rest).
+    """
+    path = "/etc/sonic/config_db.json"
+    old_files = {
+        path: {
+            "VLAN": {
+                "Vlan605": {"dhcpv6_servers": ["2a02:6b8::5"], "vlanid": "605"},
+            }
+        }
+    }
+
+    res = RunGeneratorResult()
+    res.add_json_fragment(
+        _make_json_fragment_result(
+            "l3_tor",
+            path=path,
+            acl=[JsonFragmentAcl("/VLAN/Vlan*", cant_delete=True)],
+            config={"VLAN": {}},  # l3_tor doesn't return Vlan605 anymore
+        )
+    )
+    res.add_json_fragment(
+        _make_json_fragment_result(
+            "vlans",
+            path=path,
+            acl=[JsonFragmentAcl("/VLAN/Vlan*", cant_delete=True)],
+            config={"VLAN": {"Vlan605": {"vlanid": "605"}}},
+        )
+    )
+
+    files = res.new_json_fragment_files(old_files)
+    merged, _ = files[path]
+    # Vlan605 stays; old dhcpv6_servers preserved because vlans emitted Vlan605
+    # so cant_delete keeps the rest of its subtree.
+    assert merged == {
+        "VLAN": {
+            "Vlan605": {"dhcpv6_servers": ["2a02:6b8::5"], "vlanid": "605"},
+        }
+    }
+
+
+def test_normalize_json_fragment_acl_parses_cant_delete_modifier():
+    from annet.generators import _normalize_json_fragment_acl
+
+    # `%cant_delete` → cant_delete=True
+    assert _normalize_json_fragment_acl("/VLAN/Vlan* %cant_delete") == [
+        JsonFragmentAcl("/VLAN/Vlan*", cant_delete=True)
+    ]
+    # `%cant_delete=1` → cant_delete=True
+    assert _normalize_json_fragment_acl("/VLAN/Vlan* %cant_delete=1") == [
+        JsonFragmentAcl("/VLAN/Vlan*", cant_delete=True)
+    ]
+    # `%cant_delete=0` → cant_delete=False
+    assert _normalize_json_fragment_acl("/VLAN/Vlan* %cant_delete=0") == [
+        JsonFragmentAcl("/VLAN/Vlan*", cant_delete=False)
+    ]
+    # No modifier → cant_delete=False
+    assert _normalize_json_fragment_acl("/VLAN/Vlan*") == [JsonFragmentAcl("/VLAN/Vlan*")]
+    # Mixed list
+    assert _normalize_json_fragment_acl(["/A %cant_delete", "/B"]) == [
+        JsonFragmentAcl("/A", cant_delete=True),
+        JsonFragmentAcl("/B"),
+    ]


### PR DESCRIPTION
JSONFragment generators can now mark ACL entries with `%cant_delete`                                                                                                           
  (e.g. `"/VLAN/Vlan* %cant_delete"`). A key under such a scope is removed
  only if no generator for the file emitted it; otherwise missing sub-fields                                                                                                     
  are preserved as ownership of other generators — mirroring how
  `%cant_delete` works for partial-generator ACLs.                                                                                                                               
                                                         
  Unblocks two generators sharing a parent key but writing disjoint                                                                                                              
  sub-fields (e.g. `vlanid` and `dhcpv6_servers` under `/VLAN/Vlan*`).