### PR TITLE
fix: respect other generators' ACLs in cross-generator cant_delete

### DIFF
--- a/annet/annlib/jsontools.py
+++ b/annet/annlib/jsontools.py
@@ -163,6 +163,14 @@ def apply_patch(content: Optional[bytes], patch_bytes: bytes) -> bytes:
     return new_contents
 
 
+def acl_covers_pointer(acl_pattern: str, ptr_parts: tuple[str, ...]) -> bool:
+    """True, if ACL glob covers (is a prefix of, or equal to) the given pointer parts."""
+    pattern_parts = jsonpointer.JsonPointer(acl_pattern).parts
+    if len(pattern_parts) > len(ptr_parts):
+        return False
+    return all(fnmatch.fnmatchcase(p, pat) for p, pat in zip(ptr_parts, pattern_parts))
+
+
 def resolve_json_pointers(pattern: str, content: dict[str, Any]) -> list[jsonpointer.JsonPointer]:
     """
     Resolve globbed json pointer pattern to a list of actual pointers, existing in the document.

--- a/annet/generators/result.py
+++ b/annet/generators/result.py
@@ -85,7 +85,11 @@ class RunGeneratorResult:
         # Pass 1: per-generator merge. apply_json_fragment skips deletions for
         # cant_delete acl items — those are resolved in Pass 2 after we've seen
         # every generator that touches the file.
-        cant_delete_state: dict[str, tuple[Any, list[tuple[JsonFragmentAcl, dict[str, Any]]]]] = {}
+        # Per filepath: (old_config, [(generator_acl, new_fragment), ...]).
+        # We record contributions from ALL generators with an ACL, not just
+        # cant_delete ones, so Pass 2 can tell whether a path under a
+        # cant_delete acl is owned (covered) by another generator's ACL.
+        file_contributions: dict[str, tuple[Any, list[tuple[Sequence[JsonFragmentAcl], dict[str, Any]]]]] = {}
         for generator_result in self.json_fragment_results.values():
             filepath = generator_result.path
             if filepath not in files:
@@ -93,7 +97,7 @@ class RunGeneratorResult:
                     files[filepath] = (old_files[filepath], None)
                 else:
                     files[filepath] = ({}, None)
-                cant_delete_state.setdefault(filepath, (files[filepath][0], []))
+                file_contributions.setdefault(filepath, (files[filepath][0], []))
             if use_acl:
                 result_acl = generator_result.acl_safe if safe else generator_result.acl
             else:
@@ -107,10 +111,8 @@ class RunGeneratorResult:
                 filters=filters,
             )
             if result_acl is not None:
-                _, contributions = cant_delete_state[filepath]
-                for acl_item in result_acl:
-                    if acl_item.cant_delete:
-                        contributions.append((acl_item, new_fragment))
+                _, contributions = file_contributions[filepath]
+                contributions.append((result_acl, new_fragment))
             if jsontools.format_json(new_config) == jsontools.format_json(previous_config):
                 # config is not changed, deprioritize reload_cmd
                 reload_prio = 0
@@ -124,21 +126,33 @@ class RunGeneratorResult:
                 reload_prios[filepath] = reload_prio
             files[filepath] = (new_config, reload_cmd)
 
-        # Pass 2: under each cant_delete acl, drop pointers that no generator
-        # for this file emitted in its new fragment.
-        for filepath, (old_config, contributions) in cant_delete_state.items():
+        # Pass 2: under each cant_delete acl, drop pointers that:
+        #   - no generator for this file emitted in its new fragment under that acl, AND
+        #   - aren't covered by some other (non-cant_delete) ACL of any generator
+        #     for this file (because that ACL already owns deletion in Pass 1).
+        for filepath, (old_config, contributions) in file_contributions.items():
             if not contributions or not isinstance(old_config, dict):
                 continue
+            cant_delete_acls = [
+                acl_item for acl_list, _ in contributions for acl_item in acl_list if acl_item.cant_delete
+            ]
+            if not cant_delete_acls:
+                continue
+            non_cant_delete_patterns = [
+                acl_item.pointer for acl_list, _ in contributions for acl_item in acl_list if not acl_item.cant_delete
+            ]
             merged_config, reload_cmd = files[filepath]
-            for acl_item, _ in contributions:
+            for acl_item in cant_delete_acls:
                 emitted: set[str] = set()
-                for other_acl, other_fragment in contributions:
-                    if other_acl != acl_item:
-                        continue
+                for _, other_fragment in contributions:
                     for ptr in jsontools.resolve_json_pointers(acl_item.pointer, other_fragment):
                         emitted.add(ptr.path)
                 for old_ptr in jsontools.resolve_json_pointers(acl_item.pointer, old_config):
                     if old_ptr.path in emitted:
+                        continue
+                    if any(
+                        jsontools.acl_covers_pointer(pattern, old_ptr.parts) for pattern in non_cant_delete_patterns
+                    ):
                         continue
                     parent, key = old_ptr.to_last(merged_config)
                     if isinstance(parent, dict) and isinstance(key, str):

--- a/tests/annet/test_jsonfragments.py
+++ b/tests/annet/test_jsonfragments.py
@@ -642,6 +642,113 @@ def test_cross_generator_cant_delete_preserves_subtree_when_at_least_one_emits()
     }
 
 
+def test_cross_generator_cant_delete_does_not_delete_paths_owned_by_other_acl():
+    """Regression: a cant_delete ACL on a broad scope must not delete keys
+    that another generator's narrower ACL legitimately owns and emitted."""
+    path = "/etc/sonic/config_db.json"
+    old_files = {
+        path: {
+            "VLAN": {
+                "Vlan333": {"dhcpv6_servers": ["2a02:6b8:0:3400::199"], "vlanid": "333"},
+                "Vlan605": {"vlanid": "605"},
+            }
+        }
+    }
+
+    res = RunGeneratorResult()
+    res.add_json_fragment(
+        _make_json_fragment_result(
+            "vlans",
+            path=path,
+            acl=[JsonFragmentAcl("/VLAN/Vlan*/*", cant_delete=True)],
+            config={"VLAN": {"Vlan333": {"vlanid": "333"}, "Vlan605": {"vlanid": "605"}}},
+        )
+    )
+    res.add_json_fragment(
+        _make_json_fragment_result(
+            "dhcp_relay",
+            path=path,
+            acl=[JsonFragmentAcl("/VLAN/Vlan*/dhcpv6_servers")],
+            config={"VLAN": {"Vlan333": {"dhcpv6_servers": ["2a02:6b8:0:3400::199"]}}},
+        )
+    )
+
+    files = res.new_json_fragment_files(old_files)
+    merged, _ = files[path]
+    assert merged == {
+        "VLAN": {
+            "Vlan333": {"dhcpv6_servers": ["2a02:6b8:0:3400::199"], "vlanid": "333"},
+            "Vlan605": {"vlanid": "605"},
+        }
+    }
+
+
+def test_cross_generator_non_cant_delete_acl_still_owns_deletion():
+    """A cant_delete ACL must NOT shield a path that another generator's
+    non-cant_delete ACL covers when that other generator drops it."""
+    path = "/cfg.json"
+    old_files = {path: {"VLAN": {"Vlan333": {"dhcpv6_servers": ["x"], "vlanid": "333"}}}}
+    res = RunGeneratorResult()
+    res.add_json_fragment(
+        _make_json_fragment_result(
+            "vlans",
+            path=path,
+            acl=[JsonFragmentAcl("/VLAN/Vlan*/*", cant_delete=True)],
+            config={"VLAN": {"Vlan333": {"vlanid": "333"}}},
+        )
+    )
+    res.add_json_fragment(
+        _make_json_fragment_result(
+            "dhcp_relay",
+            path=path,
+            acl=[JsonFragmentAcl("/VLAN/Vlan*/dhcpv6_servers")],
+            config={"VLAN": {}},
+        )
+    )
+    merged, _ = res.new_json_fragment_files(old_files)[path]
+    assert merged == {"VLAN": {"Vlan333": {"vlanid": "333"}}}
+
+
+def test_cross_generator_cant_delete_deletes_vlan_no_one_emits():
+    """Vlan, который не отдал ни один генератор, должен быть удалён целиком,
+    даже если cant_delete-ACL покрывает его, — потому что внутри него ничего
+    не эмиттят и других ACL, владеющих этими путями, нет на верхнем уровне."""
+    path = "/cfg.json"
+    old_files = {
+        path: {
+            "VLAN": {
+                "Vlan333": {"dhcpv6_servers": ["2a02:6b8::1"], "vlanid": "333"},
+                "Vlan605": {"vlanid": "605"},
+                "Vlan999": {"vlanid": "999"},
+            }
+        }
+    }
+    res = RunGeneratorResult()
+    res.add_json_fragment(
+        _make_json_fragment_result(
+            "vlans",
+            path=path,
+            acl=[JsonFragmentAcl("/VLAN/Vlan*", cant_delete=True)],
+            config={"VLAN": {"Vlan333": {"vlanid": "333"}, "Vlan605": {"vlanid": "605"}}},
+        )
+    )
+    res.add_json_fragment(
+        _make_json_fragment_result(
+            "dhcp_relay",
+            path=path,
+            acl=[JsonFragmentAcl("/VLAN/Vlan*/dhcpv6_servers")],
+            config={"VLAN": {"Vlan333": {"dhcpv6_servers": ["2a02:6b8::1"]}}},
+        )
+    )
+    merged, _ = res.new_json_fragment_files(old_files)[path]
+    assert merged == {
+        "VLAN": {
+            "Vlan333": {"dhcpv6_servers": ["2a02:6b8::1"], "vlanid": "333"},
+            "Vlan605": {"vlanid": "605"},
+        }
+    }
+
+
 def test_normalize_json_fragment_acl_parses_cant_delete_modifier():
     from annet.generators import _normalize_json_fragment_acl
 


### PR DESCRIPTION
  A cant_delete JSONFragment ACL on a broad scope (e.g. /VLAN/Vlan*/* %cant_delete=1) was incorrectly deleting keys that another generator's narrower ACL (e.g.                        
  /VLAN/Vlan*/dhcpv6_servers) legitimately owns and emits.                                                                                                                             
                                                                                                                                                                                       
  Pass 2 in RunGeneratorResult.new_json_fragment_files only consulted cant_delete contributions and used object identity to match acl items, so paths owned by another generator's     
  non-cant_delete ACL were treated as "nobody emitted this" and dropped.
                                                                                                                                                                                       
  Fix: Pass 2 now considers fragments from all generators when computing the "emitted" set, and skips deletion of any path covered by another (non-cant_delete) ACL — that ACL already 
  owns deletion and resolved it correctly in Pass 1.
                                                                                                                                                                                       
  Added regression tests in tests/annet/test_jsonfragments.py:                                                                                                                         
  - broad cant_delete ACL doesn't delete paths owned by another generator's narrower ACL
  - a non-cant_delete ACL still owns deletion within its scope                                                                                                                         
  - a Vlan that no generator emitted is still removed entirely