### PR TITLE
feat: diff_logic and rules for routeros

### DIFF
--- a/annet/rulebook/routeros/ignore_by_key.py
+++ b/annet/rulebook/routeros/ignore_by_key.py
@@ -1,0 +1,68 @@
+import shlex
+from collections import OrderedDict
+
+from contextlog import get_logger
+
+from annet.annlib.rulebook.common import default_diff
+from annet.annlib.types import Op
+
+
+def _normalize_command(command_line, ignore_keys=None, match_word="comment=DHCP"):
+    """Remove specified keys from commands when match_word is found for comparison.
+
+    Args:
+        command_line: RouterOS command line to normalize
+        ignore_keys: List of parameter keys to ignore (default: ['local-address', 'gateway', 'src-address', 'disabled'])
+        match_word: Word to match in command line to trigger normalization (default: 'comment=DHCP')
+
+    Returns:
+        Normalized command line with specified keys removed
+
+    Note:
+        All specified keys are ignored when match_word is found in the command
+    """
+    if match_word not in command_line:
+        return command_line
+
+    if ignore_keys is None:
+        ignore_keys = ["local-address", "src-address", "gateway", "disabled"]
+
+    # Simplified logic - ignore all specified keys when DHCP comment is present
+
+    result_command = "add"
+    try:
+        parts = shlex.split(command_line)
+
+        for part in parts[1:]:  # Skip the 'add' part
+            if "=" in part:
+                key_part = part.split("=", 1)[0]
+                # Skip if key is in ignore_keys
+                if key_part in ignore_keys:
+                    continue
+            result_command += f" {part}"
+
+        return result_command.strip()
+
+    except Exception as e:
+        get_logger().error("Failed to normalize IPSec command: %s", e)
+        return command_line
+
+
+def dhcpclient_change(old, new, diff_pre, _pops=(Op.AFFECTED,)):
+    """
+    Custom diff logic for RouterOS that ignores specified parameters
+    when comment contains "DHCP".
+
+    By default ignores: local-address, gateway, src-address, disabled
+    """
+    # Normalize both old and new configurations
+    normalized_old = OrderedDict(((_normalize_command(k), v) for k, v in old.items()))
+    normalized_new = OrderedDict(((_normalize_command(k), v) for k, v in new.items()))
+
+    # Also normalize diff_pre keys to match
+    normalized_diff_pre = OrderedDict()
+    for k, v in diff_pre.items():
+        normalized_key = _normalize_command(k)
+        normalized_diff_pre[normalized_key] = v
+
+    return default_diff(normalized_old, normalized_new, normalized_diff_pre, _pops)

--- a/annet/rulebook/routeros/remove_by_key.py
+++ b/annet/rulebook/routeros/remove_by_key.py
@@ -1,0 +1,97 @@
+import shlex
+from ipaddress import ip_address
+
+from contextlog import get_logger
+
+from annet.annlib.types import Op
+
+
+def change(key, diff, **kwargs):
+    """
+    Handle RouterOS operations.
+
+    For Op.ADDED: Use the original command
+    For Op.REMOVED: Transform 'add ... name=X ...' to 'remove name="X"'
+    Then in tabparser.py will transform to 'remove [ find + cmd + ]'
+    """
+    for added_cmd in diff[Op.ADDED]:
+        original_cmd = added_cmd["row"]
+        if "note=" in original_cmd:
+            original_cmd += " show-at-cli-login=no"
+        yield True, original_cmd, None
+
+    for removed_cmd in diff[Op.REMOVED]:
+        original_cmd = removed_cmd["row"]
+
+        try:
+            parts = shlex.split(original_cmd)
+        except Exception as e:
+            get_logger().error("Command parsing failed: %s", e)
+            continue
+
+        # Parse parameters into dictionary
+        params = {}
+        for part in parts[1:]:  # Skip the 'add' part
+            if "=" in part:
+                key_part, value = part.split("=", 1)
+                params[key_part.lower()] = value
+
+        # Create remove command using match-case for cleaner logic
+        match params:
+            case {"name": name}:
+                yield True, f'remove name="{name}"', None
+
+            case {"peer": peer}:
+                if peer.startswith("*"):
+                    yield True, "remove about", None
+                else:
+                    yield True, f'remove peer="{peer}"', None
+
+            case {"host": host}:
+                yield False, f'remove host="{host}"', None
+
+            case {"action": action, "topics": topics}:
+                if action.startswith("*"):
+                    yield True, "remove invalid", None
+                else:
+                    yield True, f'remove action="{action}" topics="{topics}"', None
+
+            case {"address": address, "interface": interface}:
+                addr, sep, mask = address.partition("/")
+                ip = ip_address(addr)
+                if not mask:
+                    mask = ip.max_prefixlen
+                    address = f"{addr}/{mask}"
+                if interface.startswith("*"):
+                    yield True, f'remove address="{address}"', None
+                else:
+                    yield True, f'remove address="{address}" interface="{interface}"', None
+
+            case {"address": address}:
+                yield True, f'remove address="{address}"', None
+
+            case {"interface": interface, "list": list}:
+                if interface.startswith("*"):
+                    yield True, f'remove list="{list}"', None
+                else:
+                    yield True, f'remove interface="{interface}"', None
+
+            case {"comment": comment, "dst-address": dst_address, "gateway": gateway}:
+                yield True, f'remove comment="{comment}" dst-address="{dst_address}" gateway="{gateway}"', None
+
+            case {"comment": comment, "dst-address": dst_address}:
+                yield True, f'remove comment="{comment}" dst-address="{dst_address}"', None
+
+            case {"disabled": disabled, "topics": topics}:
+                # remove all disabled topics
+                if disabled == "yes":
+                    yield True, f"remove disabled={disabled}", None
+
+            case {"topics": topics}:
+                topics = topics.replace(",", ".")
+                yield True, f'remove topics~"{topics}"', None
+
+            case {"disabled": _}:
+                # Always turn off www-ssl
+                if "www-ssl" in original_cmd:
+                    yield True, "set www-ssl disabled=yes", None

--- a/annet/rulebook/routeros/sequence.py
+++ b/annet/rulebook/routeros/sequence.py
@@ -1,0 +1,14 @@
+from annet.annlib.types import Op
+
+
+def erase_before(key, diff, **kwargs):
+    """
+    Handle RouterOS IP firewall and queue operations.
+    """
+
+    if diff[Op.MOVED] or diff[Op.ADDED] or diff[Op.REMOVED]:
+        # Remove all rules
+        yield False, "remove dynamic=no", None
+    # Then the rules will be recreated in a new order
+    for cmd in list(diff[Op.ADDED] + diff[Op.MOVED] + diff[Op.UNCHANGED]):
+        yield True, cmd["row"], None

--- a/annet/rulebook/texts/routeros.order
+++ b/annet/rulebook/texts/routeros.order
@@ -21,7 +21,7 @@ interface
             remove
         port %split
             remove
-        remove
+        remove %order_reverse
         add
         port %split
             add

--- a/annet/rulebook/texts/routeros.order
+++ b/annet/rulebook/texts/routeros.order
@@ -4,25 +4,16 @@
 #   обратной, но занимает место между прямыми там, где указано (т.е. undo vlan batch
 #   будет стоять после блоков interface).
 
+
+user
+    group
+        add
+    ssh_key
+        add
+
 file
     print
     set
-
-snmp
-    community
-        set
-        add
-
-snmp
-    set
-
-system
-    logging
-        action
-            set
-            add
-        set
-        add
 
 interface
     bridge
@@ -30,22 +21,199 @@ interface
             remove
         port %split
             remove
-        remove %order_reverse
+        remove
         add
         port %split
             add
         vlan %split
             add
-
-interface
+    vlan
+        add
     gre
         add
-
-interface
+    l2tp-client
+        add
+    pppoe-client
+        add
+    wireless
+        cap
+            set
     list
-        member
+        member %split
+            remove
+        set
+        remove
+        add
+        member %split
+            add
+
+routing
+    rule %split
+        remove
+    table %split
+        remove
+    table %split
+        add
+    rule %split
+        add
+    filter
+        rule
+            add
+    bgp
+        template
+            set
+            add
+        connection
             add
 
 ip
     address
+        remove
         add
+    route
+        add
+    dhcp-server %split
+        remove
+    pool
+        add
+    dns
+        set
+        static
+            add
+    dhcp-server %split
+        add
+        network
+            remove
+            add
+        config
+            set
+    firewall
+        address-list
+            add
+        filter
+            add
+        nat
+            add
+    dhcp-client
+        add
+    ipsec
+        mode-config
+            set
+            add
+        profile
+            set
+            add
+        peer
+            add
+        proposal
+            set
+            add
+        policy
+            group
+                set
+                add
+            set
+            add
+        settings
+            set
+        identity
+            add
+
+    neighbor
+        discovery-settings
+            set
+    service
+        set
+    ssh
+        set
+
+ipv6
+    address
+        remove
+        add
+    route
+        add
+    firewall
+        address-list
+            add
+        filter
+            add
+        nat
+            add
+
+caps-man
+    channel
+        add
+    datapath
+        add
+    security
+        add
+    configuration
+        add
+    provisioning
+        add
+    manager
+        set
+        interface
+            set
+            add
+
+queue
+    simple
+        add
+
+snmp
+    community
+        set
+        add
+    set
+
+system
+    clock
+        set
+        manual
+            set
+    identity
+        set
+    logging
+        remove
+        action
+            set
+            add
+        set
+        add
+    note
+        set
+    ntp
+        server
+            set
+        client
+            set
+            servers
+                add
+    routerboard
+        settings
+            set
+    script
+        remove
+        add
+    scheduler
+        remove
+        add
+
+tool
+    bandwidth-server
+        set
+    mac-server
+        set
+        mac-winbox
+            set
+        ping
+            set
+    netwatch
+        add
+    romon
+        set
+        port
+            set
+            add

--- a/annet/rulebook/texts/routeros.rul
+++ b/annet/rulebook/texts/routeros.rul
@@ -13,14 +13,69 @@
 
 
 user
-    add ~ %diff_logic=annet.rulebook.routeros.user.diff
     ~
     group
+        add ~
+    ssh_key
         add ~
 
 file
     print file=*
     set * %logic=annet.rulebook.routeros.file.change
+
+interface
+    gre
+        add ~ %logic=annet.rulebook.routeros.remove_by_key.change
+    l2tp-client
+        add ~ %logic=annet.rulebook.routeros.remove_by_key.change
+    list
+        add ~ %logic=annet.rulebook.routeros.remove_by_key.change
+        member
+            add ~ %logic=annet.rulebook.routeros.remove_by_key.change
+
+ip
+    address
+        add ~ %logic=annet.rulebook.routeros.remove_by_key.change
+    route
+        add ~ %logic=annet.rulebook.routeros.remove_by_key.change %diff_logic=annet.rulebook.routeros.ignore_by_key.dhcpclient_change
+    dhcp-server
+        add ~ %logic=annet.rulebook.routeros.remove_by_key.change
+        network
+            add ~ %logic=annet.rulebook.routeros.remove_by_key.change
+    firewall
+        filter
+            add ~ %logic=annet.rulebook.routeros.sequence.erase_before
+        nat
+            add ~ %logic=annet.rulebook.routeros.sequence.erase_before
+    ipsec
+        peer
+            add ~ %logic=annet.rulebook.routeros.remove_by_key.change %diff_logic=annet.rulebook.routeros.ignore_by_key.dhcpclient_change
+        identity
+            add ~ %logic=annet.rulebook.routeros.remove_by_key.change
+    service
+        set ~ %logic=annet.rulebook.routeros.remove_by_key.change
+
+ipv6
+    address
+        add ~ %logic=annet.rulebook.routeros.remove_by_key.change
+    route
+        add ~ %logic=annet.rulebook.routeros.remove_by_key.change
+    firewall
+        filter
+            add ~ %logic=annet.rulebook.routeros.sequence.erase_before
+        nat
+            add ~ %logic=annet.rulebook.routeros.sequence.erase_before
+
+routing
+    bgp
+        connection
+            add ~ %logic=annet.rulebook.routeros.remove_by_key.change
+    rule
+        add ~ %diff_logic=annet.rulebook.routeros.ignore_by_key.dhcpclient_change
+
+queue
+    simple
+        add ~ %logic=annet.rulebook.routeros.sequence.erase_before
 
 system
     logging
@@ -28,19 +83,16 @@ system
             set ~
             add ~
         set ~
-        add ~
+        add ~ %logic=annet.rulebook.routeros.remove_by_key.change
+    note
+        set ~ %logic=annet.rulebook.routeros.remove_by_key.change
+    script
+        add ~ %logic=annet.rulebook.routeros.remove_by_key.change
+    scheduler
+        add ~ %logic=annet.rulebook.routeros.remove_by_key.change
 
-interface
-    gre
-        add
-
-interface
-    list
-        member
-            add
-
-ip
-    address
-        add ~
+tool
+    netwatch
+            add ~ %logic=annet.rulebook.routeros.remove_by_key.change
 
 ~ %global

--- a/tests/annet/test_patch/routeros_firewall.yaml
+++ b/tests/annet/test_patch/routeros_firewall.yaml
@@ -3,10 +3,10 @@
   vendor: routeros
   before: |
   after: |
-    /ipv6 firewall
-     add action=accept chain=input
     /ip firewall
      add action=accept chain=input
+    /ipv6 firewall
+     add action=accept chain=input
   patch: |
-    /ipv6 firewall add action=accept chain=input
     /ip firewall add action=accept chain=input
+    /ipv6 firewall add action=accept chain=input


### PR DESCRIPTION
**Add diff logic and rules for RouterOS**

### Changes
- Added `ignore_by_key.py` - rule to ignore configuration blocks by key
- Added `remove_by_key.py` - rule to remove configuration blocks by key  
- Added `sequence.py` - sequence handling for RouterOS
- Updated `routeros.order` - extended ordering rules
- Updated `routeros.rul` - enhanced rule definitions

### Summary
Implements diff generation logic for RouterOS platform with key-based filtering capabilities for configuration management.