### PR TITLE
fix: exclude S5735I yunshan ports and Stack-Port from implicit

### DIFF
--- a/annet/implicit.py
+++ b/annet/implicit.py
@@ -65,7 +65,7 @@ def _implicit_tree(device):
                  """
         elif device.hw.Huawei.Quidway.S5700.S5735I:
             text = """
-                !interface (?!Vlanif).*
+                !interface (?!Vlanif|10GE1/0/[56]|Stack-Port).*
                     port link-type access %regexp=port link-type .*
                 interface NULL0
             """


### PR DESCRIPTION
The last two `10GE` ports on S5735I (10GE1/0/5, 10GE1/0/6) are yunshan/stack ports that don't accept `port link-type` config, same as Stack-Port* interfaces. Injecting the implicit `port link-type access` default for them produced a spurious diff, leading to a deploy command the device rejects with `"Unrecognized command found at '^' position".`