### PR TITLE
fix: Small patching fixes for aruba

### DIFF
--- a/annet/implicit.py
+++ b/annet/implicit.py
@@ -208,6 +208,12 @@ def _implicit_tree(device):
                     ping
                         set enabled=yes %regexp=set enabled=.*
         """
+    elif device.hw.Aruba:
+        text = """
+            !arm
+                no 80mhz-support
+                no 160mhz-support
+        """
 
     return parse_text(text)
 

--- a/annet/rulebook/texts/aruba.rul
+++ b/annet/rulebook/texts/aruba.rul
@@ -72,6 +72,11 @@ wlan ssid-profile ~
     radius-reauth-interval
     dtim-period
 
+wlan auth-server ~
+    ip
+    deadtime
+    key
+
 ntp-server
 rf-band
 name

--- a/annet/rulebook/texts/aruba.rul
+++ b/annet/rulebook/texts/aruba.rul
@@ -51,16 +51,22 @@ arm
     g-channels
     min-tx-power
     max-tx-power
+    free-channel-index
+    band-steering-mode
 
 rf dot11g-radio-profile
     max-distance
     max-tx-power
     min-tx-power
+    free-channel-index
+    interference-immunity
 
 rf dot11a-radio-profile
     max-distance
     max-tx-power
     min-tx-power
+    free-channel-index
+    interference-immunity
 
 wlan access-rule ~
     rule ~          %ordered
@@ -77,6 +83,7 @@ wlan auth-server ~
     deadtime
     key
 
+hash-mgmt-user
 ntp-server
 rf-band
 name

--- a/tests/annet/test_patch/aruba_implicit.yaml
+++ b/tests/annet/test_patch/aruba_implicit.yaml
@@ -1,0 +1,21 @@
+- vendor: Aruba
+  before: |
+    arm
+
+  after: |
+    arm
+      no 80mhz-support
+      no 160mhz-support
+
+  patch: ""
+
+- vendor: Aruba
+  before: |
+    arm
+      no 80mhz-support
+      no 160mhz-support
+
+  after: |
+    arm
+
+  patch: ""

--- a/tests/annet/test_patch/aruba_wlan_auth_server.yaml
+++ b/tests/annet/test_patch/aruba_wlan_auth_server.yaml
@@ -1,0 +1,20 @@
+- vendor: Aruba
+  diff: |
+    wlan auth-server test
+      - ip 192.168.255.1
+      + ip 192.168.254.1
+      - deadtime 2
+      + deadtime 3
+      - key KEY1
+      + key KEY2
+
+  patch: |
+    conf t
+    wlan auth-server test
+      deadtime 3
+      ip 192.168.254.1
+      key KEY2
+      exit
+    end
+    commit apply
+    write memory


### PR DESCRIPTION
* implicit no 80mhz-support/160mhz-support commands
* patching rules for wlan auth-server section