### PR TITLE
fix b4com tabparser

### DIFF
--- a/annet/vendors/tabparser.py
+++ b/annet/vendors/tabparser.py
@@ -404,7 +404,7 @@ class B4comFormatter(BlockExitFormatter):
                 continue
 
             if exit_af_re.match(line):
-                result.append(" " + line)
+                result.append(line)
                 inside_af = False
                 continue
 

--- a/annet/vendors/tabparser.py
+++ b/annet/vendors/tabparser.py
@@ -389,7 +389,7 @@ class B4comFormatter(BlockExitFormatter):
         To this:
         address-family ipv6 unicast
          max-paths ebgp 48
-         exit-address-family
+        exit-address-family
         exit
         """
         result = []


### PR DESCRIPTION
B4com CS2148 have an error:

```
annet.vendors.tabparser.ParserError: Invalid top indentation: line 568: exit-address-family
```

and this PR repairs it.