### PR TITLE
fix: allow non-unique commands in patches and remove duplicate exit emission

### DIFF
--- a/annet/annlib/patching.py
+++ b/annet/annlib/patching.py
@@ -6,7 +6,8 @@ import re
 import sys
 import textwrap
 from collections import OrderedDict as odict
-from collections.abc import Iterable
+from collections import defaultdict
+from collections.abc import Iterable, Sequence
 from typing import (
     Any,
     Callable,
@@ -557,6 +558,7 @@ def _filter_rows_by_rulebook_selector(config, rb, selector, ret, path=()):
 
 def make_pre(diff: Diff, _parent_match=None) -> dict[str, Any]:
     pre = odict()
+    reversals = defaultdict(set)
     for op, row, children, match in diff:
         if _parent_match and _parent_match["attrs"]["multiline"]:
             # Если родительское правило было мультилайном, то все внутренности станут его контентом.
@@ -575,6 +577,13 @@ def make_pre(diff: Diff, _parent_match=None) -> dict[str, Any]:
             }
         raw_rule = match["raw_rule"]
         key = match["key"]
+
+        # prevent generation of duplicate command when
+        # replacing "do" with "undo" command, or vise versa
+        if "reverse" in match["attrs"] and op in (Op.ADDED, Op.REMOVED):
+            if row in reversals[{Op.ADDED: Op.REMOVED, Op.REMOVED: Op.ADDED}[op]]:
+                continue
+            reversals[op].add(match["attrs"]["reverse"].format(*key))
 
         if raw_rule not in pre:
             pre[raw_rule] = {

--- a/annet/vendors/tabparser.py
+++ b/annet/vendors/tabparser.py
@@ -4,10 +4,9 @@ import dataclasses
 import itertools
 import json
 import re
-import textwrap
 from collections import OrderedDict as odict
-from collections.abc import Callable, Iterator
-from typing import TYPE_CHECKING, Any, Dict, Generic, Iterable, List, Optional, Tuple, TypeAlias
+from collections.abc import Callable, Iterator, Sequence
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, TypeAlias
 
 from annet.annlib.types import Op
 
@@ -69,26 +68,26 @@ class FormatterContext:
 
 
 class NotUniquePatch:
-    def __init__(self):
-        """In the case of comments, odict is not suitable: there may be several identical edit and exit"""
-        self._items = []
-        self._keys = set()
+    def __init__(self) -> None:
+        """Plain odict is not suitable: there may be several block enters and exits"""
+        self._items = list[tuple[str, FormatterContext]]()
+        self._keys = set[str]()
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: FormatterContext) -> None:
         self._keys.add(key)
         self._items.append((key, value))
 
-    def keys(self):
+    def keys(self) -> list[str]:
         return list(self)
 
-    def items(self):
+    def items(self) -> Sequence[tuple[str, FormatterContext]]:
         return self._items
 
-    def __contains__(self, item):
+    def __contains__(self, item: str) -> bool:
         return item in self._keys
 
-    def __iter__(self):
-        return iter(item[0] for item in self._items)
+    def __iter__(self) -> Iterable[str]:
+        return iter(k for k, _ in self._items)
 
     def __bool__(self) -> bool:
         return bool(self._items)
@@ -96,7 +95,7 @@ class NotUniquePatch:
 
 # =====
 class CommonFormatter:
-    cmd_path_cls = odict
+    cmd_path_cls = NotUniquePatch
 
     def __init__(self, indent="  "):
         self._indent = indent
@@ -116,10 +115,10 @@ class CommonFormatter:
     def diff(self, diff):
         return list(self.diff_generator(diff))
 
-    def patch(self, patch: "PatchTree") -> str:
+    def patch(self, patch: PatchTree) -> str:
         return "\n".join(_filtered_block_marks(self._indent_blocks(self._blocks(patch, is_patch=True))))
 
-    def cmd_paths(self, patch: "PatchTree") -> odict:
+    def cmd_paths(self, patch: PatchTree) -> NotUniquePatch:
         ret = self.cmd_path_cls()
         path = []
         for row, context in self.blocks_and_context(patch, is_patch=True):
@@ -168,7 +167,7 @@ class CommonFormatter:
                 row = self._indent * _level + row
             yield row
 
-    def blocks_and_context(self, tree: "PatchTree", is_patch: bool, context: Optional[FormatterContext] = None):
+    def blocks_and_context(self, tree: PatchTree, is_patch: bool, context: Optional[FormatterContext] = None):
         if context is None:
             context = FormatterContext()
 
@@ -194,7 +193,7 @@ class CommonFormatter:
                 yield from self.blocks_and_context(sub_config, is_patch, context=FormatterContext(parent=context))
                 yield BlockEnd, None
 
-    def _blocks(self, tree: "PatchTree", is_patch: bool):
+    def _blocks(self, tree: PatchTree, is_patch: bool):
         for row, _context in self.blocks_and_context(tree, is_patch):
             yield row
 
@@ -237,31 +236,20 @@ class BlockExitFormatter(CommonFormatter):
                     yield exit_statement, last_row_context
 
 
-class HuaweiPatch(NotUniquePatch):
-    policy_end_blocks = ("end-list", "endif", "end-filter")
-
-    def __setitem__(self, key, value):
-        if not key:
-            return
-
-        if key not in self or (key[0].startswith("xpl") and key[-1] in self.policy_end_blocks):
-            super().__setitem__(key, value)
-
-
 class HuaweiFormatter(BlockExitFormatter):
-    cmd_path_cls = HuaweiPatch
     block_exit_command = "quit"
     no_block_exit = (
         "rsa peer-public-key",
         "dsa peer-public-key",
         "public-key-code begin",
     )
+    policy_end_blocks = ("end-list", "endif", "end-filter")
 
     def split(self, text):
         # на старых прошивка наблюдается баг с двумя пробелами в этом месте в конфиге
         # например на VRP V100R006C00SPC500 + V100R006SPH003
         tree = self.split_remove_spaces(text)
-        tree[:] = filter(lambda x: not str(x).strip().startswith(HuaweiPatch.policy_end_blocks), tree)
+        tree[:] = filter(lambda x: not str(x).strip().startswith(self.policy_end_blocks), tree)
         return tree
 
     def block_exit(self, context: Optional[FormatterContext]):
@@ -339,6 +327,7 @@ class CiscoFormatter(BlockExitFormatter):
             text = text.replace(banner, replace_str)
 
         tree = self.split_remove_spaces(text)
+        result: list[str] = []
         for i, item in enumerate(tree):
             # fix incorrect indent for "exit-address-family"
             if item == " exit-address-family":
@@ -347,18 +336,25 @@ class CiscoFormatter(BlockExitFormatter):
             if i and tree[i - 1].startswith("class-map match"):
                 if item.startswith("  description"):
                     item = item[1:]
+            stripped = item.strip()
+            is_block_exit = stripped in block_exit_strings
             block_exit_strings, new_indent = self._split_indent(item, additional_indent, block_exit_strings)
-            tree[i] = f"{' ' * additional_indent}{item}"
+            # Drop block-exit marker lines from the parsed tree: they are syntactic
+            # block delimiters (already used above to compute indent), not body rows.
+            # Keeping them caused the formatter to later inject a second block-exit,
+            # producing duplicates like "exit-address-family\nexit-address-family".
+            if not is_block_exit:
+                result.append(f"{' ' * additional_indent}{item}")
             additional_indent = new_indent
 
-        # restore banner content in the `tree`
-        for i, item in enumerate(tree):
+        # restore banner content
+        for i, item in enumerate(result):
             if item in repl_map:
-                tree[i] = repl_map[item]
+                result[i] = repl_map[item]
 
-        return tree
+        return result
 
-    def block_exit(self, context: Optional[FormatterContext]) -> str:
+    def block_exit(self, context: Optional[FormatterContext]):
         current = context and context.row or ""
 
         if current.startswith(("address-family")):
@@ -373,6 +369,11 @@ class NexusFormatter(BlockExitFormatter):
 
 
 class B4comFormatter(BlockExitFormatter):
+    # Syntactic block-end markers that appear inline in B4COM configs. They are
+    # used as delimiters and must not enter the parsed tree as body rows,
+    # otherwise the formatter would emit a duplicate exit at format time.
+    block_end_markers = ("exit", "exit-address-family")
+
     def _fix_af_indentation(self, text: str) -> str:
         """Fixes the indentation of address-family blocks in B4COM configuration.
         This method ensures that lines within address-family blocks are indented correctly.
@@ -417,9 +418,15 @@ class B4comFormatter(BlockExitFormatter):
 
     def split(self, text):
         text = self._fix_af_indentation(text)
-        return self.split_remove_spaces(text)
+        tree = self.split_remove_spaces(text)
+        # Drop syntactic block-end markers (see ``block_end_markers``): they are
+        # delimiters in the on-device text, not body rows. Keeping them would
+        # make ``BlockExitFormatter`` inject a second exit at format time and
+        # produce duplicates like "exit\nexit".
+        tree[:] = [row for row in tree if row.strip() not in self.block_end_markers]
+        return tree
 
-    def block_exit(self, context: Optional[FormatterContext]) -> str:
+    def block_exit(self, context: Optional[FormatterContext]):
         current = context and context.row or ""
 
         if current.startswith(("address-family")):
@@ -445,7 +452,7 @@ class AsrFormatter(BlockExitFormatter):
         tree[:] = filter(lambda x: not x.endswith(policy_end_blocks), tree)
         return tree
 
-    def block_exit(self, context: Optional[FormatterContext]) -> str:
+    def block_exit(self, context: Optional[FormatterContext]):
         current = context and context.row or ""
 
         if current.startswith(("prefix-set", "as-path-set", "community-set")):
@@ -460,7 +467,6 @@ class AsrFormatter(BlockExitFormatter):
 
 class JuniperFormatter(CommonFormatter):
     patch_set_prefix = "set"
-    cmd_path_cls = NotUniquePatch
 
     @dataclasses.dataclass
     class Comment:
@@ -524,7 +530,7 @@ class JuniperFormatter(CommonFormatter):
     def patch_plain(self, patch):
         return list(self.cmd_paths(patch).keys())
 
-    def _blocks(self, tree: "PatchTree", is_patch: bool):
+    def _blocks(self, tree: PatchTree, is_patch: bool):
         for row in super()._blocks(tree, is_patch):
             if isinstance(row, str) and row.startswith(self.Comment.begin):
                 yield f"{self.Comment.begin} {self.Comment.loads(row).comment} {self.Comment.end}"
@@ -550,7 +556,7 @@ class JuniperFormatter(CommonFormatter):
         if isinstance(line, str):
             yield line + self._statement_end
 
-    def cmd_paths(self, patch, _prev=tuple()):
+    def cmd_paths(self, patch, _prev=tuple()) -> NotUniquePatch:
         commands = self.cmd_path_cls()
 
         for item in patch.itms:
@@ -643,8 +649,8 @@ class NokiaFormatter(JuniperFormatter):
         finish = finish if finish is not None else len(ret)
         return ret[start:finish]
 
-    def cmd_paths(self, patch, _prev=tuple()):
-        commands = odict()
+    def cmd_paths(self, patch, _prev=tuple()) -> NotUniquePatch:
+        commands = self.cmd_path_cls()
         for item in patch.itms:
             key, childs, context = item.row, item.child, item.context
             if childs:
@@ -683,7 +689,7 @@ class RosFormatter(CommonFormatter):
     def patch_plain(self, patch):
         return list(self.cmd_paths(patch).keys())
 
-    def blocks_and_context(self, tree: "PatchTree", is_patch: bool, context: Optional[FormatterContext] = None):
+    def blocks_and_context(self, tree: PatchTree, is_patch: bool, context: Optional[FormatterContext] = None):
         if is_patch:
             raise RuntimeError("Ros not supported blocks in patch")
 
@@ -797,18 +803,19 @@ class RosFormatter(CommonFormatter):
                 split.append(self._indent * level + row)
         return list(filter(None, split))
 
-    def cmd_paths(self, patch, _prev=""):
+    def cmd_paths(self, patch, _prev="") -> NotUniquePatch:
         rm_regexs = (
             (re.compile(r"^add "), ""),
             (re.compile(r"^print file="), "name="),
         )
 
-        commands = odict()
+        commands = self.cmd_path_cls()
         for item in patch.itms:
             key, childs, context = item.row, item.child, item.context
             if childs:
                 childs_prev = f"{_prev} {key.strip()}".lstrip()
-                commands.update(self.cmd_paths(childs, _prev=childs_prev))
+                for cmd, subcmds in self.cmd_paths(childs, _prev=childs_prev).items():
+                    commands[cmd] = subcmds
             else:
                 if key.startswith("remove"):
                     find_cmd = key.removeprefix("remove").strip()

--- a/tests/annet/test_patch.py
+++ b/tests/annet/test_patch.py
@@ -43,4 +43,4 @@ def test_patch(name, sample, ann_connectors):
     for cmd in cmds:
         generated.append("%s%s\n" % ("  " * cmd.level, str(cmd)))
 
-    assert expected_patch == "".join(generated), "Wrong patch in %s" % name
+    assert "".join(generated) == expected_patch, "Wrong patch in %s" % name

--- a/tests/annet/test_patch/cisco_vlandb.yaml
+++ b/tests/annet/test_patch/cisco_vlandb.yaml
@@ -182,11 +182,11 @@
       + no shutdown
   patch: |
     conf t
-    vlan 191
-      no shutdown
-      exit
     vlan 190
       name DEV
+      exit
+    vlan 191
+      no shutdown
       exit
     exit
     copy running-config startup-config
@@ -245,11 +245,11 @@
   patch: |
     conf t
     no vlan 300-305,310
-    vlan 299
-      no shutdown
-      exit
     vlan 321
       name TRANSIT
+      exit
+    vlan 299
+      no shutdown
       exit
     vlan 320-321
       exit


### PR DESCRIPTION
This PR started as enabling non-unique commands in patches (e.g. multiple `edit`/`exit` entries in `cmd_paths`), but uncovered a few related bugs along the way:

1. `cmd_paths` deduplicated rows via `OrderedDict`, dropping legitimate duplicate commands.
2. Cisco/B4com `split` methods kept syntactic block-end markers (`exit`, `exit-address-family`) as body rows in the parsed tree, which caused `BlockExitFormatter` to inject a second exit at format time — producing duplicates like `exit-address-family\nexit-address-family`.
3. `make_pre` could emit both a `do` and its `undo` form for the same row when a rulebook had a `reverse` attribute, generating duplicate commands.

## Changes

### `annet/vendors/tabparser.py`
- **`NotUniquePatch` is now the default `cmd_path_cls` on `CommonFormatter`.** Previously most formatters used plain `OrderedDict`, which silently deduplicated keys. `HuaweiPatch` (a `NotUniquePatch` subclass that did custom filtering of `xpl` end-block tokens) is removed; `HuaweiFormatter.split` already strips those tokens, so the special-case dedup logic was redundant.
- **Strip syntactic block-end markers from the parsed tree in `CiscoFormatter.split` and `B4comFormatter.split`.** This mirrors what `HuaweiFormatter.split` already does for `end-list`/`endif`/`end-filter` and `AsrFormatter.split` does for `end-set`/`endif`/`end-policy`. Cisco's `_split_indent` still uses these tokens to compute indentation; we just drop them from the output so they don't enter the diff/patch tree as body rows. This eliminates duplicate `exit` / `exit-address-family` emissions in patches for newly added blocks (e.g. a brand-new `address-family ipv6`).
- `NokiaFormatter.cmd_paths` and `RosFormatter.cmd_paths` updated to use `cmd_path_cls` (i.e. `NotUniquePatch`) instead of hard-coded `odict`, so they don't drop duplicate rows either.
- Misc typing cleanup (`PatchTree` forward refs, return type annotations).

### `annet/annlib/patching.py`
- In `make_pre`, when a rule has a `reverse` attribute (a command and its inverse), skip emitting a row if its reverse counterpart has already been emitted for the opposite op. Prevents producing both `foo` and `no foo` for the same logical change.

### Tests
- `tests/annet/test_patch.py`: flip `assert` argument order so pytest prints `generated` vs `expected` (actual vs expected) instead of the other way around.
- `tests/annet/test_patch/cisco_vlandb.yaml`: update two expected patches to reflect the new (now stable) order of commands when duplicates are preserved.

## Why the cisco/b4com fix is the principled one
The `exit` and `exit-address-family` lines in on-device configs are *syntactic block delimiters*, not body commands. Keeping them as rows in the parsed tree meant the diff machinery treated them as regular content and propagated them into added blocks — and then the formatter independently injected its own block-exit, producing duplicates. The Huawei and ASR formatters already filter their equivalent tokens; this PR extends the same approach to Cisco and B4com.