### PR TITLE
huawei bgp: fix patch ordering and nested config re-apply on IP peer asn-number change

### DIFF
--- a/annet/rulebook/huawei/bgp.py
+++ b/annet/rulebook/huawei/bgp.py
@@ -1,5 +1,6 @@
 import socket
 
+from annet.annlib.rulebook.common import default_diff
 from annet.annlib.types import Op
 from annet.rulebook import common
 
@@ -73,6 +74,135 @@ def bfd(rule, key, diff, **_):
         diff[Op.REMOVED] = []
     if diff[Op.ADDED]:
         yield from common.default(rule, key, diff, **_)
+
+
+def reapply_after_as_number_change(old, new, diff_pre, _pops=(Op.AFFECTED,)):
+    """
+    On Huawei, removing or changing the as-number of an existing IP peer
+    triggers `undo peer <ip>`, which wipes every `peer <ip> ...` command in
+    the same scope. The default diff doesn't reflect this implicit wipe, so
+    we rewrite the bgp subtree here:
+
+    1. AS-number CHANGE on an IP peer: the peer's other rows are identical in
+       old and new, so the default diff marks them UNCHANGED and they are
+       never re-sent — leaving the device with a half-configured peer. We
+       flip those AFFECTED rows to ADDED so the patcher re-emits them after
+       `undo peer <ip>`.
+
+    2. AS-number CHANGE / full IP-peer REMOVAL: any REMOVED rows for the same
+       IP become redundant and would error against a nonexistent peer
+       ("Error: The peer session does not exist"). We drop them.
+
+    The `peer <ip> as-number ...` row can live at the bgp top level or inside
+    an address-family / vpn-instance block, so the wiped/recreated sets are
+    computed per block (see `_rewrite_block`). A bgp top-level `undo peer
+    <ip>` wipes the peer in the global family blocks too, so the set is
+    inherited downward — but it stops at a `vpn-instance` boundary, since a
+    vpn-instance peer is a separate namespace and its `undo peer <ip>` is
+    issued (and only wipes) within that block.
+
+    Scope: IP peers only. Peer-group renames go through a different
+    Huawei command (`undo peer <group> as-number`, non-destructive) and
+    don't need re-emit. Peer-group removal isn't handled here either; the
+    pre-PR per-option-undo shape is correct on the device (just noisier).
+    """
+    items = default_diff(old, new, diff_pre, _pops)
+
+    result = []
+    for item in items:
+        bgp_old = old.get(item.row, {})
+        bgp_new = new.get(item.row, {})
+        children = _rewrite_block(item.children, bgp_old, bgp_new, set(), set())
+        result.append(item._replace(children=children))
+    return result
+
+
+def _wiped_peer_ips(old, new):
+    """IPs whose `peer <ip> as-number ...` row at this level is in `old` but
+    not in `new` — i.e. peers for which peer() will emit `undo peer <ip>`
+    (covers both full removal and as-number value change)."""
+    wiped_peer_ips = set()
+    for row in old:
+        if row in new or not _is_peer_as_number_row(row):
+            continue
+        key = _peer_key(row)
+        if _is_ip_addr(key):
+            wiped_peer_ips.add(key)
+    return wiped_peer_ips
+
+
+def _peer_ips_with_as_number(rows):
+    """IPs that appear in a `peer <ip> as-number ...` row at this level."""
+    peer_ips = set()
+    for row in rows:
+        if not _is_peer_as_number_row(row):
+            continue
+        key = _peer_key(row)
+        if _is_ip_addr(key):
+            peer_ips.add(key)
+    return peer_ips
+
+
+def _peer_key(row):
+    tokens = row.split()
+    if len(tokens) >= 2 and tokens[0] == "peer":
+        return tokens[1]
+    return None
+
+
+def _is_peer_as_number_row(row):
+    tokens = row.split()
+    return len(tokens) >= 3 and tokens[0] == "peer" and tokens[2] == "as-number"
+
+
+def _is_vpn_instance_block(row):
+    return "vpn-instance" in row.split()
+
+
+def _rewrite_block(items, old_level, new_level, inherited_wiped, inherited_recreated):
+    """Rewrite one block of the bgp subtree (the bgp body itself, or a family
+    / vpn-instance block). `old_level`/`new_level` are this block's old/new
+    config dicts, used to find peers wiped at this scope.
+
+    `wiped` is the set of IPs whose `peer <ip> as-number ...` row disappears
+    at this scope or any enclosing one; `recreated` is the subset that still
+    has an as-number row in `new` (renumbered, not removed). For each
+    `peer <ip> ...` DiffItem whose IP is wiped:
+      - REMOVED rows are dropped (redundant after the upstream `undo peer
+        <ip>`), except a REMOVED `peer <ip> as-number Y` row, which is kept
+        as the trigger that makes huawei.bgp.peer emit `undo peer <ip>`;
+      - AFFECTED rows are flipped to ADDED for a recreated IP, so the
+        re-declared peer's other rows are re-applied after the wipe.
+
+    A `vpn-instance` block is a separate peer namespace, so the inherited
+    sets are not carried across that boundary — only the block's own peers
+    apply inside it."""
+    local_wiped = _wiped_peer_ips(old_level, new_level)
+    wiped = inherited_wiped | local_wiped
+    recreated = inherited_recreated | (local_wiped & _peer_ips_with_as_number(new_level))
+
+    result = []
+    for item in items:
+        key = _peer_key(item.row)
+        is_wiped_peer = key in wiped
+        if is_wiped_peer and item.op == Op.REMOVED and not _is_peer_as_number_row(item.row):
+            continue
+        if _is_vpn_instance_block(item.row):
+            child_wiped, child_recreated = set(), set()
+        else:
+            child_wiped, child_recreated = wiped, recreated
+        children = _rewrite_block(
+            item.children,
+            old_level.get(item.row, {}),
+            new_level.get(item.row, {}),
+            child_wiped,
+            child_recreated,
+        )
+        if is_wiped_peer and item.op == Op.AFFECTED and key in recreated:
+            result.append(item._replace(op=Op.ADDED, children=children))
+        else:
+            result.append(item._replace(children=children))
+    return result
 
 
 def _is_ip_addr(addr_or_string):

--- a/annet/rulebook/texts/huawei.order
+++ b/annet/rulebook/texts/huawei.order
@@ -253,6 +253,15 @@ bgp
     # [NOCDEV-1182] у load-balancing есть несколько взаимоисключающих флейверов
     undo undo maximum load-balancing %order_reverse
     maximum load-balancing
+    # Tear down peers first: changing as-number of an existing IP peer on
+    # Huawei requires a prior `undo peer <ip>` (otherwise the device errors
+    # with "The peer already exists in AS <old>"), and changing a peer-group's
+    # as-number requires `undo peer <group> as-number` before re-declaring it
+    # (otherwise "The as-number for session group cannot be changed because
+    # some peer exists"). Both rules are end-anchored so they don't shadow
+    # the per-option undo rules at the bottom of the bgp block.
+    undo peer ~/[^\s]+$/ %order_reverse
+    undo peer * as-number %order_reverse
     # [NOCDEV-2043] Тут только декларируем пиров и группы
     # поскольку на них есть ссылки из family блоков
     group
@@ -272,7 +281,6 @@ bgp
     undo peer * description %order_reverse
     undo peer * * * %order_reverse
     undo peer * * %order_reverse
-    undo peer * %order_reverse
     undo group * %order_reverse
     peer * ~
 

--- a/annet/rulebook/texts/huawei.rul
+++ b/annet/rulebook/texts/huawei.rul
@@ -377,7 +377,7 @@ xpl ~
 bgp path-attribute attr-set *
 bgp path-attribute *
 
-bgp %logic=annet.rulebook.huawei.bgp.undo_commit
+bgp %logic=annet.rulebook.huawei.bgp.undo_commit %diff_logic=annet.rulebook.huawei.bgp.reapply_after_as_number_change
     private-4-byte-as
     router-id
 

--- a/tests/annet/test_patch/huawei_peer_as_number_change_group.yaml
+++ b/tests/annet/test_patch/huawei_peer_as_number_change_group.yaml
@@ -1,0 +1,30 @@
+- vendor: huawei
+  name: group as-number rename emits undo before declare and does not re-emit member rows
+  before: |
+    bgp 65536
+     group SPINES external
+     peer SPINES as-number 12345
+     peer 192.0.2.10 as-number 12345
+     peer 192.0.2.10 group SPINES
+     ipv4-family unicast
+      peer SPINES enable
+      peer 192.0.2.10 enable
+      peer 192.0.2.10 route-policy DENY_ALL import
+  after: |
+    bgp 65536
+     group SPINES external
+     peer SPINES as-number 2
+     peer 192.0.2.10 as-number 12345
+     peer 192.0.2.10 group SPINES
+     ipv4-family unicast
+      peer SPINES enable
+      peer 192.0.2.10 enable
+      peer 192.0.2.10 route-policy DENY_ALL import
+  patch: |
+    system-view
+    bgp 65536
+      undo peer SPINES as-number
+      peer SPINES as-number 2
+      quit
+    q
+    save

--- a/tests/annet/test_patch/huawei_peer_as_number_change_unrelated.yaml
+++ b/tests/annet/test_patch/huawei_peer_as_number_change_unrelated.yaml
@@ -1,0 +1,32 @@
+- vendor: huawei
+  name: only the as-number-changed peer is re-emitted, siblings stay unchanged
+  before: |
+    bgp 65536
+     peer 192.0.2.1 as-number 12345
+     peer 192.0.2.2 as-number 64500
+     ipv4-family unicast
+      peer 192.0.2.1 enable
+      peer 192.0.2.1 route-policy DENY_ALL import
+      peer 192.0.2.2 enable
+      peer 192.0.2.2 route-policy DENY_ALL import
+  after: |
+    bgp 65536
+     peer 192.0.2.1 as-number 2
+     peer 192.0.2.2 as-number 64500
+     ipv4-family unicast
+      peer 192.0.2.1 enable
+      peer 192.0.2.1 route-policy DENY_ALL import
+      peer 192.0.2.2 enable
+      peer 192.0.2.2 route-policy DENY_ALL import
+  patch: |
+    system-view
+    bgp 65536
+      undo peer 192.0.2.1
+      peer 192.0.2.1 as-number 2
+      ipv4-family unicast
+        peer 192.0.2.1 enable
+        peer 192.0.2.1 route-policy DENY_ALL import
+        quit
+      quit
+    q
+    save

--- a/tests/annet/test_patch/huawei_peer_as_number_change_v4.yaml
+++ b/tests/annet/test_patch/huawei_peer_as_number_change_v4.yaml
@@ -1,0 +1,25 @@
+- vendor: huawei
+  before: |
+    bgp 65536
+     peer 192.0.2.1 as-number 12345
+     ipv4-family unicast
+      peer 192.0.2.1 enable
+      peer 192.0.2.1 route-policy DENY_ALL import
+  after: |
+    bgp 65536
+     peer 192.0.2.1 as-number 2
+     ipv4-family unicast
+      peer 192.0.2.1 enable
+      peer 192.0.2.1 route-policy DENY_ALL import
+  patch: |
+    system-view
+    bgp 65536
+      undo peer 192.0.2.1
+      peer 192.0.2.1 as-number 2
+      ipv4-family unicast
+        peer 192.0.2.1 enable
+        peer 192.0.2.1 route-policy DENY_ALL import
+        quit
+      quit
+    q
+    save

--- a/tests/annet/test_patch/huawei_peer_as_number_change_v6.yaml
+++ b/tests/annet/test_patch/huawei_peer_as_number_change_v6.yaml
@@ -1,0 +1,25 @@
+- vendor: huawei
+  before: |
+    bgp 65536
+     peer 2001:db8::1 as-number 12345
+     ipv6-family unicast
+      peer 2001:db8::1 enable
+      peer 2001:db8::1 route-policy DENY_ALL import
+  after: |
+    bgp 65536
+     peer 2001:db8::1 as-number 2
+     ipv6-family unicast
+      peer 2001:db8::1 enable
+      peer 2001:db8::1 route-policy DENY_ALL import
+  patch: |
+    system-view
+    bgp 65536
+      undo peer 2001:db8::1
+      peer 2001:db8::1 as-number 2
+      ipv6-family unicast
+        peer 2001:db8::1 enable
+        peer 2001:db8::1 route-policy DENY_ALL import
+        quit
+      quit
+    q
+    save

--- a/tests/annet/test_patch/huawei_peer_as_number_change_vpn_isolation.yaml
+++ b/tests/annet/test_patch/huawei_peer_as_number_change_vpn_isolation.yaml
@@ -1,0 +1,67 @@
+# The same IP is a peer in two different vpn-instances. Only the peer in
+# vpn-instance ONE changes its as-number; the identically-numbered peer in
+# vpn-instance TWO must be left completely untouched. This locks the
+# per-vpn-instance scoping: a wipe in one block must not leak into another.
+- vendor: huawei
+  before: |
+    bgp 65536
+     ipv4-family vpn-instance ONE
+      peer 192.0.2.1 as-number 12345
+      peer 192.0.2.1 route-policy RP_ONE import
+     ipv4-family vpn-instance TWO
+      peer 192.0.2.1 as-number 10
+      peer 192.0.2.1 route-policy RP_TWO import
+  after: |
+    bgp 65536
+     ipv4-family vpn-instance ONE
+      peer 192.0.2.1 as-number 1234
+      peer 192.0.2.1 route-policy RP_ONE import
+     ipv4-family vpn-instance TWO
+      peer 192.0.2.1 as-number 10
+      peer 192.0.2.1 route-policy RP_TWO import
+  patch: |
+    system-view
+    bgp 65536
+      ipv4-family vpn-instance ONE
+        undo peer 192.0.2.1
+        peer 192.0.2.1 as-number 1234
+        peer 192.0.2.1 route-policy RP_ONE import
+        quit
+      quit
+    q
+    save
+# The same IP is used both as a global BGP peer and as a vpn-instance peer.
+# Only the global peer changes its as-number; the vpn-instance peer must be
+# left completely untouched. This locks the vpn-instance boundary: a global
+# `undo peer <ip>` must not leak into a VPN namespace.
+- vendor: huawei
+  before: |
+    bgp 65536
+     peer 192.0.2.1 as-number 12345
+     ipv4-family unicast
+      peer 192.0.2.1 enable
+      peer 192.0.2.1 route-policy RP_GLOBAL import
+     ipv4-family vpn-instance CUSTOMER
+      peer 192.0.2.1 as-number 10
+      peer 192.0.2.1 route-policy RP_VPN import
+  after: |
+    bgp 65536
+     peer 192.0.2.1 as-number 1234
+     ipv4-family unicast
+      peer 192.0.2.1 enable
+      peer 192.0.2.1 route-policy RP_GLOBAL import
+     ipv4-family vpn-instance CUSTOMER
+      peer 192.0.2.1 as-number 10
+      peer 192.0.2.1 route-policy RP_VPN import
+  patch: |
+    system-view
+    bgp 65536
+      undo peer 192.0.2.1
+      peer 192.0.2.1 as-number 1234
+      ipv4-family unicast
+        peer 192.0.2.1 enable
+        peer 192.0.2.1 route-policy RP_GLOBAL import
+        quit
+      quit
+    q
+    save

--- a/tests/annet/test_patch/huawei_peer_as_number_change_vpn_v4.yaml
+++ b/tests/annet/test_patch/huawei_peer_as_number_change_vpn_v4.yaml
@@ -1,0 +1,27 @@
+# IPv4 peer as-number change where the peer is declared inside a
+# vpn-instance address-family block. Changing it in place is rejected by the
+# device ("The peer already exists in AS ..."), so the peer is recreated with
+# `undo peer <ip>`. That undo wipes the peer's other rows in the same block,
+# so the unchanged route-policy must be re-applied after the recreation.
+- vendor: huawei
+  before: |
+    bgp 65536
+     ipv4-family vpn-instance EXAMPLE
+      peer 192.0.2.1 as-number 12345
+      peer 192.0.2.1 route-policy DENY_ALL import
+  after: |
+    bgp 65536
+     ipv4-family vpn-instance EXAMPLE
+      peer 192.0.2.1 as-number 1234
+      peer 192.0.2.1 route-policy DENY_ALL import
+  patch: |
+    system-view
+    bgp 65536
+      ipv4-family vpn-instance EXAMPLE
+        undo peer 192.0.2.1
+        peer 192.0.2.1 as-number 1234
+        peer 192.0.2.1 route-policy DENY_ALL import
+        quit
+      quit
+    q
+    save

--- a/tests/annet/test_patch/huawei_peer_as_number_change_vpn_v6.yaml
+++ b/tests/annet/test_patch/huawei_peer_as_number_change_vpn_v6.yaml
@@ -1,0 +1,24 @@
+# Same as huawei_peer_as_number_change_vpn_v4 but for an IPv6 peer inside an
+# ipv6-family vpn-instance block.
+- vendor: huawei
+  before: |
+    bgp 65536
+     ipv6-family vpn-instance EXAMPLE
+      peer 2001:db8::1 as-number 12345
+      peer 2001:db8::1 route-policy DENY_ALL import
+  after: |
+    bgp 65536
+     ipv6-family vpn-instance EXAMPLE
+      peer 2001:db8::1 as-number 1234
+      peer 2001:db8::1 route-policy DENY_ALL import
+  patch: |
+    system-view
+    bgp 65536
+      ipv6-family vpn-instance EXAMPLE
+        undo peer 2001:db8::1
+        peer 2001:db8::1 as-number 1234
+        peer 2001:db8::1 route-policy DENY_ALL import
+        quit
+      quit
+    q
+    save

--- a/tests/annet/test_patch/huawei_peer_full_removal.yaml
+++ b/tests/annet/test_patch/huawei_peer_full_removal.yaml
@@ -1,0 +1,46 @@
+- vendor: huawei
+  name: full IP peer removal collapses bgp-level and family-level per-option undos
+  before: |
+    bgp 65536
+     peer 192.0.2.1 as-number 12345
+     peer 192.0.2.1 description some peer
+     peer 192.0.2.2 as-number 64500
+     ipv4-family unicast
+      peer 192.0.2.1 enable
+      peer 192.0.2.1 route-policy DENY_ALL import
+      peer 192.0.2.2 enable
+  after: |
+    bgp 65536
+     peer 192.0.2.2 as-number 64500
+     ipv4-family unicast
+      peer 192.0.2.2 enable
+  patch: |
+    system-view
+    bgp 65536
+      undo peer 192.0.2.1
+      quit
+    q
+    save
+- vendor: huawei
+  name: full IPv6 peer removal collapses bgp-level and family-level per-option undos
+  before: |
+    bgp 65536
+     peer 2001:db8::1 as-number 12345
+     peer 2001:db8::1 description some peer
+     peer 2001:db8::2 as-number 64500
+     ipv6-family unicast
+      peer 2001:db8::1 enable
+      peer 2001:db8::1 route-policy DENY_ALL import
+      peer 2001:db8::2 enable
+  after: |
+    bgp 65536
+     peer 2001:db8::2 as-number 64500
+     ipv6-family unicast
+      peer 2001:db8::2 enable
+  patch: |
+    system-view
+    bgp 65536
+      undo peer 2001:db8::1
+      quit
+    q
+    save

--- a/tests/annet/test_patch/huawei_peer_full_removal_vpn.yaml
+++ b/tests/annet/test_patch/huawei_peer_full_removal_vpn.yaml
@@ -1,0 +1,27 @@
+# Full removal of a peer declared inside a vpn-instance block. `undo peer
+# <ip>` wipes every row for that peer, so the family-level per-option undos
+# are redundant (and would error against a nonexistent peer). The patch
+# collapses to a single `undo peer <ip>`. A sibling peer in the same block is
+# untouched.
+- vendor: huawei
+  before: |
+    bgp 65536
+     ipv4-family vpn-instance EXAMPLE
+      peer 192.0.2.1 as-number 12345
+      peer 192.0.2.1 route-policy DENY_ALL import
+      peer 192.0.2.2 as-number 5
+      peer 192.0.2.2 route-policy KEEP import
+  after: |
+    bgp 65536
+     ipv4-family vpn-instance EXAMPLE
+      peer 192.0.2.2 as-number 5
+      peer 192.0.2.2 route-policy KEEP import
+  patch: |
+    system-view
+    bgp 65536
+      ipv4-family vpn-instance EXAMPLE
+        undo peer 192.0.2.1
+        quit
+      quit
+    q
+    save

--- a/tests/annet/test_patch/huawei_peer_full_removal_vpn_isolation.yaml
+++ b/tests/annet/test_patch/huawei_peer_full_removal_vpn_isolation.yaml
@@ -1,0 +1,29 @@
+# Removing a peer from one vpn-instance must NOT touch the same IP in
+# another vpn-instance. Mirrors a lab transcript: `undo peer 192.0.2.1`
+# issued inside vpn-instance EXAMPLE2 wipes only that VRF's peer; the
+# identically-numbered peer in EXAMPLE (with its route-policy) survives.
+# This locks the per-vpn-instance scoping for the removal case — it is
+# critical that a peer in a different VRF is never deleted.
+- vendor: huawei
+  before: |
+    bgp 65536
+     ipv4-family vpn-instance EXAMPLE
+      peer 192.0.2.1 as-number 3
+      peer 192.0.2.1 route-policy DENY_ALL export
+     ipv4-family vpn-instance EXAMPLE2
+      peer 192.0.2.1 as-number 3
+  after: |
+    bgp 65536
+     ipv4-family vpn-instance EXAMPLE
+      peer 192.0.2.1 as-number 3
+      peer 192.0.2.1 route-policy DENY_ALL export
+     ipv4-family vpn-instance EXAMPLE2
+  patch: |
+    system-view
+    bgp 65536
+      ipv4-family vpn-instance EXAMPLE2
+        undo peer 192.0.2.1
+        quit
+      quit
+    q
+    save

--- a/tests/annet/test_patch/huawei_peer_no_as_number_change.yaml
+++ b/tests/annet/test_patch/huawei_peer_no_as_number_change.yaml
@@ -1,0 +1,24 @@
+- vendor: huawei
+  name: route-policy rename with as-number unchanged produces no undo peer and no re-emit
+  before: |
+    bgp 65536
+     peer 192.0.2.1 as-number 12345
+     ipv4-family unicast
+      peer 192.0.2.1 enable
+      peer 192.0.2.1 route-policy DENY_ALL import
+  after: |
+    bgp 65536
+     peer 192.0.2.1 as-number 12345
+     ipv4-family unicast
+      peer 192.0.2.1 enable
+      peer 192.0.2.1 route-policy PERMIT_ALL import
+  patch: |
+    system-view
+    bgp 65536
+      ipv4-family unicast
+        undo peer 192.0.2.1 route-policy DENY_ALL import
+        peer 192.0.2.1 route-policy PERMIT_ALL import
+        quit
+      quit
+    q
+    save

--- a/tests/annet/test_patch/huawei_undo_peer2.yaml
+++ b/tests/annet/test_patch/huawei_undo_peer2.yaml
@@ -9,7 +9,6 @@
   patch: |
     system-view
     bgp 64215.89
-      undo peer fe80::c1:d1 description
       undo peer fe80::c1:d1
       quit
     q
@@ -24,7 +23,6 @@
   patch: |
     system-view
     bgp 64215.89
-      undo peer fe80::c1:d1 bfd enable
       undo peer fe80::c1:d1
       quit
     q
@@ -56,10 +54,6 @@
   patch: |
     system-view
     bgp 65000.65001
-      ipv6-family unicast
-        undo peer fe80::e999:d1 group TOR
-        undo peer fe80::e999:d1 enable
-        quit
       undo peer fe80::e999:d1
       quit
     q

--- a/tests/annet/test_patch/huawei_undo_peer_group_as_number.yaml
+++ b/tests/annet/test_patch/huawei_undo_peer_group_as_number.yaml
@@ -10,13 +10,13 @@
   patch: |
     system-view
     bgp 64514.0
+      undo peer CD_LU as-number
       ipv4-family vpn-instance EXAMPLE3
         undo peer CD_V4_EXAMPLE3 as-number
         quit
       ipv6-family vpn-instance EXAMPLE3
         undo peer CD_V6_EXAMPLE3 as-number
         quit
-      undo peer CD_LU as-number
       quit
     q
     save


### PR DESCRIPTION
## Summary

Huawei does not allow changing the AS number of an existing IP BGP peer in place:

```
[~huawei-sw] peer 1.1.1.1 as-number 2
Error: The peer already exists in AS 12345.
```

There is also no `undo peer X as-number Y` command for an IP peer — you
can't surgically remove only the as-number. The only way to change an IP
peer's as-number is to fully recreate the peer:

```
undo peer 1.1.1.1
peer 1.1.1.1 as-number 12345
```

`undo peer X` destroys every per-peer setting under every family block,
so the nested configuration must be re-applied after recreation.

After `undo peer X`, any per-option undo on that peer fails:

```
[~...-bgp]undo peer 1.1.1.1
Warning: All the configurations related to the BGP peer will be deleted. Continue? [Y/N]:y
[*...-bgp] ipv4-family unicast
[*...-bgp-af-ipv4]undo peer 1.1.1.1 enable
Error: The peer session does not exist.
```

The goal is for annet to produce clean patches: no commands that the device will reject, even if the deployment runner would mask the errors.
This drives both the ordering choices and the diff_logic.

Today, given the running config:

```
bgp 65536
  peer 1.1.1.1 as-number 12345
  ipv4-family unicast
    peer 1.1.1.1 enable
    peer 1.1.1.1 route-policy DENY_ALL import
    quit
  quit
```

and a target that changes only the as-number to `1234`, annet produces a patch the device rejects:

```
bgp 65536
  peer 1.1.1.1 as-number 1234      # rejected: peer already exists in AS 12345
  undo peer 1.1.1.1
  quit
```

After this PR:

```
bgp 65536
  undo peer 1.1.1.1
  peer 1.1.1.1 as-number 1234
  ipv4-family unicast
    peer 1.1.1.1 enable
    peer 1.1.1.1 route-policy DENY_ALL import
    quit
  quit
```

A full peer deletion is also cleaner. Before:

```
bgp 65536
  undo peer 1.1.1.1 description    # redundant — peer about to be wiped
  undo peer 1.1.1.1
  ipv4-family unicast
    undo peer 1.1.1.1 enable        # redundant — peer no longer exists
    undo peer 1.1.1.1 route-policy DENY_ALL import
    quit
  quit
```

After:

```
bgp 65536
  undo peer 1.1.1.1
  quit
```

### Peers under a VPN address-family

A `peer <ip>` can also be declared inside a `vpn-instance` block (`ipv4-family vpn-instance EXAMPLE`). The same recreate-and-re-apply logic applies, scoped to that block — `undo peer <ip>` is emitted inside the vpn-instance and only wipes that block's rows.

As-number change of a VPN peer (the unchanged route-policy is re-applied after the wipe):

```
bgp 65536
  ipv4-family vpn-instance EXAMPLE
    undo peer 192.0.2.1
    peer 192.0.2.1 as-number 1234
    peer 192.0.2.1 route-policy DENY_ALL import
    quit
  quit
```

Full removal of a VPN peer collapses to a single in-block `undo peer <ip>` (a sibling peer in the same block is untouched):

```
bgp 65536
  ipv4-family vpn-instance EXAMPLE
    undo peer 192.0.2.1
    quit
  quit
```

The vpn-instance boundary is a separate peer namespace: the same IP can be a
peer in two different vpn-instances, or both a global peer and a VPN peer,
and a wipe in one scope must never leak into another. These isolation cases
need their full multi-VRF before/after to make sense, so see the test
fixtures rather than an excerpt here:
[`huawei_peer_as_number_change_vpn_isolation.yaml`](tests/annet/test_patch/huawei_peer_as_number_change_vpn_isolation.yaml)
and
[`huawei_peer_full_removal_vpn_isolation.yaml`](tests/annet/test_patch/huawei_peer_full_removal_vpn_isolation.yaml).

## Scope

This PR fixes **IP peer** as-number change and full removal, whether the
peer is declared at the bgp top level or inside an address-family /
vpn-instance block (e.g. `ipv4-family vpn-instance EXAMPLE`). 

Peer-group removal is out of scope.

## Changes

1. **`annet/rulebook/texts/huawei.order`** — inside the `bgp` block, add
   two end-anchored rules above the family sub-block:
   - `undo peer ~/[^\s]+$/ %order_reverse` — matches exactly 3-token
     `undo peer X` (IP peer destroy). The `~/regex/` escape hatch is used
     to inject a literal `$` end-anchor; otherwise `undo peer *` would be
     a greedy prefix pattern shadowing every more-specific `undo peer …`
     rule deeper in the file.
   - `undo peer * as-number %order_reverse` — matches `undo peer X
     as-number` (4-token, peer-group as-number undo). Terminates at the
     literal `as-number`, so it doesn't bleed onto `undo peer X
     connect-interface` etc.

   Other per-option `undo peer …` rules (`description`, `* * *`, `* *`)
   stay at their original after-family positions.

2. **`annet/rulebook/texts/huawei.rul`** — attach
   `%diff_logic=annet.rulebook.huawei.bgp.reapply_after_as_number_change`
   to the `bgp` rule.

3. **`annet/rulebook/huawei/bgp.py`** — new `reapply_after_as_number_change`
   that runs at diff-build time over the `bgp` subtree, recursing block by
   block (`_rewrite_block`). The `peer <ip> as-number …` row can live at the
   bgp top level *or* inside a family / vpn-instance block, so each block
   computes:
   - `wiped` — IPs whose `peer <ip> as-number …` row is in this block's `old`
     but not `new` (full removal *or* as-number value change), unioned with
     wiped IPs inherited from enclosing blocks (a top-level `undo peer <ip>`
     wipes the global family blocks too). `huawei.bgp.peer` emits `undo peer
     <ip>` for these.
   - `recreated` — subset that still has a `peer <ip> as-number …` row in
     `new` (renumbered, not deleted).

   And rewrites the diff:
   - Drops every `peer <ip> …` REMOVED row whose IP is in `wiped`
     (redundant after `undo peer <ip>` and would error against a nonexistent
     peer) — except the REMOVED `peer <ip> as-number Y` row, which is kept as
     the trigger that drives `huawei.bgp.peer` to emit `undo peer <ip>`.
   - Flips `peer <ip> …` AFFECTED rows to ADDED when the IP is in
     `recreated`, so the re-emit happens after `undo peer <ip>`.
   - Resets the inherited sets at a `vpn-instance` boundary: a vpn-instance
     peer is a separate namespace and its `undo peer <ip>` only wipes within
     that block, so an identically-numbered peer in another vpn-instance is
     left untouched.

   No `huawei.order` change is needed for the vpn-instance case — ordering
   inside a family block already emits `undo peer` before `peer as-number`
   before the re-applied options.

## Tests

- **Two pre-existing golden patches** updated:
  - `huawei_undo_peer_group_as_number.yaml` — `undo peer CD_LU as-number`
    moves from after-family to before-family (caught by the new 4-token
    end-anchored rule).
  - `huawei_undo_peer2.yaml` (#1, #2, #4) — previously asserted redundant
    per-option undos that would error against a wiped peer; now assert
    the cleaner single `undo peer X` output.
- **Six new YAMLs** for top-level peers in `tests/annet/test_patch/`
  covering IPv4 / IPv6 as-number changes, peer-group as-number rename
  (regression for the 4-token order rule), an unrelated sibling peer
  (untouched), a route-policy rename (no spurious undo), and full peer
  removal for both v4 and v6.
- **Five new YAMLs** for peers declared inside a vpn-instance block:
  IPv4 / IPv6 as-number change (unchanged route-policy re-applied), full
  removal (collapses to a single `undo peer <ip>`, sibling peer untouched),
  and three isolation cases proving a wipe in one scope never leaks into
  another:
  - same IP in two vpn-instances, only ONE's as-number changes;
  - same IP as a global peer and a vpn-instance peer, only the global peer's
    as-number changes (the VPN peer is untouched);
  - same IP in two vpn-instances (mirroring a lab transcript), only one
    VRF's peer is removed (the other VRF's peer, with its route-policy,
    survives).
- All addresses are from the IANA documentation pools `192.0.2.0/24` and
  `2001:db8::/32`.
