### PR TITLE
add `py.typed`, for real this time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
             ]
         ),
         package_data={
-            "annet": ["configs/*"],
+            "annet": ["configs/*", "py.typed"],
             "annet.rulebook": ["texts/*.rul", "texts/*.order", "texts/*.deploy"],
             "annet.annlib.netdev.devdb": ["data/*.json"],
         },


### PR DESCRIPTION
`py.typed` has to be added to package data, otherwise it will be discarded and all users that install our releases will not see it