### PR TITLE
feature: add support for circuits and trace iface in netbox adapter

### DIFF
--- a/annet/adapters/netbox/v37/storage.py
+++ b/annet/adapters/netbox/v37/storage.py
@@ -123,6 +123,15 @@ class NetboxV37Adapter(
         raw_groups = self.netbox.ipam_all_fhrp_groups_by_id(id=list(ids))
         return self.convert_fhrp_groups(raw_groups.results)
 
+    def get_circuit(self, circuit_id: int) -> api_models.Circuit:
+        return self.netbox.circuit(circuit_id)
+
+    def list_circuits(self, query: dict[str, list[str]]) -> list[api_models.Circuit]:
+        return self.netbox.circuits_all(**query).results
+
+    def trace_interface(self, iface_id: int) -> list[api_models.TraceTuple]:
+        return self.netbox.dcim_interface_trace(iface_id)
+
 
 class NetboxStorageV37(
     BaseNetboxStorage[

--- a/annet/adapters/netbox/v41/storage.py
+++ b/annet/adapters/netbox/v41/storage.py
@@ -115,6 +115,15 @@ class NetboxV41Adapter(
         raw_groups = self.netbox.ipam_all_fhrp_groups_by_id(id=list(ids))
         return self.convert_fhrp_groups(raw_groups.results)
 
+    def get_circuit(self, circuit_id: int) -> api_models.Circuit:
+        return self.netbox.circuit(circuit_id)
+
+    def list_circuits(self, query: dict[str, list[str]]) -> list[api_models.Circuit]:
+        return self.netbox.circuits_all(**query).results
+
+    def trace_interface(self, iface_id: int) -> list[api_models.TraceTuple]:
+        return self.netbox.dcim_interface_trace(iface_id)
+
 
 class NetboxStorageV41(
     BaseNetboxStorage[NetboxDeviceV41, InterfaceV41, IpAddressV41, PrefixV41, FHRPGroupV41, FHRPGroupAssignmentV41]

--- a/annet/adapters/netbox/v42/storage.py
+++ b/annet/adapters/netbox/v42/storage.py
@@ -123,6 +123,15 @@ class NetboxV42Adapter(
         raw_groups = self.netbox.ipam_all_fhrp_groups_by_id(id=list(ids))
         return self.convert_fhrp_groups(raw_groups.results)
 
+    def get_circuit(self, circuit_id: int) -> api_models.Circuit:
+        return self.netbox.circuit(circuit_id)
+
+    def list_circuits(self, query: dict[str, list[str]]) -> list[api_models.Circuit]:
+        return self.netbox.circuits_all(**query).results
+
+    def trace_interface(self, iface_id: int) -> list[api_models.TraceTuple]:
+        return self.netbox.dcim_interface_trace(iface_id)
+
 
 class NetboxStorageV42(
     BaseNetboxStorage[

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
         },
         extras_require={
             "netbox": [
-                "annetbox[sync]>=0.11.1",
+                "annetbox[sync]>=1.0.0",
                 "requests-cache>=1.2.1",
             ],
         },


### PR DESCRIPTION
Bumps annetbox version to `annetbox[sync]>=1.0.0`
This requires https://github.com/annetutil/annet/pull/559 to be merged first.

New methods:
  * get_circuit
  * list_circuits
  * trace_interface