### PR TITLE
feat: add ?/{regex}/ non-capturing match placeholder to rulebook syntax

### DIFF
--- a/annet/annlib/rbparser/syntax.py
+++ b/annet/annlib/rbparser/syntax.py
@@ -63,6 +63,24 @@ def compile_row_regexp(row, flags=0):
         row = row.replace("(?i)", "")
         flags |= re.IGNORECASE
 
+    # ?/{regex}/ -> (?:{regex}), a non-capturing match against an arbitrary regexp.
+    # Unlike */{regex}/ (which captures a single word) and ~/{regex}/, nothing is
+    # captured into a group. The regexp is protected from the placeholder
+    # substitutions below, i.e. *, (...) inside it stay part of the regexp instead
+    # of being treated as placeholders. The ? prefix is glued to the /, so this
+    # form does not clash with literal slashes (e.g. in interface names like
+    # Eth0/0/1) nor with the */{regex}/ and ~/{regex}/ forms.
+    protected: list[str] = []
+
+    def _protect(match: re.Match) -> str:
+        # Turn the default groups inside the regexp into non-capturing ones, so the
+        # ?/{regex}/ form only matches and captures nothing.
+        regexp = re.sub(r"\(([^\?])", r"(?:\1", match.group(1))
+        protected.append(regexp)
+        return f"\x00{len(protected) - 1}\x00"
+
+    row = re.sub(r"(?:^|(?<=\s))\?/(((?!\?/).)+)/", _protect, row)
+
     if "*" in row:
         row = re.sub(r"\(([^\?])", r"(?:\1", row)  # Все дефолтные группы превратить в non-captured
         row = re.sub(r"\*/(\S+)/", r"(\1)", row)  # */{regex_one_word}/ -> ({regex_one_word})
@@ -82,6 +100,8 @@ def compile_row_regexp(row, flags=0):
     else:
         row += r"(?:\s|$)"
     row = re.sub(r"\s+", r"\\s+", row)
+    if protected:
+        row = re.sub(r"\x00(\d+)\x00", lambda m: f"(?:{protected[int(m.group(1))]})", row)
     return re.compile("^" + row, flags=flags)
 
 

--- a/annet/annlib/rbparser/syntax.py
+++ b/annet/annlib/rbparser/syntax.py
@@ -69,7 +69,8 @@ def compile_row_regexp(row, flags=0):
     # substitutions below, i.e. *, (...) inside it stay part of the regexp instead
     # of being treated as placeholders. The ? prefix is glued to the /, so this
     # form does not clash with literal slashes (e.g. in interface names like
-    # Eth0/0/1) nor with the */{regex}/ and ~/{regex}/ forms.
+    # Eth0/0/1) nor with the */{regex}/ and ~/{regex}/ forms. The first / after
+    # ?/ closes the placeholder, so the regexp itself cannot contain a literal /.
     protected: list[str] = []
 
     def _protect(match: re.Match) -> str:
@@ -79,7 +80,7 @@ def compile_row_regexp(row, flags=0):
         protected.append(regexp)
         return f"\x00{len(protected) - 1}\x00"
 
-    row = re.sub(r"(?:^|(?<=\s))\?/(((?!\?/).)+)/", _protect, row)
+    row = re.sub(r"(?:^|(?<=\s))\?/([^/]+)/", _protect, row)
 
     if "*" in row:
         row = re.sub(r"\(([^\?])", r"(?:\1", row)  # Все дефолтные группы превратить в non-captured
@@ -95,8 +96,11 @@ def compile_row_regexp(row, flags=0):
     elif row.endswith("..."):
         row = row[:-3]
     elif "~/" in row:
-        # ~/{regex}/ -> {regex}, () не нужны поскольку уже (?:) - non-captured
-        row = re.sub(r"~/(((?!~/).)+)/", r"\1", row)
+        # ~/{regex}/ -> (?:{regex}), a non-capturing match. The first / after ~/
+        # closes the placeholder (so the regexp cannot contain a literal /), and the
+        # (?:) wrap keeps a top-level alternation (a|b) from leaking into the rest of
+        # the row.
+        row = re.sub(r"~/([^/]+)/", r"(?:\1)", row)
     else:
         row += r"(?:\s|$)"
     row = re.sub(r"\s+", r"\\s+", row)

--- a/docs/usage/acl.rst
+++ b/docs/usage/acl.rst
@@ -46,6 +46,26 @@ Placeholders can match by regular expressions:
     ip routing vrf ~/(?!MEth|MGMT)/
 
 
+There are three regular-expression forms:
+
+- ``*/{regex}/`` matches a single word and captures it into a group;
+- ``~/{regex}/`` matches without capturing, but is ignored when the row ends
+  with the ``~`` or ``...`` placeholder, and its contents are still subject to
+  placeholder substitution;
+- ``?/{regex}/`` matches without capturing, and unlike ``~/{regex}/`` can be
+  combined with a trailing ``~`` placeholder; any ``*`` or ``(...)`` inside the
+  regex stay part of the regex instead of being treated as placeholders.
+
+For example, to match ``0 permit udp any 10.212.32.224 0.0.0.31``:
+
+.. code-block:: text
+
+    ?/(.*)/permit ~
+
+The ``?`` is attached to the ``/``, so this form does not clash with literal
+slashes (for example in interface names such as ``Eth0/0/1``).
+
+
 If you want a case-insensitive match, you can specify it with the ``(?i)`` prefix, for example:
 
 .. code-block:: text

--- a/tests/annet/test_syntax.py
+++ b/tests/annet/test_syntax.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 import pytest
 
-from annet.annlib.rbparser.syntax import parse_text
+from annet.annlib.rbparser.syntax import compile_row_regexp, parse_text
 
 
 @pytest.mark.parametrize(
@@ -73,3 +73,31 @@ def test_parse_text(raw_rule, expected) -> None:
         )
         == expected
     )
+
+
+@pytest.mark.parametrize(
+    "row, line, should_match",
+    [
+        # ?/{regex}/ matches without capturing, and the regexp is protected from
+        # placeholder substitution (the inner * and (...) stay part of the regexp).
+        ("?/(.*)/permit ~", "0 permit udp any 10.212.32.224 0.0.0.31", True),
+        ("?/(.*)/permit ~", "0 deny udp any", False),
+        ("?/permit|deny/ ~", "permit udp any", True),
+        ("?/permit|deny/ ~", "remark something", False),
+        ("ip ?/v4|v6/ route ~", "ip v6 route ::/0", True),
+        ("ip ?/v4|v6/ route ~", "ip v8 route x", False),
+        # the ? prefix keeps literal slashes (e.g. interface names) intact
+        ("interface Eth0/0/1", "interface Eth0/0/1", True),
+        ("interface Eth0/0/1", "interface Eth0X0X1", False),
+        # combines with the case-insensitive prefix
+        ("(?i)?/INT.*/ ~", "Interface foo", True),
+    ],
+)
+def test_compile_row_regexp_noncapturing_match(row, line, should_match) -> None:
+    assert bool(compile_row_regexp(row).match(line)) is should_match
+
+
+def test_compile_row_regexp_noncapturing_has_no_extra_groups() -> None:
+    # Only the trailing `~` contributes a capture group; ?/(.*)/ captures nothing.
+    assert compile_row_regexp("?/(.*)/permit ~").groups == 1
+    assert compile_row_regexp("?/(.*)/permit").groups == 0

--- a/tests/annet/test_syntax.py
+++ b/tests/annet/test_syntax.py
@@ -76,25 +76,50 @@ def test_parse_text(raw_rule, expected) -> None:
 
 
 @pytest.mark.parametrize(
-    "row, line, should_match",
+    "row, expected_pattern, line, should_match",
     [
+        # --- ?/{regex}/ ---------------------------------------------------------
         # ?/{regex}/ matches without capturing, and the regexp is protected from
         # placeholder substitution (the inner * and (...) stay part of the regexp).
-        ("?/(.*)/permit ~", "0 permit udp any 10.212.32.224 0.0.0.31", True),
-        ("?/(.*)/permit ~", "0 deny udp any", False),
-        ("?/permit|deny/ ~", "permit udp any", True),
-        ("?/permit|deny/ ~", "remark something", False),
-        ("ip ?/v4|v6/ route ~", "ip v6 route ::/0", True),
-        ("ip ?/v4|v6/ route ~", "ip v8 route x", False),
-        # the ? prefix keeps literal slashes (e.g. interface names) intact
-        ("interface Eth0/0/1", "interface Eth0/0/1", True),
-        ("interface Eth0/0/1", "interface Eth0X0X1", False),
-        # combines with the case-insensitive prefix
-        ("(?i)?/INT.*/ ~", "Interface foo", True),
+        ("?/(.*)/permit ~", r"^(?:(?:.*))permit\s+(.+)", "0 permit udp any 10.212.32.224 0.0.0.31", True),
+        ("?/(.*)/permit ~", r"^(?:(?:.*))permit\s+(.+)", "0 deny udp any", False),
+        ("?/permit|deny/ ~", r"^(?:permit|deny)\s+(.+)", "permit udp any", True),
+        ("?/permit|deny/ ~", r"^(?:permit|deny)\s+(.+)", "remark something", False),
+        ("ip ?/v4|v6/ route ~", r"^ip\s+(?:v4|v6)\s+route\s+(.+)", "ip v6 route ::/0", True),
+        ("ip ?/v4|v6/ route ~", r"^ip\s+(?:v4|v6)\s+route\s+(.+)", "ip v8 route x", False),
+        # without ? prefix literal slashes are treated like regular characters
+        ("interface Eth0/0/1", r"^interface\s+Eth0/0/1(?:\s|$)", "interface Eth0/0/1", True),
+        ("interface Eth0/0/1", r"^interface\s+Eth0/0/1(?:\s|$)", "interface Eth0X0X1", False),
+        # combines with the case-insensitive prefix (which is stripped into a flag)
+        ("(?i)?/INT.*/ ~", r"^(?:INT.*)\s+(.+)", "Interface foo", True),
+        # glued to following text, no trailing ~: still closes at the first /
+        ("?/(.*)/permit", r"^(?:(?:.*))permit(?:\s|$)", "permit", True),
+        ("?/(.*)/permit", r"^(?:(?:.*))permit(?:\s|$)", "deny", False),
+        # --- ~/{regex}/ ---------------------------------------------------------
+        # ~/{regex}/ is wrapped in (?:...) so a top-level alternation does not leak
+        # into the rest of the row.
+        ("~/a|b/ x", r"^(?:a|b)\s+x", "a x", True),
+        ("~/a|b/ x", r"^(?:a|b)\s+x", "b x", True),
+        ("~/a|b/ x", r"^(?:a|b)\s+x", "c x", False),
+        # the regexp ends at its own first /, so literal slashes after it stay intact
+        ("~/interface|if/ eth0/1/2", r"^(?:interface|if)\s+eth0/1/2", "if eth0/1/2", True),
+        ("~/interface|if/ eth0/1/2", r"^(?:interface|if)\s+eth0/1/2", "if eth0X1X2", False),
+        # several ~/.../ on one row do not bleed into each other
+        ("~/a|b/ x ~/c|d/", r"^(?:a|b)\s+x\s+(?:c|d)", "a x d", True),
+        ("~/a|b/ x ~/c|d/", r"^(?:a|b)\s+x\s+(?:c|d)", "a x e", False),
+        # --- ?/{regex}/ and ~/{regex}/ mixed ------------------------------------
+        # several placeholders on one row do not bleed into each other: each one
+        # ends at its own first /, and the ~/x/ in between stays intact.
+        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(?:x)\s+(?:y|z)", "a x y", True),
+        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(?:x)\s+(?:y|z)", "b x z", True),
+        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(?:x)\s+(?:y|z)", "a q y", False),
+        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(?:x)\s+(?:y|z)", "a x q", False),
     ],
 )
-def test_compile_row_regexp_noncapturing_match(row, line, should_match) -> None:
-    assert bool(compile_row_regexp(row).match(line)) is should_match
+def test_compile_row_regexp(row, expected_pattern, line, should_match) -> None:
+    compiled = compile_row_regexp(row)
+    assert compiled.pattern == expected_pattern
+    assert bool(compiled.match(line)) is should_match
 
 
 def test_compile_row_regexp_noncapturing_has_no_extra_groups() -> None:


### PR DESCRIPTION
Adds a new rulebook placeholder form `?/{regex}/` that matches an arbitrary regular expression without capturing it into a group.

The existing forms `*/{regex}/` (captures one word) and `~/{regex}/` couldn't match an arbitrary regexp anywhere in the row while still combining with a trailing `~`. Writing the regexp inline also failed because the `*` and `(...)` placeholder substitutions run over the whole row, reinterpreting characters inside the user's own regexp.

`compile_row_regexp` now extracts `?/{regex}/` segments before placeholder processing, protects their contents, and restores them wrapped in a non-capturing group. The `?` is glued to the `/`, so the form does not clash with literal slashes (e.g. interface names like `Eth0/0/1`) nor with the existing `*/{regex}/` and `~/{regex}/` forms.