### PR TITLE
fix: allow `Device` objects to be passed directly to `Devices`

### DIFF
--- a/annet/adapters/file/provider.py
+++ b/annet/adapters/file/provider.py
@@ -150,11 +150,18 @@ class Devices:
     def __post_init__(self):
         if isinstance(self.devices, list):
             devices = []
-            for dev in self.devices:
-                try:
-                    devices.append(Device(dev=DeviceStorage(**dev)))
-                except Exception as e:
-                    raise Exception("unable to parse %s as Device: %s" % (dev, e))
+
+            for dev_params in self.devices:
+                if isinstance(dev_params, Device):
+                    dev = dev_params
+                else:
+                    try:
+                        dev = Device(dev=DeviceStorage(**dev_params))
+                    except Exception as e:
+                        raise Exception(f"unable to parse {dev!r} as Device") from e
+
+                devices.append(dev)
+
             self.devices = devices
 
 


### PR DESCRIPTION
Fixes #388.

```python
devs = Devices(
    devices=[
        Device(dev=DeviceStorage(fqdn="1.1.1.1", vendor="cisco")),
        Device(dev=DeviceStorage(fqdn="1.1.1.2", vendor="juniper")),
    ]
)
```
is now allowed along with
```python
devs = Devices(
    devices=[
        {"fqdn": "1.1.1.1", "vendor": "cisco"},
        {"fqdn": "1.1.1.2", "vendor": "juniper"},
    ]
)
```