### PR TITLE
fix: netbox v37 adapter was broken with annet v4.0.0

### DIFF
--- a/annet/adapters/netbox/common/models.py
+++ b/annet/adapters/netbox/common/models.py
@@ -57,8 +57,8 @@ class DeviceIp(DumpableView):
 
 @dataclass
 class Vrf(Entity):
-    description: str
     rd: str | None  # netbox get null if not present
+    description: str | None = None  # netbox v37 does not include this field in VrfBrief
 
 
 @dataclass

--- a/annet/adapters/netbox/v37/models.py
+++ b/annet/adapters/netbox/v37/models.py
@@ -14,6 +14,7 @@ from annet.adapters.netbox.common.models import (
     Label,
     NetboxDevice,
     Prefix,
+    Vrf,
 )
 
 
@@ -45,7 +46,7 @@ class FHRPGroupAssignmentV37(FHRPGroupAssignment[FHRPGroupV37]):
 
 @dataclass
 class InterfaceV37(Interface[IpAddressV37, FHRPGroupAssignmentV37]):
-    def _add_new_addr(self, address_mask: str, vrf: Entity | None, family: IpFamily) -> None:
+    def _add_new_addr(self, address_mask: str, vrf: Vrf | None, family: IpFamily) -> None:
         self.ip_addresses.append(
             IpAddressV37(
                 id=0,

--- a/annet/adapters/netbox/v37/storage.py
+++ b/annet/adapters/netbox/v37/storage.py
@@ -2,12 +2,13 @@ import ssl
 from typing import Callable
 
 from adaptix import P
-from adaptix.conversion import get_converter, link, link_constant, link_function
+from adaptix.conversion import allow_unlinked_optional, get_converter, link, link_constant, link_function
 from annetbox.v37 import client_sync
 from annetbox.v37 import models as api_models
 from requests import Session
 
 from annet.adapters.netbox.common.adapter import NetboxAdapter, get_device_breed, get_device_hw
+from annet.adapters.netbox.common.models import Vrf
 from annet.adapters.netbox.common.storage_base import BaseNetboxStorage
 from annet.storage import Storage
 
@@ -62,6 +63,7 @@ class NetboxV37Adapter(
                 link_constant(P[InterfaceV37].ip_addresses, factory=list),
                 link_constant(P[InterfaceV37].fhrp_groups, factory=list),
                 link_constant(P[InterfaceV37].lag_min_links, value=None),
+                allow_unlinked_optional(P[Vrf].description),
             ],
         )
         self.convert_ip_addresses = get_converter(
@@ -69,11 +71,11 @@ class NetboxV37Adapter(
             list[IpAddressV37],
             recipe=[
                 link_constant(P[IpAddressV37].prefix, value=None),
+                allow_unlinked_optional(P[Vrf].description),
             ],
         )
         self.convert_ip_prefixes = get_converter(
-            list[api_models.Prefix],
-            list[PrefixV37],
+            list[api_models.Prefix], list[PrefixV37], recipe=[allow_unlinked_optional(P[Vrf].description)]
         )
         self.convert_fhrp_group_assignments = get_converter(
             list[api_models.FHRPGroupAssignmentBrief],


### PR DESCRIPTION
I have cleaned up the `VrfBrief.description` field in annetbox v37 model https://github.com/annetutil/annetbox/pull/71/changes/8a03d32f98dce50126a5cc68c8bdb9414e4fdad1, since ts indeed is [not returned by the netbox 3.7](https://pastebin.com/39R4zFGt)

But I completely missed that `common.models.Vrf` adapter class (which should hide differences between api versions of netbox) has this field as a mandatory one: https://github.com/annetutil/annet/commit/64857efabe615ffd2f60707ea622de2768adfe46

This lead to annet v4.0.0 being broken with netbox 3.7 entirely due to adaptix not being able to resolve the description field.