### PR TITLE
fix: make _make_reverse handle ?/regex/ and ~/regex/ placeholders correctly

### DIFF
--- a/annet/annlib/rbparser/syntax.py
+++ b/annet/annlib/rbparser/syntax.py
@@ -63,24 +63,25 @@ def compile_row_regexp(row, flags=0):
         row = row.replace("(?i)", "")
         flags |= re.IGNORECASE
 
-    # ?/{regex}/ -> (?:{regex}), a non-capturing match against an arbitrary regexp.
-    # Unlike */{regex}/ (which captures a single word) and ~/{regex}/, nothing is
-    # captured into a group. The regexp is protected from the placeholder
-    # substitutions below, i.e. *, (...) inside it stay part of the regexp instead
-    # of being treated as placeholders. The ? prefix is glued to the /, so this
-    # form does not clash with literal slashes (e.g. in interface names like
-    # Eth0/0/1) nor with the */{regex}/ and ~/{regex}/ forms. The first / after
-    # ?/ closes the placeholder, so the regexp itself cannot contain a literal /.
-    protected: list[str] = []
+    # ?/{regex}/ and ~/{regex}/ both match an arbitrary regexp. ?/{regex}/ is a
+    # non-capturing match (nothing reaches a group), while ~/{regex}/ captures its
+    # whole matched span into a single group (like */{regex}/ but spanning more than
+    # one word). Both are pulled out before the placeholder substitutions below so
+    # that *, (...) inside the user's own regexp stay part of the regexp instead of
+    # being reinterpreted, and so any groups the user wrote inside collapse to
+    # non-capturing -- only the ~/ wrapper itself captures. The ? / ~ prefix is glued
+    # to the /, so neither form clashes with literal slashes (e.g. interface names
+    # like Eth0/0/1). The first / after the prefix closes the placeholder, so the
+    # regexp itself cannot contain a literal / (hence [^/]+).
+    protected: list[tuple[str, bool]] = []  # (regexp, captures)
 
     def _protect(match: re.Match) -> str:
-        # Turn the default groups inside the regexp into non-capturing ones, so the
-        # ?/{regex}/ form only matches and captures nothing.
-        regexp = re.sub(r"\(([^\?])", r"(?:\1", match.group(1))
-        protected.append(regexp)
+        captures = match.group(1) == "~"
+        regexp = re.sub(r"\(([^\?])", r"(?:\1", match.group(2))
+        protected.append((regexp, captures))
         return f"\x00{len(protected) - 1}\x00"
 
-    row = re.sub(r"(?:^|(?<=\s))\?/([^/]+)/", _protect, row)
+    row = re.sub(r"(?:^|(?<=\s))([?~])/([^/]+)/", _protect, row)
 
     if "*" in row:
         row = re.sub(r"\(([^\?])", r"(?:\1", row)  # Все дефолтные группы превратить в non-captured
@@ -95,17 +96,16 @@ def compile_row_regexp(row, flags=0):
         row = row[:-1] + "(.+)"
     elif row.endswith("..."):
         row = row[:-3]
-    elif "~/" in row:
-        # ~/{regex}/ -> (?:{regex}), a non-capturing match. The first / after ~/
-        # closes the placeholder (so the regexp cannot contain a literal /), and the
-        # (?:) wrap keeps a top-level alternation (a|b) from leaking into the rest of
-        # the row.
-        row = re.sub(r"~/([^/]+)/", r"(?:\1)", row)
     else:
         row += r"(?:\s|$)"
     row = re.sub(r"\s+", r"\\s+", row)
     if protected:
-        row = re.sub(r"\x00(\d+)\x00", lambda m: f"(?:{protected[int(m.group(1))]})", row)
+
+        def _restore(match: re.Match) -> str:
+            regexp, captures = protected[int(match.group(1))]
+            return f"({regexp})" if captures else f"(?:{regexp})"
+
+        row = re.sub(r"\x00(\d+)\x00", _restore, row)
     return re.compile("^" + row, flags=flags)
 
 

--- a/annet/rulebook/patching.py
+++ b/annet/rulebook/patching.py
@@ -199,9 +199,18 @@ def _make_reverse(row, reverse_prefix, flags=0):
     if row[-1] == "~":
         row = row[:-1] + "{}"
 
+    # Handle the arbitrary-regexp placeholders before the * substitution below, so any
+    # *, (...) inside the user's own regexp is not mistaken for a capturing placeholder.
+    # Mirroring compile_row_regexp: ~/{regex}/ captures, so it becomes a {}; ?/{regex}/
+    # captures nothing, so it is dropped entirely (no {}). The first / after ?/ or ~/
+    # closes the placeholder, so the regexp cannot itself contain a literal / (hence
+    # [^/]+). Surrounding whitespace of the dropped ?/.../ collapses to keep words
+    # separated whether the placeholder is leading, trailing, or in the middle.
+    row = re.sub(r"~/[^/]+/", "{}", row, flags=flags)
+    row = re.sub(r"\s*\?/[^/]+/\s*", " ", row, flags=flags)
+
     row = re.sub(r"\*(/\S+/)?", "{}", row, flags=flags)
-    row = re.sub(r"\s*~(/\S+/)?", "", row, flags=flags)
-    return row
+    return row.strip()
 
 
 def _attrs_to_regexp(attrs):

--- a/tests/annet/test_patching.py
+++ b/tests/annet/test_patching.py
@@ -4,8 +4,10 @@ from textwrap import dedent
 
 import pytest
 
+from annet.annlib.rbparser import syntax
 from annet.patching import PatchTree, make_diff
 from annet.rulebook.common import default, default_diff, ordered_diff
+from annet.rulebook.patching import _make_reverse
 from annet.types import Op
 from annet.vendors.tabparser import CommonFormatter
 
@@ -125,3 +127,32 @@ def test_patch_class_to_from_json():
 
     json = tree.to_json()
     assert json == PatchTree.from_json(json).to_json()
+
+
+@pytest.mark.parametrize(
+    ("row", "expected"),
+    [
+        # plain word/tail captures keep one {} each
+        ("snmp-agent sys-info *", "no snmp-agent sys-info {}"),
+        ("* permit ~", "no {} permit {}"),
+        # */{regex}/ and ~/{regex}/ are both capturing -> one {} each
+        ("*/(.*)/permit ~", "no {}permit {}"),
+        ("*/syslog-level/ ~/(emergency|alert|info)/ *", "no {} {} {}"),
+        ("~/(a|b)/ permit", "no {} permit"),
+        ("~/(a|b)/ permit ~", "no {} permit {}"),
+        # ?/{regex}/ is non-capturing -> no {}, and the * inside it must not leak out
+        ("?/(.*)/permit ~", "no permit {}"),
+        # the * inside a ~/{regex}/ regexp must not leak out as an extra {}
+        ("~/(a*)/permit ~", "no {}permit {}"),
+        # a mix of all placeholder kinds in one row
+        ("?/a/ */b/ ~/c/ *", "no {} {} {}"),
+        # an existing reverse prefix is stripped rather than doubled
+        ("no permit *", "permit {}"),
+    ],
+)
+def test_make_reverse(row, expected):
+    reverse = _make_reverse(row, "no")
+    assert reverse == expected
+    # the number of {} must match the number of capturing groups produced for the
+    # row, since reverse.format(*match.groups()) relies on that invariant
+    assert reverse.count("{}") == syntax.compile_row_regexp(row).groups

--- a/tests/annet/test_syntax.py
+++ b/tests/annet/test_syntax.py
@@ -96,24 +96,28 @@ def test_parse_text(raw_rule, expected) -> None:
         ("?/(.*)/permit", r"^(?:(?:.*))permit(?:\s|$)", "permit", True),
         ("?/(.*)/permit", r"^(?:(?:.*))permit(?:\s|$)", "deny", False),
         # --- ~/{regex}/ ---------------------------------------------------------
-        # ~/{regex}/ is wrapped in (?:...) so a top-level alternation does not leak
-        # into the rest of the row.
-        ("~/a|b/ x", r"^(?:a|b)\s+x", "a x", True),
-        ("~/a|b/ x", r"^(?:a|b)\s+x", "b x", True),
-        ("~/a|b/ x", r"^(?:a|b)\s+x", "c x", False),
+        # ~/{regex}/ captures its whole matched span into a single group (any inner
+        # group the user wrote collapses to non-capturing -- only the wrapper captures),
+        # so a top-level alternation does not leak into the rest of the row either.
+        ("~/a|b/ x", r"^(a|b)\s+x(?:\s|$)", "a x", True),
+        ("~/a|b/ x", r"^(a|b)\s+x(?:\s|$)", "b x", True),
+        ("~/a|b/ x", r"^(a|b)\s+x(?:\s|$)", "c x", False),
         # the regexp ends at its own first /, so literal slashes after it stay intact
-        ("~/interface|if/ eth0/1/2", r"^(?:interface|if)\s+eth0/1/2", "if eth0/1/2", True),
-        ("~/interface|if/ eth0/1/2", r"^(?:interface|if)\s+eth0/1/2", "if eth0X1X2", False),
-        # several ~/.../ on one row do not bleed into each other
-        ("~/a|b/ x ~/c|d/", r"^(?:a|b)\s+x\s+(?:c|d)", "a x d", True),
-        ("~/a|b/ x ~/c|d/", r"^(?:a|b)\s+x\s+(?:c|d)", "a x e", False),
+        ("~/interface|if/ eth0/1/2", r"^(interface|if)\s+eth0/1/2(?:\s|$)", "if eth0/1/2", True),
+        ("~/interface|if/ eth0/1/2", r"^(interface|if)\s+eth0/1/2(?:\s|$)", "if eth0X1X2", False),
+        # several ~/.../ on one row do not bleed into each other; each captures
+        ("~/a|b/ x ~/c|d/", r"^(a|b)\s+x\s+(c|d)(?:\s|$)", "a x d", True),
+        ("~/a|b/ x ~/c|d/", r"^(a|b)\s+x\s+(c|d)(?:\s|$)", "a x e", False),
+        # ~/{regex}/ also works when combined with a trailing ~
+        ("~/(a|b)/ permit ~", r"^((?:a|b))\s+permit\s+(.+)", "a permit foo bar", True),
+        ("~/(a|b)/ permit ~", r"^((?:a|b))\s+permit\s+(.+)", "c permit foo", False),
         # --- ?/{regex}/ and ~/{regex}/ mixed ------------------------------------
         # several placeholders on one row do not bleed into each other: each one
-        # ends at its own first /, and the ~/x/ in between stays intact.
-        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(?:x)\s+(?:y|z)", "a x y", True),
-        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(?:x)\s+(?:y|z)", "b x z", True),
-        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(?:x)\s+(?:y|z)", "a q y", False),
-        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(?:x)\s+(?:y|z)", "a x q", False),
+        # ends at its own first /. The ?/.../ stay non-capturing, the ~/x/ captures.
+        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)(?:\s|$)", "a x y", True),
+        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)(?:\s|$)", "b x z", True),
+        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)(?:\s|$)", "a q y", False),
+        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)(?:\s|$)", "a x q", False),
     ],
 )
 def test_compile_row_regexp(row, expected_pattern, line, should_match) -> None:
@@ -122,7 +126,12 @@ def test_compile_row_regexp(row, expected_pattern, line, should_match) -> None:
     assert bool(compiled.match(line)) is should_match
 
 
-def test_compile_row_regexp_noncapturing_has_no_extra_groups() -> None:
-    # Only the trailing `~` contributes a capture group; ?/(.*)/ captures nothing.
+def test_compile_row_regexp_capturing_groups() -> None:
+    # ?/{regex}/ captures nothing; ~/{regex}/ captures one group regardless of any
+    # * elsewhere in the row; only the trailing `~` adds its own group.
     assert compile_row_regexp("?/(.*)/permit ~").groups == 1
     assert compile_row_regexp("?/(.*)/permit").groups == 0
+    assert compile_row_regexp("~/(a|b)/ permit").groups == 1
+    assert compile_row_regexp("~/(a|b)/ permit ~").groups == 2
+    # the * that previously de-capturing-ized inner groups no longer affects ~/.../
+    assert compile_row_regexp("*/x/ ~/(a|b)/ *").groups == 3


### PR DESCRIPTION
`_make_reverse` builds the reverse (undo) format string whose `{}` are filled from `match.groups()`, so its `{}` count must equal the number of capturing groups `compile_row_regexp` produces for the row.

The `*` placeholder substitution ran over the whole row, including the contents of the non-capturing `?/{regex}/` placeholder: `?/(.*)/permit ~` produced `no ?/(.{})/permit {}` -- the `*` inside `(.*)` became a stray `{}` and the regexp itself was left in. Strip the regexp placeholders before the `*` substitution instead.

While here, make `~/{regex}/` a real, consistent capturing group. Previously it was wrapped non-capturing, and whether anything leaked into a group depended on the user's own inner `()` plus whether a `*` appeared elsewhere in the row. It now captures its whole matched span into one group regardless, mirrored by `_make_reverse` emitting one `{}`; `?/{regex}/` stays non-capturing (no `{}`). This also fixes a latent bug where a row ending in `~` left a `~/{regex}/` earlier in the row as literal text, since the old elif branch never ran when the trailing-~ branch won.