### PR TITLE
feat: vendor-owned (de)serialization for JSON-fragment configs

### DIFF
--- a/annet/api/__init__.py
+++ b/annet/api/__init__.py
@@ -521,11 +521,12 @@ class PCDeployerJob(DeployerJob):
                     file_content: str = file_content_or_json_cfg
                     diff_content = "\n".join(differ.diff_file(res.device.hw, file, old_files.get(file), file_content))
                 else:  # generator_type == GeneratorType.JSON_FRAGMENT
+                    vendor = registry_connector.get().match(res.device.hw)
                     old_json_cfg = old_json_fragment_files[file]
                     json_patch = jsontools.make_patch(old_json_cfg, file_content_or_json_cfg)
                     file_content = jsontools.format_json(json_patch)
-                    old_text = jsontools.format_json(old_json_cfg)
-                    new_text = jsontools.format_json(file_content_or_json_cfg)
+                    old_text = vendor.serialize_json_fragment(res.device.hw, old_json_cfg)
+                    new_text = vendor.serialize_json_fragment(res.device.hw, file_content_or_json_cfg)
                     diff_content = "\n".join(differ.diff_file(res.device.hw, file, old_text, new_text))
 
                 if diff_content or force_reload:

--- a/annet/api/__init__.py
+++ b/annet/api/__init__.py
@@ -525,8 +525,8 @@ class PCDeployerJob(DeployerJob):
                     old_json_cfg = old_json_fragment_files[file]
                     json_patch = jsontools.make_patch(old_json_cfg, file_content_or_json_cfg)
                     file_content = jsontools.format_json(json_patch)
-                    old_text = vendor.serialize_json_fragment(res.device.hw, old_json_cfg)
-                    new_text = vendor.serialize_json_fragment(res.device.hw, file_content_or_json_cfg)
+                    old_text = vendor.serialize_json_fragment(res.device.hw, file, old_json_cfg)
+                    new_text = vendor.serialize_json_fragment(res.device.hw, file, file_content_or_json_cfg)
                     diff_content = "\n".join(differ.diff_file(res.device.hw, file, old_text, new_text))
 
                 if diff_content or force_reload:

--- a/annet/diff.py
+++ b/annet/diff.py
@@ -59,13 +59,13 @@ def json_fragment_diff(
     vendor = registry_connector.get().match(hw)
 
     def jsonify_multi(files):
-        return {path: vendor.serialize_json_fragment(hw, cfg) for path, cfg in files.items()}
+        return {path: vendor.serialize_json_fragment(hw, path, cfg) for path, cfg in files.items()}
 
     def jsonify_multi_with_cmd(files):
         ret = {}
         for path, cfg_reload_cmd in files.items():
             cfg, reload_cmd = cfg_reload_cmd
-            ret[path] = (vendor.serialize_json_fragment(hw, cfg), reload_cmd)
+            ret[path] = (vendor.serialize_json_fragment(hw, path, cfg), reload_cmd)
         return ret
 
     jold, jnew = jsonify_multi(old_files), jsonify_multi_with_cmd(new_files)

--- a/annet/diff.py
+++ b/annet/diff.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any, Dict, Generator, List, Mapping, Optional, Protocol, Tuple, Union
 
 from annet import cli_args, filtering, patching, rulebook
-from annet.annlib import jsontools
 from annet.annlib.diff import (  # pylint: disable=unused-import
     colorize_line,
     diff_cmp,
@@ -57,14 +56,16 @@ def json_fragment_diff(
     old_files: Dict[str, Any],
     new_files: Dict[str, Tuple[Any, Optional[str]]],
 ) -> Generator[PCDiffFile, None, None]:
+    vendor = registry_connector.get().match(hw)
+
     def jsonify_multi(files):
-        return {path: jsontools.format_json(cfg) for path, cfg in files.items()}
+        return {path: vendor.serialize_json_fragment(hw, cfg) for path, cfg in files.items()}
 
     def jsonify_multi_with_cmd(files):
         ret = {}
         for path, cfg_reload_cmd in files.items():
             cfg, reload_cmd = cfg_reload_cmd
-            ret[path] = (jsontools.format_json(cfg), reload_cmd)
+            ret[path] = (vendor.serialize_json_fragment(hw, cfg), reload_cmd)
         return ret
 
     jold, jnew = jsonify_multi(old_files), jsonify_multi_with_cmd(new_files)

--- a/annet/gen.py
+++ b/annet/gen.py
@@ -342,7 +342,7 @@ def split_downloaded_files(
                 if device_flat_files[filepath] is not None:  # file exists
                     try:
                         ret.json_fragment_files[filepath] = vendor.deserialize_json_fragment(
-                            device.hw, device_flat_files[filepath]
+                            device.hw, filepath, device_flat_files[filepath]
                         )
 
                     except Exception as exc:
@@ -476,7 +476,7 @@ def old_raw(
                 yield (
                     device,
                     {
-                        path: vendor.serialize_json_fragment(device.hw, data)
+                        path: vendor.serialize_json_fragment(device.hw, path, data)
                         for path, data in files.json_fragment_files.items()
                     },
                 )
@@ -513,7 +513,7 @@ def worker(
 
         vendor = registry_connector.get().match(device.hw)
         for path, (data, _) in sorted(new_file_fragments.items(), key=itemgetter(0)):
-            dumped_data = vendor.serialize_json_fragment(device.hw, data)
+            dumped_data = vendor.serialize_json_fragment(device.hw, path, data)
             yield (output_driver.entire_config_dest_path(device, path), dumped_data, False)
         # Consider result of partial run empty and create an empty dest file
         # only if there are some acl rules that has been matched.

--- a/annet/gen.py
+++ b/annet/gen.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import dataclasses
 import itertools
-import json
 import os
 import sys
 import textwrap
@@ -26,7 +25,6 @@ import tabulate
 from contextlog import get_logger
 
 from annet import generators, implicit, patching, rulebook, tracing
-from annet.annlib import jsontools
 from annet.annlib.rbparser.acl import compile_acl_text
 from annet.cli_args import DeployOptions, GenOptions, ShowGenOptions
 from annet.deploy import get_fetcher, scrub_config
@@ -332,6 +330,7 @@ def split_downloaded_files(
 ) -> DeviceDownloadedFiles:
     """Split downloaded files per generator type: entire/json_fragment."""
     ret = DeviceDownloadedFiles()
+    vendor = registry_connector.get().match(device.hw)
 
     for gen in gens.file_gens(device):
         filepath = gen.path(device)
@@ -342,9 +341,11 @@ def split_downloaded_files(
             elif isinstance(gen, JSONFragment):
                 if device_flat_files[filepath] is not None:  # file exists
                     try:
-                        ret.json_fragment_files[filepath] = json.loads(device_flat_files[filepath])
+                        ret.json_fragment_files[filepath] = vendor.deserialize_json_fragment(
+                            device.hw, device_flat_files[filepath]
+                        )
 
-                    except json.decoder.JSONDecodeError as exc:
+                    except Exception as exc:
                         raise GeneratorError(
                             f"failed to parse file {filepath!r} from generator {gen.get_name()}"
                         ) from exc
@@ -471,7 +472,14 @@ def old_raw(
             if files.entire_files:
                 yield device, files.entire_files
             if files.json_fragment_files:
-                yield device, {path: jsontools.format_json(data) for path, data in files.json_fragment_files.items()}
+                vendor = registry_connector.get().match(device.hw)
+                yield (
+                    device,
+                    {
+                        path: vendor.serialize_json_fragment(device.hw, data)
+                        for path, data in files.json_fragment_files.items()
+                    },
+                )
 
 
 @tracing.function
@@ -503,8 +511,9 @@ def worker(
         for entire_path, (entire_data, _) in sorted(new_files.items(), key=itemgetter(0)):
             yield (output_driver.entire_config_dest_path(device, entire_path), entire_data, False)
 
+        vendor = registry_connector.get().match(device.hw)
         for path, (data, _) in sorted(new_file_fragments.items(), key=itemgetter(0)):
-            dumped_data = json.dumps(data, indent=4, sort_keys=True, ensure_ascii=False)
+            dumped_data = vendor.serialize_json_fragment(device.hw, data)
             yield (output_driver.entire_config_dest_path(device, path), dumped_data, False)
         # Consider result of partial run empty and create an empty dest file
         # only if there are some acl rules that has been matched.

--- a/annet/vendors/base.py
+++ b/annet/vendors/base.py
@@ -2,10 +2,17 @@ import abc
 import json
 from typing import Any, ClassVar
 
+import yaml
+
 from annet.annlib import jsontools
 from annet.annlib.command import CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.vendors.tabparser import CommonFormatter
+
+
+def is_yaml_path(path: str) -> bool:
+    """Whether a JSON-fragment file path denotes a YAML document by its extension."""
+    return path.lower().endswith((".yaml", ".yml"))
 
 
 class AbstractVendor(abc.ABC):
@@ -15,17 +22,21 @@ class AbstractVendor(abc.ABC):
     def match(self) -> list[str]:
         raise NotImplementedError
 
-    def deserialize_json_fragment(self, hw: HardwareView, text: str) -> dict[str, Any]:
+    def deserialize_json_fragment(self, hw: HardwareView, path: str, text: str) -> dict[str, Any]:
         """Parse a JSON-fragment file's on-device text into the canonical dict form.
 
-        Defaults to JSON; vendors whose config is stored differently (e.g. YAML, or a
-        top-level list rather than a map) override this. ``hw`` is passed so a single
-        vendor serving several device kinds can branch on hardware.
+        Defaults to format detection by file extension: ``.yaml``/``.yml`` is parsed as
+        YAML, anything else as JSON. ``hw`` and ``path`` are passed so a vendor serving
+        several device kinds (or several files) can branch on hardware or file.
         """
+        if is_yaml_path(path):
+            return yaml.safe_load(text) or {}
         return json.loads(text)
 
-    def serialize_json_fragment(self, hw: HardwareView, config: dict[str, Any]) -> str:
+    def serialize_json_fragment(self, hw: HardwareView, path: str, config: dict[str, Any]) -> str:
         """Render the canonical dict form back into the file's on-device text."""
+        if is_yaml_path(path):
+            return yaml.safe_dump(config, sort_keys=False, default_flow_style=False)
         return jsontools.format_json(config)
 
     def apply(self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str) -> tuple[CommandList, CommandList]:

--- a/annet/vendors/base.py
+++ b/annet/vendors/base.py
@@ -1,6 +1,8 @@
 import abc
-from typing import ClassVar
+import json
+from typing import Any, ClassVar
 
+from annet.annlib import jsontools
 from annet.annlib.command import CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.vendors.tabparser import CommonFormatter
@@ -12,6 +14,19 @@ class AbstractVendor(abc.ABC):
     @abc.abstractmethod
     def match(self) -> list[str]:
         raise NotImplementedError
+
+    def deserialize_json_fragment(self, hw: HardwareView, text: str) -> dict[str, Any]:
+        """Parse a JSON-fragment file's on-device text into the canonical dict form.
+
+        Defaults to JSON; vendors whose config is stored differently (e.g. YAML, or a
+        top-level list rather than a map) override this. ``hw`` is passed so a single
+        vendor serving several device kinds can branch on hardware.
+        """
+        return json.loads(text)
+
+    def serialize_json_fragment(self, hw: HardwareView, config: dict[str, Any]) -> str:
+        """Render the canonical dict form back into the file's on-device text."""
+        return jsontools.format_json(config)
 
     def apply(self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str) -> tuple[CommandList, CommandList]:
         return CommandList(), CommandList()

--- a/annet/vendors/library/pc.py
+++ b/annet/vendors/library/pc.py
@@ -1,4 +1,8 @@
 import os
+from collections import OrderedDict
+from typing import Any
+
+import yaml
 
 from annet.annlib.command import Command, CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
@@ -13,6 +17,19 @@ class PCVendor(AbstractVendor):
 
     def match(self) -> list[str]:
         return ["PC"]
+
+    def _is_nvos(self, hw: HardwareView) -> bool:
+        return hw.soft.startswith("nvos")
+
+    def deserialize_json_fragment(self, hw: HardwareView, text: str) -> dict[str, Any]:
+        if self._is_nvos(hw):
+            return nvos_yaml_to_dict(text)
+        return super().deserialize_json_fragment(hw, text)
+
+    def serialize_json_fragment(self, hw: HardwareView, config: dict[str, Any]) -> str:
+        if self._is_nvos(hw):
+            return dict_to_nvos_yaml(config)
+        return super().serialize_json_fragment(hw, config)
 
     @property
     def reverse(self) -> str:
@@ -37,3 +54,28 @@ class PCVendor(AbstractVendor):
     @property
     def exit(self) -> str:
         return ""
+
+
+def nvos_yaml_to_dict(text: str) -> dict[str, Any]:
+    """Parse an NVOS YAML config into the canonical dict form.
+
+    NVOS stores its config as a top-level YAML *list of single-key maps*, e.g.
+    ``[{'header': {...}}, {'set': {...}}]``. The list is order-significant and the
+    keys are unique, so it maps losslessly onto an ordered dict.
+    """
+    doc = yaml.safe_load(text)
+    if doc is None:
+        return OrderedDict()
+    if isinstance(doc, list):
+        merged: "OrderedDict[str, Any]" = OrderedDict()
+        for item in doc:
+            for key, value in item.items():
+                merged[key] = value
+        return merged
+    return doc
+
+
+def dict_to_nvos_yaml(config: dict[str, Any]) -> str:
+    """Render the canonical dict form back into NVOS' top-level list-of-maps YAML."""
+    doc = [{key: value} for key, value in config.items()]
+    return yaml.safe_dump(doc, sort_keys=False, default_flow_style=False)

--- a/annet/vendors/library/pc.py
+++ b/annet/vendors/library/pc.py
@@ -6,7 +6,7 @@ import yaml
 
 from annet.annlib.command import Command, CommandList
 from annet.annlib.netdev.views.hardware import HardwareView
-from annet.vendors.base import AbstractVendor
+from annet.vendors.base import AbstractVendor, is_yaml_path
 from annet.vendors.registry import registry
 from annet.vendors.tabparser import CommonFormatter
 
@@ -21,15 +21,15 @@ class PCVendor(AbstractVendor):
     def _is_nvos(self, hw: HardwareView) -> bool:
         return hw.soft.startswith("nvos")
 
-    def deserialize_json_fragment(self, hw: HardwareView, text: str) -> dict[str, Any]:
-        if self._is_nvos(hw):
+    def deserialize_json_fragment(self, hw: HardwareView, path: str, text: str) -> dict[str, Any]:
+        if self._is_nvos(hw) and is_yaml_path(path):
             return nvos_yaml_to_dict(text)
-        return super().deserialize_json_fragment(hw, text)
+        return super().deserialize_json_fragment(hw, path, text)
 
-    def serialize_json_fragment(self, hw: HardwareView, config: dict[str, Any]) -> str:
-        if self._is_nvos(hw):
+    def serialize_json_fragment(self, hw: HardwareView, path: str, config: dict[str, Any]) -> str:
+        if self._is_nvos(hw) and is_yaml_path(path):
             return dict_to_nvos_yaml(config)
-        return super().serialize_json_fragment(hw, config)
+        return super().serialize_json_fragment(hw, path, config)
 
     @property
     def reverse(self) -> str:

--- a/tests/annet/test_nvos_serialization.py
+++ b/tests/annet/test_nvos_serialization.py
@@ -1,0 +1,80 @@
+"""Tests for vendor-owned (de)serialization of JSON-fragment configs.
+
+Covers the default JSON behaviour on AbstractVendor and the NVOS YAML
+list-of-single-key-maps codec on PCVendor.
+"""
+
+from collections import OrderedDict
+
+import pytest
+
+from annet.annlib.netdev.views.hardware import HardwareView
+from annet.vendors.library.pc import PCVendor, dict_to_nvos_yaml, nvos_yaml_to_dict
+
+
+HW = HardwareView("PC", "")
+
+
+# Example NVOS config: top-level YAML list of single-key maps.
+NVOS_YAML = """\
+- header:
+    model: q3400
+    nvue-api-version: nvue_v1
+    rev-id: 1.0
+    version: 3.2.0.0
+- set:
+    interface:
+      eth0:
+"""
+
+NVOS_DICT = {
+    "header": {
+        "model": "q3400",
+        "nvue-api-version": "nvue_v1",
+        "rev-id": 1.0,
+        "version": "3.2.0.0",
+    },
+    "set": {"interface": {"eth0": None}},
+}
+
+
+def test_nvos_yaml_to_dict_collapses_top_level_list():
+    result = nvos_yaml_to_dict(NVOS_YAML)
+    assert result == NVOS_DICT
+    # order of the top-level list is preserved as dict insertion order
+    assert list(result.keys()) == ["header", "set"]
+
+
+def test_nvos_yaml_to_dict_empty():
+    assert nvos_yaml_to_dict("") == OrderedDict()
+
+
+def test_dict_to_nvos_yaml_emits_top_level_list():
+    text = dict_to_nvos_yaml(NVOS_DICT)
+    # top level must be a YAML list, not a map
+    assert text.lstrip().startswith("- ")
+
+
+def test_nvos_round_trip_preserves_content_and_order():
+    cfg = OrderedDict(NVOS_DICT)
+    restored = nvos_yaml_to_dict(dict_to_nvos_yaml(cfg))
+    assert restored == cfg
+    assert list(restored.keys()) == list(cfg.keys())
+
+
+def test_pc_vendor_defaults_to_json():
+    vendor = PCVendor()
+    text = vendor.serialize_json_fragment(HW, {"set": {"interface": {"eth0": None}}})
+    # default codec is JSON, so it round-trips through the JSON deserializer
+    assert vendor.deserialize_json_fragment(HW, text) == {"set": {"interface": {"eth0": None}}}
+    # ...and the rendered form is JSON, not YAML
+    assert text.lstrip().startswith("{")
+
+
+def test_pc_vendor_uses_nvos_codec_when_matched(monkeypatch):
+    vendor = PCVendor()
+    monkeypatch.setattr(PCVendor, "_is_nvos", lambda self, hw: True)
+
+    text = vendor.serialize_json_fragment(HW, NVOS_DICT)
+    assert text.lstrip().startswith("- ")  # YAML list
+    assert vendor.deserialize_json_fragment(HW, text) == NVOS_DICT

--- a/tests/annet/test_nvos_serialization.py
+++ b/tests/annet/test_nvos_serialization.py
@@ -6,13 +6,12 @@ list-of-single-key-maps codec on PCVendor.
 
 from collections import OrderedDict
 
-import pytest
-
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.vendors.library.pc import PCVendor, dict_to_nvos_yaml, nvos_yaml_to_dict
 
 
 HW = HardwareView("PC", "")
+NVOS_HW = HardwareView("PC", "nvos")
 
 
 # Example NVOS config: top-level YAML list of single-key maps.
@@ -62,19 +61,34 @@ def test_nvos_round_trip_preserves_content_and_order():
     assert list(restored.keys()) == list(cfg.keys())
 
 
-def test_pc_vendor_defaults_to_json():
+def test_json_path_uses_json_codec():
     vendor = PCVendor()
-    text = vendor.serialize_json_fragment(HW, {"set": {"interface": {"eth0": None}}})
-    # default codec is JSON, so it round-trips through the JSON deserializer
-    assert vendor.deserialize_json_fragment(HW, text) == {"set": {"interface": {"eth0": None}}}
-    # ...and the rendered form is JSON, not YAML
+    cfg = {"set": {"interface": {"eth0": None}}}
+    text = vendor.serialize_json_fragment(HW, "config.json", cfg)
+    assert text.lstrip().startswith("{")  # JSON, not YAML
+    assert vendor.deserialize_json_fragment(HW, "config.json", text) == cfg
+
+
+def test_yaml_path_non_nvos_uses_plain_yaml():
+    vendor = PCVendor()
+    cfg = {"set": {"interface": {"eth0": None}}}
+    text = vendor.serialize_json_fragment(HW, "config.yaml", cfg)
+    # plain YAML mapping at the top level, NOT the NVOS list-of-maps form
+    assert not text.lstrip().startswith("- ")
+    assert vendor.deserialize_json_fragment(HW, "config.yaml", text) == cfg
+
+
+def test_nvos_yaml_path_uses_nvos_codec():
+    vendor = PCVendor()
+    text = vendor.serialize_json_fragment(NVOS_HW, "startup.yaml", NVOS_DICT)
+    assert text.lstrip().startswith("- ")  # NVOS top-level list of maps
+    assert vendor.deserialize_json_fragment(NVOS_HW, "startup.yaml", text) == NVOS_DICT
+
+
+def test_nvos_json_path_still_uses_json_codec():
+    # NVOS only changes YAML handling; a .json file on an NVOS box is still JSON.
+    vendor = PCVendor()
+    cfg = {"set": {"interface": {"eth0": None}}}
+    text = vendor.serialize_json_fragment(NVOS_HW, "config.json", cfg)
     assert text.lstrip().startswith("{")
-
-
-def test_pc_vendor_uses_nvos_codec_when_matched(monkeypatch):
-    vendor = PCVendor()
-    monkeypatch.setattr(PCVendor, "_is_nvos", lambda self, hw: True)
-
-    text = vendor.serialize_json_fragment(HW, NVOS_DICT)
-    assert text.lstrip().startswith("- ")  # YAML list
-    assert vendor.deserialize_json_fragment(HW, text) == NVOS_DICT
+    assert vendor.deserialize_json_fragment(NVOS_HW, "config.json", text) == cfg


### PR DESCRIPTION
JSON-fragment generators previously assumed the on-disk format was always JSON and the in-memory form a dict. Make (de)serialization a property of the vendor instead: AbstractVendor gains JSON-defaulted deserialize_json_fragment/serialize_json_fragment, and every read/show/diff boundary routes through them. Existing vendors are unaffected.

PCVendor (which serves all Linux devices) overrides both, branching on hardware to support NVOS, whose config is YAML with a top-level list of single-key maps that collapses losslessly to/from an ordered dict.

The patch artifact stays core jsontools.make_patch — it is computed from canonical dicts we already own and is not device-native config.