### PR TITLE
fix: don't anchor a trailing zero-width regex placeholder

### DIFF
--- a/annet/annlib/rbparser/syntax.py
+++ b/annet/annlib/rbparser/syntax.py
@@ -91,11 +91,28 @@ def compile_row_regexp(row, flags=0):
     # Заменяем <someting> на named-группы
     row = re.sub(r"<(\w+)>", r"(?P<\1>\\w+)", row)
 
+    # A trailing ?/{regex}/ or ~/{regex}/ whose regexp can match the empty string
+    # (e.g. a bare negative lookahead like ~/(?!foo)/) defines its own right
+    # boundary. Appending the (?:\s|$) anchor after a zero-width match can never
+    # succeed -- the anchor would have to match at the very start of the token --
+    # so such a placeholder must not be anchored, matching the pre-?/{regex}/
+    # behaviour where ~/{regex}/ was never anchored.
+    trailing_empty = False
+    trailing_match = re.search(r"\x00(\d+)\x00\s*$", row)
+    if trailing_match:
+        trailing_regexp = protected[int(trailing_match.group(1))][0]
+        try:
+            trailing_empty = re.compile(trailing_regexp).match("") is not None
+        except re.error:
+            trailing_empty = False
+
     if row.endswith("~"):
         # We determine the most specific regex for the row at matching in match_row_to_acls
         row = row[:-1] + "(.+)"
     elif row.endswith("..."):
         row = row[:-3]
+    elif trailing_empty:
+        pass
     else:
         row += r"(?:\s|$)"
     row = re.sub(r"\s+", r"\\s+", row)

--- a/tests/annet/test_syntax.py
+++ b/tests/annet/test_syntax.py
@@ -118,6 +118,21 @@ def test_parse_text(raw_rule, expected) -> None:
         ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)(?:\s|$)", "b x z", True),
         ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)(?:\s|$)", "a q y", False),
         ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)(?:\s|$)", "a x q", False),
+        # --- trailing zero-width placeholder ------------------------------------
+        # A trailing ~/{regex}/ or ?/{regex}/ whose regexp matches an empty span
+        # (a bare negative lookahead) is NOT anchored with (?:\s|$): the anchor
+        # would have to match at the start of the token and could never succeed.
+        # Used by ACLs like `forwarding-options ~/(?!(sampling|port-mirroring))/`.
+        ("~/(?!(sampling|port-mirroring))/", r"^((?!(?:sampling|port-mirroring)))", "enhanced-hash-key", True),
+        ("~/(?!(sampling|port-mirroring))/", r"^((?!(?:sampling|port-mirroring)))", "sampling", False),
+        ("~/(?!(sampling|port-mirroring))/", r"^((?!(?:sampling|port-mirroring)))", "port-mirroring", False),
+        ("user ~/(?!RO|SU)/", r"^user\s+((?!RO|SU))", "user admin", True),
+        ("user ~/(?!RO|SU)/", r"^user\s+((?!RO|SU))", "user RO", False),
+        ("interface ?/(?!Tunnel)/", r"^interface\s+(?:(?!Tunnel))", "interface Eth0", True),
+        ("interface ?/(?!Tunnel)/", r"^interface\s+(?:(?!Tunnel))", "interface Tunnel0", False),
+        # a trailing placeholder that still consumes input keeps the (?:\s|$) anchor
+        ("~/c|d/", r"^(c|d)(?:\s|$)", "d", True),
+        ("~/c|d/", r"^(c|d)(?:\s|$)", "e", False),
     ],
 )
 def test_compile_row_regexp(row, expected_pattern, line, should_match) -> None:


### PR DESCRIPTION
compile_row_regexp used to give ~/{regex}/ a dedicated branch that never appended the (?:\s|$) word-boundary anchor. The ?/{regex}/ feature (#574) removed that branch and routed both placeholders through the generic else: row += "(?:\s|$)".

For a trailing placeholder whose regexp matches a zero-width span -- e.g. a bare negative lookahead like ~/(?!(sampling|port-mirroring))/ used in ACLs -- the result is ^((?!(?:sampling|port-mirroring)))(?:\s|$). The lookahead is zero-width, so the anchor has to match at the start of the token and fails for any real value (e.g. "enhanced-hash-key"), silently breaking the ACL.

This leaked into ACL compilation, not just rulebooks: ~all ~/(?!...)/ ACLs with no consuming tail were affected.

Skip the anchor when the trailing placeholder's regexp can match the empty string, restoring the pre-#574 behaviour for zero-width placeholders while keeping the anchor for placeholders that consume input. Add regression tests covering both.