### PR TITLE
fix: allow literal slashes inside ?/{regex}/ and ~/{regex}/ placeholders

### DIFF
--- a/annet/annlib/rbparser/syntax.py
+++ b/annet/annlib/rbparser/syntax.py
@@ -71,8 +71,15 @@ def compile_row_regexp(row, flags=0):
     # being reinterpreted, and so any groups the user wrote inside collapse to
     # non-capturing -- only the ~/ wrapper itself captures. The ? / ~ prefix is glued
     # to the /, so neither form clashes with literal slashes (e.g. interface names
-    # like Eth0/0/1). The first / after the prefix closes the placeholder, so the
-    # regexp itself cannot contain a literal / (hence [^/]+).
+    # like Eth0/0/1).
+    #
+    # The placeholder closes at the FIRST / that is followed by whitespace/end-of-row
+    # (a token boundary) or that is the last / on the row. This lets the regexp itself
+    # contain literal slashes -- e.g. ~/(GE.+?/[12](\.|$))/ for interface names like
+    # GE1/0/2 -- while a placeholder followed by literal text (~/interface|if/ eth0/1/2
+    # or the glued ?/(.*)/permit) still closes at its own boundary / and leaves that
+    # text intact. A leading (?:^|(?<=\s)) and the (?![?~]/)-style boundary keep
+    # several placeholders on one row from bleeding into each other.
     protected: list[tuple[str, bool]] = []  # (regexp, captures)
 
     def _protect(match: re.Match) -> str:
@@ -81,7 +88,7 @@ def compile_row_regexp(row, flags=0):
         protected.append((regexp, captures))
         return f"\x00{len(protected) - 1}\x00"
 
-    row = re.sub(r"(?:^|(?<=\s))([?~])/([^/]+)/", _protect, row)
+    row = re.sub(r"(?:^|(?<=\s))([?~])/(.+?)/(?=\s|[^/]*$)", _protect, row)
 
     if "*" in row:
         row = re.sub(r"\(([^\?])", r"(?:\1", row)  # Все дефолтные группы превратить в non-captured

--- a/tests/annet/test_syntax.py
+++ b/tests/annet/test_syntax.py
@@ -102,9 +102,40 @@ def test_parse_text(raw_rule, expected) -> None:
         ("~/a|b/ x", r"^(a|b)\s+x(?:\s|$)", "a x", True),
         ("~/a|b/ x", r"^(a|b)\s+x(?:\s|$)", "b x", True),
         ("~/a|b/ x", r"^(a|b)\s+x(?:\s|$)", "c x", False),
-        # the regexp ends at its own first /, so literal slashes after it stay intact
+        # a placeholder followed by literal text closes at its own boundary / (the one
+        # followed by whitespace), so literal slashes after it stay intact
         ("~/interface|if/ eth0/1/2", r"^(interface|if)\s+eth0/1/2(?:\s|$)", "if eth0/1/2", True),
         ("~/interface|if/ eth0/1/2", r"^(interface|if)\s+eth0/1/2(?:\s|$)", "if eth0X1X2", False),
+        # the regexp may itself contain literal slashes: it closes at the last / when no
+        # earlier / sits on a token boundary. Used by ACLs like
+        # `interface ~/(GE.+?/[12](\.|$))/` matching interface names such as GE1/0/2.
+        (
+            r"interface ~/(GE.+?/[12](\.|$))/",
+            r"^interface\s+((?:GE.+?/[12](?:\.|$)))(?:\s|$)",
+            "interface GE1/0/2",
+            True,
+        ),
+        (
+            r"interface ~/(GE.+?/[12](\.|$))/",
+            r"^interface\s+((?:GE.+?/[12](?:\.|$)))(?:\s|$)",
+            "interface GE1/0/1",
+            True,
+        ),
+        (
+            r"interface ~/(GE.+?/[12](\.|$))/",
+            r"^interface\s+((?:GE.+?/[12](?:\.|$)))(?:\s|$)",
+            "interface GE1/0/3",
+            False,
+        ),
+        (
+            r"interface ~/(GE.+?/[12](\.|$))/",
+            r"^interface\s+((?:GE.+?/[12](?:\.|$)))(?:\s|$)",
+            "interface XE1/0/2",
+            False,
+        ),
+        # a slash-containing regexp still does not bleed into a following placeholder
+        (r"~/a/b/ ~/c/d/", r"^(a/b)\s+(c/d)(?:\s|$)", "a/b c/d", True),
+        (r"~/a/b/ ~/c/d/", r"^(a/b)\s+(c/d)(?:\s|$)", "a/b c/e", False),
         # several ~/.../ on one row do not bleed into each other; each captures
         ("~/a|b/ x ~/c|d/", r"^(a|b)\s+x\s+(c|d)(?:\s|$)", "a x d", True),
         ("~/a|b/ x ~/c|d/", r"^(a|b)\s+x\s+(c|d)(?:\s|$)", "a x e", False),


### PR DESCRIPTION
compile_row_regexp protected ?/{regex}/ and ~/{regex}/ placeholders with ([?~])/([^/]+)/, which stops the regexp body at the first literal slash. PR #574 introduced this when it unified the two placeholders; before that, the ~/{regex}/ branch matched greedily to the last slash, so the regexp could contain slashes.

This silently broke ACLs whose regexp embeds a slash, e.g.

    interface ~/(GE.+?/[12](\.|$))/  %cant_delete=1

The body was chopped at GE.+?/, compiling to a pattern that matches nothing, so a real line like "interface GE1/0/2" was left uncovered and patching raised AclError: interface GE1/0/2.

Close the placeholder at the first / that sits on a token boundary (followed by whitespace or end-of-row), or the last / if none does. This keeps literal slashes inside the regexp while a placeholder followed by literal text (~/interface|if/ eth0/1/2) or glued to it (?/(.*)/permit) still closes at its own boundary slash and leaves that text intact. Multiple placeholders on one row still do not bleed into each other.

Add regression tests covering slash-containing regexps, the two-placeholder case, and the existing boundary/glued cases.