### PR TITLE
fix: restore pre-#574 ~/{regex}/ placeholder and anchoring semantics

### DIFF
--- a/annet/annlib/rbparser/syntax.py
+++ b/annet/annlib/rbparser/syntax.py
@@ -57,6 +57,42 @@ def parse_text_multi(text: str, params_scheme) -> ParsedTree:
     return ret
 
 
+def _ends_with_zero_width(pat: str) -> bool:
+    """True if ``pat`` ends with a top-level zero-width lookaround group -- (?!...),
+    (?=...), (?<=...) or (?<!...) -- whose closing paren is the last character. Such a
+    tail matches a zero-width span, so a (?:\\s|$) word-boundary anchor appended after
+    it could never succeed. Escapes and [...] character classes are skipped so their
+    parens are not miscounted."""
+    pat = pat.rstrip()
+    if not pat.endswith(")"):
+        return False
+    depth = 0
+    in_class = False
+    last_top_is_lookaround = False
+    i = 0
+    n = len(pat)
+    while i < n:
+        c = pat[i]
+        if c == "\\":
+            i += 2
+            continue
+        if in_class:
+            if c == "]":
+                in_class = False
+        elif c == "[":
+            in_class = True
+        elif c == "(":
+            if depth == 0:
+                last_top_is_lookaround = pat[i : i + 3] in ("(?!", "(?=") or pat[i : i + 4] in ("(?<=", "(?<!")
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0 and i == n - 1:
+                return last_top_is_lookaround
+        i += 1
+    return False
+
+
 @functools.lru_cache()
 def compile_row_regexp(row, flags=0):
     if "(?i)" in row:
@@ -73,13 +109,18 @@ def compile_row_regexp(row, flags=0):
     # to the /, so neither form clashes with literal slashes (e.g. interface names
     # like Eth0/0/1).
     #
-    # The placeholder closes at the FIRST / that is followed by whitespace/end-of-row
-    # (a token boundary) or that is the last / on the row. This lets the regexp itself
-    # contain literal slashes -- e.g. ~/(GE.+?/[12](\.|$))/ for interface names like
-    # GE1/0/2 -- while a placeholder followed by literal text (~/interface|if/ eth0/1/2
-    # or the glued ?/(.*)/permit) still closes at its own boundary / and leaves that
-    # text intact. A leading (?:^|(?<=\s)) and the (?![?~]/)-style boundary keep
-    # several placeholders on one row from bleeding into each other.
+    # The closing / is the first one followed by whitespace, or (lazily) by non-slash
+    # text running up to the start of another ?/ or ~/ placeholder or end-of-row. This
+    # lets the regexp itself embed literal slashes (~/(GE.+?/[12](\.|$))/ for names like
+    # GE1/0/2), splits placeholders glued directly or via literal text -- e.g.
+    # ~/(25GE.+?/[12])/.~/(\d+)/ mode l2 -- at their join, and still leaves trailing
+    # literal text after a placeholder intact (~/interface|if/ eth0/1/2, ?/(.*)/permit).
+    #
+    # ~ is never a regexp metachar, so ~/ is matched anywhere -- including inside a
+    # hand-written regexp like interface (?!Vbdif(~/(52\d{4})/)), where the generator
+    # interpolates ~/.../ into a larger (?!...) expression. ? IS a quantifier, so ?/ is
+    # only treated as a placeholder at the row start, after whitespace, or after one of
+    # the structural chars "( ! = |" -- never after an atom it could be quantifying.
     protected: list[tuple[str, bool]] = []  # (regexp, captures)
 
     def _protect(match: re.Match) -> str:
@@ -88,7 +129,9 @@ def compile_row_regexp(row, flags=0):
         protected.append((regexp, captures))
         return f"\x00{len(protected) - 1}\x00"
 
-    row = re.sub(r"(?:^|(?<=\s))([?~])/(.+?)/(?=\s|[^/]*$)", _protect, row)
+    _close = r"/(?=\s|[^/]*?(?:[?~]/|$))"
+    row = re.sub(r"(~)/(.+?)" + _close, _protect, row)
+    row = re.sub(r"(?:^|(?<=[\s(!=|]))(\?)/(.+?)" + _close, _protect, row)
 
     if "*" in row:
         row = re.sub(r"\(([^\?])", r"(?:\1", row)  # Все дефолтные группы превратить в non-captured
@@ -98,27 +141,25 @@ def compile_row_regexp(row, flags=0):
     # Заменяем <someting> на named-группы
     row = re.sub(r"<(\w+)>", r"(?P<\1>\\w+)", row)
 
-    # A trailing ?/{regex}/ or ~/{regex}/ whose regexp can match the empty string
-    # (e.g. a bare negative lookahead like ~/(?!foo)/) defines its own right
-    # boundary. Appending the (?:\s|$) anchor after a zero-width match can never
-    # succeed -- the anchor would have to match at the very start of the token --
-    # so such a placeholder must not be anchored, matching the pre-?/{regex}/
-    # behaviour where ~/{regex}/ was never anchored.
-    trailing_empty = False
-    trailing_match = re.search(r"\x00(\d+)\x00\s*$", row)
-    if trailing_match:
-        trailing_regexp = protected[int(trailing_match.group(1))][0]
-        try:
-            trailing_empty = re.compile(trailing_regexp).match("") is not None
-        except re.error:
-            trailing_empty = False
+    # The (?:\s|$) anchor is appended so a row matches a whole token, not a prefix
+    # (interface Eth0 must not match interface Eth01). It is skipped when the row's own
+    # right edge is a regexp, which defines its own boundary -- matching the pre-?/{regex}/
+    # behaviour where ~/{regex}/ rows were never anchored. Two shapes:
+    #   * the row ends with a ?/{regex}/ or ~/{regex}/ placeholder. The user's regexp owns
+    #     the right edge, so the line may legitimately continue past the match -- e.g.
+    #     interface ~/(25GE1\/0\/10(?![0-9]))/ must still match the subinterface
+    #     25GE1/0/10.1501. (Anchoring here also breaks regexps that end in a zero-width
+    #     assertion, like a trailing (?![0-9]) or a bare ~/(?!foo)/.)
+    #   * the row ends with a hand-written zero-width lookaround that never went through
+    #     the placeholder machinery, e.g. interface (?!25GE.+?/...|Vbdif(...)).
+    trailing_placeholder = re.search(r"\x00\d+\x00\s*$", row) is not None
 
     if row.endswith("~"):
         # We determine the most specific regex for the row at matching in match_row_to_acls
         row = row[:-1] + "(.+)"
     elif row.endswith("..."):
         row = row[:-3]
-    elif trailing_empty:
+    elif trailing_placeholder or _ends_with_zero_width(row):
         pass
     else:
         row += r"(?:\s|$)"

--- a/tests/annet/test_syntax.py
+++ b/tests/annet/test_syntax.py
@@ -111,44 +111,75 @@ def test_parse_text(raw_rule, expected) -> None:
         # `interface ~/(GE.+?/[12](\.|$))/` matching interface names such as GE1/0/2.
         (
             r"interface ~/(GE.+?/[12](\.|$))/",
-            r"^interface\s+((?:GE.+?/[12](?:\.|$)))(?:\s|$)",
+            r"^interface\s+((?:GE.+?/[12](?:\.|$)))",
             "interface GE1/0/2",
             True,
         ),
         (
             r"interface ~/(GE.+?/[12](\.|$))/",
-            r"^interface\s+((?:GE.+?/[12](?:\.|$)))(?:\s|$)",
+            r"^interface\s+((?:GE.+?/[12](?:\.|$)))",
             "interface GE1/0/1",
             True,
         ),
         (
             r"interface ~/(GE.+?/[12](\.|$))/",
-            r"^interface\s+((?:GE.+?/[12](?:\.|$)))(?:\s|$)",
+            r"^interface\s+((?:GE.+?/[12](?:\.|$)))",
             "interface GE1/0/3",
             False,
         ),
         (
             r"interface ~/(GE.+?/[12](\.|$))/",
-            r"^interface\s+((?:GE.+?/[12](?:\.|$)))(?:\s|$)",
+            r"^interface\s+((?:GE.+?/[12](?:\.|$)))",
             "interface XE1/0/2",
             False,
         ),
         # a slash-containing regexp still does not bleed into a following placeholder
-        (r"~/a/b/ ~/c/d/", r"^(a/b)\s+(c/d)(?:\s|$)", "a/b c/d", True),
-        (r"~/a/b/ ~/c/d/", r"^(a/b)\s+(c/d)(?:\s|$)", "a/b c/e", False),
+        (r"~/a/b/ ~/c/d/", r"^(a/b)\s+(c/d)", "a/b c/d", True),
+        (r"~/a/b/ ~/c/d/", r"^(a/b)\s+(c/d)", "a/b c/e", False),
+        # two placeholders glued with no separator split at the join (the second starts
+        # right after the first's closing /). Used by ACLs like
+        # `interface {downlinks}{vlans} mode l2` where downlinks itself embeds slashes.
+        (
+            r"interface ~/(25GE.+?/[12](\.|$))/~/(\d+|to)/ mode l2",
+            r"^interface\s+((?:25GE.+?/[12](?:\.|$)))((?:\d+|to))\s+mode\s+l2(?:\s|$)",
+            "interface 25GE1/0/2.134 mode l2",
+            True,
+        ),
+        (
+            r"interface ~/(25GE.+?/[12](\.|$))/~/(\d+|to)/ mode l2",
+            r"^interface\s+((?:25GE.+?/[12](?:\.|$)))((?:\d+|to))\s+mode\s+l2(?:\s|$)",
+            "interface 25GE1/0/3.134 mode l2",
+            False,
+        ),
+        # two placeholders separated only by literal text (here a `.`) also split: the
+        # second placeholder is recognised even though it is preceded by the `.`, not by
+        # whitespace. The downlink regexp escapes its own slashes (25GE1\/0\/10). Used by
+        # `interface {downlinks}.{vlans} mode l2`.
+        (
+            r"interface ~/(25GE1\/0\/10(?![0-9]))/.~/(\d+|to)/ mode l2",
+            r"^interface\s+((?:25GE1\/0\/10(?![0-9]))).((?:\d+|to))\s+mode\s+l2(?:\s|$)",
+            "interface 25GE1/0/10.1501 mode l2",
+            True,
+        ),
+        (
+            r"interface ~/(25GE1\/0\/10(?![0-9]))/.~/(\d+|to)/ mode l2",
+            r"^interface\s+((?:25GE1\/0\/10(?![0-9]))).((?:\d+|to))\s+mode\s+l2(?:\s|$)",
+            "interface 25GE1/0/100.1501 mode l2",
+            False,
+        ),
         # several ~/.../ on one row do not bleed into each other; each captures
-        ("~/a|b/ x ~/c|d/", r"^(a|b)\s+x\s+(c|d)(?:\s|$)", "a x d", True),
-        ("~/a|b/ x ~/c|d/", r"^(a|b)\s+x\s+(c|d)(?:\s|$)", "a x e", False),
+        ("~/a|b/ x ~/c|d/", r"^(a|b)\s+x\s+(c|d)", "a x d", True),
+        ("~/a|b/ x ~/c|d/", r"^(a|b)\s+x\s+(c|d)", "a x e", False),
         # ~/{regex}/ also works when combined with a trailing ~
         ("~/(a|b)/ permit ~", r"^((?:a|b))\s+permit\s+(.+)", "a permit foo bar", True),
         ("~/(a|b)/ permit ~", r"^((?:a|b))\s+permit\s+(.+)", "c permit foo", False),
         # --- ?/{regex}/ and ~/{regex}/ mixed ------------------------------------
         # several placeholders on one row do not bleed into each other: each one
         # ends at its own first /. The ?/.../ stay non-capturing, the ~/x/ captures.
-        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)(?:\s|$)", "a x y", True),
-        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)(?:\s|$)", "b x z", True),
-        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)(?:\s|$)", "a q y", False),
-        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)(?:\s|$)", "a x q", False),
+        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)", "a x y", True),
+        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)", "b x z", True),
+        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)", "a q y", False),
+        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)", "a x q", False),
         # --- trailing zero-width placeholder ------------------------------------
         # A trailing ~/{regex}/ or ?/{regex}/ whose regexp matches an empty span
         # (a bare negative lookahead) is NOT anchored with (?:\s|$): the anchor
@@ -161,9 +192,51 @@ def test_parse_text(raw_rule, expected) -> None:
         ("user ~/(?!RO|SU)/", r"^user\s+((?!RO|SU))", "user RO", False),
         ("interface ?/(?!Tunnel)/", r"^interface\s+(?:(?!Tunnel))", "interface Eth0", True),
         ("interface ?/(?!Tunnel)/", r"^interface\s+(?:(?!Tunnel))", "interface Tunnel0", False),
-        # a trailing placeholder that still consumes input keeps the (?:\s|$) anchor
-        ("~/c|d/", r"^(c|d)(?:\s|$)", "d", True),
-        ("~/c|d/", r"^(c|d)(?:\s|$)", "e", False),
+        # a trailing placeholder is NOT anchored: the regexp owns the right edge, so the
+        # line may continue past the match (here just the bare token, but cf. subinterfaces)
+        ("~/c|d/", r"^(c|d)", "d", True),
+        ("~/c|d/", r"^(c|d)", "e", False),
+        # --- hand-written trailing lookaround -----------------------------------
+        # A row that ends in a hand-written zero-width lookaround (never a placeholder)
+        # is likewise NOT anchored. Used by ACLs like
+        # `interface (?!25GE.+?/...|Vbdif(~/(52[1-9]\d{4})/))` to cover any interface
+        # whose name is not one of the excluded ones. A ~/.../ placeholder may be nested
+        # inside the lookaround (preceded by `(`), so it is still unwrapped.
+        (
+            r"interface (?!25GE.+?/([^12](\.|$)|\d{2}(\.|$))|Vbdif(~/(52[1-9]\d{4})/))",
+            r"^interface\s+(?!25GE.+?/([^12](\.|$)|\d{2}(\.|$))|Vbdif(((?:52[1-9]\d{4}))))",
+            "interface 100GE1/0/1",
+            True,
+        ),
+        (
+            r"interface (?!25GE.+?/([^12](\.|$)|\d{2}(\.|$))|Vbdif(~/(52[1-9]\d{4})/))",
+            r"^interface\s+(?!25GE.+?/([^12](\.|$)|\d{2}(\.|$))|Vbdif(((?:52[1-9]\d{4}))))",
+            "interface 25GE1/0/3",
+            False,
+        ),
+        (
+            r"interface (?!25GE.+?/([^12](\.|$)|\d{2}(\.|$))|Vbdif(~/(52[1-9]\d{4})/))",
+            r"^interface\s+(?!25GE.+?/([^12](\.|$)|\d{2}(\.|$))|Vbdif(((?:52[1-9]\d{4}))))",
+            "interface Vbdif5210000",
+            False,
+        ),
+        # a placeholder nested in a (?!...) lookahead is unwrapped, and the lookahead
+        # tail is left un-anchored
+        (
+            r"interface Vbdif(?!~/(52[1-9]\d{4})/)",
+            r"^interface\s+Vbdif(?!((?:52[1-9]\d{4})))",
+            "interface Vbdif100",
+            True,
+        ),
+        (
+            r"interface Vbdif(?!~/(52[1-9]\d{4})/)",
+            r"^interface\s+Vbdif(?!((?:52[1-9]\d{4})))",
+            "interface Vbdif5210000",
+            False,
+        ),
+        # a plain trailing capturing group (not a lookaround) still gets the anchor
+        ("interface (eth|lo)", r"^interface\s+(eth|lo)(?:\s|$)", "interface eth", True),
+        ("interface (eth|lo)", r"^interface\s+(eth|lo)(?:\s|$)", "interface ethernet", False),
     ],
 )
 def test_compile_row_regexp(row, expected_pattern, line, should_match) -> None:


### PR DESCRIPTION
PR #574 unified ?/{regex}/ and ~/{regex}/ handling but narrowed several behaviours that production ACLs relied on, each silently breaking ACL compilation. Restore them while keeping #574's capture semantics and tests:

* Nested placeholders. ~/{regex}/ is now matched anywhere, not only at a word boundary, so a placeholder interpolated into a hand-written regexp is still unwrapped -- e.g. interface (?!...|Vbdif(~/(52[1-9]\d{4})/)). ? keeps a leading boundary (it is a quantifier); ~ never needs one.

* Glued / dot-separated placeholders. The closing / is the first one followed by whitespace, or (lazily) by non-slash text up to the next ?/ or ~/ or end-of-row. This splits ~/(25GE.+?/[12])/~/(\d+)/ and ~/(...\/...)/.~/(...)/ at their joins while still letting a regexp embed literal slashes.

* Trailing anchoring. A row ending in a placeholder, or in a hand-written zero-width lookaround (interface (?!...)), is no longer anchored with (?:\s|$). The user's regexp owns the right edge, so a line may legitimately continue past the match -- e.g. interface ~/(25GE1\/0\/10(?![0-9]))/ must still match the subinterface 25GE1/0/10.1501. This generalises the #588 fix (which only un-anchored empty-matching trailing placeholders) and the earlier zero-width lookahead fix.

Extend the regression tests to cover nested, glued and dot-separated placeholders, hand-written trailing lookarounds, and the un-anchored trailing-placeholder cases.