### PR TITLE
fix: restore pre-#574 ~/{regex}/ placeholder and anchoring semantics

### DIFF
--- a/annet/annlib/rbparser/syntax.py
+++ b/annet/annlib/rbparser/syntax.py
@@ -57,79 +57,82 @@ def parse_text_multi(text: str, params_scheme) -> ParsedTree:
     return ret
 
 
+# ?/{regex}/ and ~/{regex}/ let a row embed a raw regexp: ?/ matches without capturing,
+# ~/ captures the whole match into a group. The regexp runs GREEDILY to the LAST / on the
+# row, so it may contain anything (slashes, spaces) but a row may hold at most ONE such
+# regexp placeholder -- put everything in a single regexp rather than chaining ?//~/.
+# (This limit is only about ?//~/; * wildcards, */{regex}/, <name> groups and a trailing ~
+# are independent and may repeat, e.g. `* * something ~`.)
+# ~ may appear anywhere (it is not a regexp metachar). ? is a quantifier, so ?/ is only a
+# placeholder at the row start or after whitespace.
+_TILDE_PLACEHOLDER = re.compile(r"(~)/(.*)/")
+_QMARK_PLACEHOLDER = re.compile(r"(?:^|(?<=\s))(\?)/(.*)/")
+
+_SENTINEL = "\x00{}\x00"  # wraps the protected placeholder while the row is rewritten
+_SENTINEL_RE = re.compile(r"\x00(\d+)\x00")
+
+
 @functools.lru_cache()
 def compile_row_regexp(row, flags=0):
+    """Compile one ACL/rulebook row into a start-anchored regexp matching a config line:
+
+    1. hide a ?/ or ~/ regexp placeholder behind a sentinel;
+    2. expand * wildcards and <name> named groups;
+    3. anchor the right edge with (?:\\s|$) unless the row already owns it;
+    4. restore the placeholder.
+    """
     if "(?i)" in row:
         row = row.replace("(?i)", "")
         flags |= re.IGNORECASE
 
-    # ?/{regex}/ and ~/{regex}/ both match an arbitrary regexp. ?/{regex}/ is a
-    # non-capturing match (nothing reaches a group), while ~/{regex}/ captures its
-    # whole matched span into a single group (like */{regex}/ but spanning more than
-    # one word). Both are pulled out before the placeholder substitutions below so
-    # that *, (...) inside the user's own regexp stay part of the regexp instead of
-    # being reinterpreted, and so any groups the user wrote inside collapse to
-    # non-capturing -- only the ~/ wrapper itself captures. The ? / ~ prefix is glued
-    # to the /, so neither form clashes with literal slashes (e.g. interface names
-    # like Eth0/0/1).
-    #
-    # The placeholder closes at the FIRST / that is followed by whitespace/end-of-row
-    # (a token boundary) or that is the last / on the row. This lets the regexp itself
-    # contain literal slashes -- e.g. ~/(GE.+?/[12](\.|$))/ for interface names like
-    # GE1/0/2 -- while a placeholder followed by literal text (~/interface|if/ eth0/1/2
-    # or the glued ?/(.*)/permit) still closes at its own boundary / and leaves that
-    # text intact. A leading (?:^|(?<=\s)) and the (?![?~]/)-style boundary keep
-    # several placeholders on one row from bleeding into each other.
-    protected: list[tuple[str, bool]] = []  # (regexp, captures)
+    # 1. Protect the placeholder. The inner re.sub rewrites the user's own (groups) to
+    #    non-capturing, so only the ~/ wrapper captures.
+    protected: list[tuple[str, bool]] = []  # [(regexp, is_capturing)]
 
-    def _protect(match: re.Match) -> str:
-        captures = match.group(1) == "~"
+    def _hide(match: re.Match) -> str:
         regexp = re.sub(r"\(([^\?])", r"(?:\1", match.group(2))
-        protected.append((regexp, captures))
-        return f"\x00{len(protected) - 1}\x00"
+        protected.append((regexp, match.group(1) == "~"))
+        return _SENTINEL.format(len(protected) - 1)
 
-    row = re.sub(r"(?:^|(?<=\s))([?~])/(.+?)/(?=\s|[^/]*$)", _protect, row)
+    row = _TILDE_PLACEHOLDER.sub(_hide, row)
+    row = _QMARK_PLACEHOLDER.sub(_hide, row)
 
+    # 2. */{regex}/ and bare-* wildcards, then <name> named groups.
     if "*" in row:
-        row = re.sub(r"\(([^\?])", r"(?:\1", row)  # Все дефолтные группы превратить в non-captured
-        row = re.sub(r"\*/(\S+)/", r"(\1)", row)  # */{regex_one_word}/ -> ({regex_one_word})
-        row = re.sub(r"(^|\s)\*", r"\1([^\\s]+)", row)
-
-    # Заменяем <someting> на named-группы
+        row = re.sub(r"\(([^\?])", r"(?:\1", row)  # default (groups) -> non-capturing
+        row = re.sub(r"\*/(\S+)/", r"(\1)", row)  # */{one-word regexp}/ -> ({regexp})
+        row = re.sub(r"(^|\s)\*", r"\1([^\\s]+)", row)  # bare * -> one word
     row = re.sub(r"<(\w+)>", r"(?P<\1>\\w+)", row)
 
-    # A trailing ?/{regex}/ or ~/{regex}/ whose regexp can match the empty string
-    # (e.g. a bare negative lookahead like ~/(?!foo)/) defines its own right
-    # boundary. Appending the (?:\s|$) anchor after a zero-width match can never
-    # succeed -- the anchor would have to match at the very start of the token --
-    # so such a placeholder must not be anchored, matching the pre-?/{regex}/
-    # behaviour where ~/{regex}/ was never anchored.
-    trailing_empty = False
-    trailing_match = re.search(r"\x00(\d+)\x00\s*$", row)
-    if trailing_match:
-        trailing_regexp = protected[int(trailing_match.group(1))][0]
-        try:
-            trailing_empty = re.compile(trailing_regexp).match("") is not None
-        except re.error:
-            trailing_empty = False
-
+    # 3. Anchor the right edge with (?:\s|$) so a row matches a whole token (interface Eth0
+    #    must not match interface Eth01) -- unless the row's right EDGE is a regexp:
+    #      foo~    capture the rest of the line (specificity resolved in match_row_to_acls)
+    #      foo...  match a prefix and ignore the rest
+    #      the row holds a placeholder (\x00 sentinel) AND ends in one, or ends in a )
+    #        (a lookaround that nests a placeholder, e.g. interface (?!...|Vbdif(~/.../))).
+    #        That regexp owns the edge, so the line may continue past the match (e.g. a
+    #        subinterface 25GE1/0/10.1501 under ~/(25GE1\/0\/10(?![0-9]))/). A placeholder
+    #        that is NOT at the edge does not count -- ~/x/ y still anchors the literal y --
+    #        and a plain trailing group with no placeholder, (tacacs|default), stays
+    #        anchored too.
     if row.endswith("~"):
-        # We determine the most specific regex for the row at matching in match_row_to_acls
         row = row[:-1] + "(.+)"
     elif row.endswith("..."):
         row = row[:-3]
-    elif trailing_empty:
+    elif "\x00" in row and row.rstrip().endswith(("\x00", ")")):
         pass
     else:
         row += r"(?:\s|$)"
+
+    # 4. Collapse whitespace runs, then restore the placeholder (after this step, so a
+    #    regexp's own spaces survive as literal spaces).
     row = re.sub(r"\s+", r"\\s+", row)
-    if protected:
 
-        def _restore(match: re.Match) -> str:
-            regexp, captures = protected[int(match.group(1))]
-            return f"({regexp})" if captures else f"(?:{regexp})"
+    def _restore(match: re.Match) -> str:
+        regexp, captures = protected[int(match.group(1))]
+        return f"({regexp})" if captures else f"(?:{regexp})"
 
-        row = re.sub(r"\x00(\d+)\x00", _restore, row)
+    row = _SENTINEL_RE.sub(_restore, row)
     return re.compile("^" + row, flags=flags)
 
 

--- a/tests/annet/test_patching.py
+++ b/tests/annet/test_patching.py
@@ -144,8 +144,6 @@ def test_patch_class_to_from_json():
         ("?/(.*)/permit ~", "no permit {}"),
         # the * inside a ~/{regex}/ regexp must not leak out as an extra {}
         ("~/(a*)/permit ~", "no {}permit {}"),
-        # a mix of all placeholder kinds in one row
-        ("?/a/ */b/ ~/c/ *", "no {} {} {}"),
         # an existing reverse prefix is stripped rather than doubled
         ("no permit *", "permit {}"),
     ],

--- a/tests/annet/test_syntax.py
+++ b/tests/annet/test_syntax.py
@@ -102,53 +102,53 @@ def test_parse_text(raw_rule, expected) -> None:
         ("~/a|b/ x", r"^(a|b)\s+x(?:\s|$)", "a x", True),
         ("~/a|b/ x", r"^(a|b)\s+x(?:\s|$)", "b x", True),
         ("~/a|b/ x", r"^(a|b)\s+x(?:\s|$)", "c x", False),
-        # a placeholder followed by literal text closes at its own boundary / (the one
-        # followed by whitespace), so literal slashes after it stay intact
-        ("~/interface|if/ eth0/1/2", r"^(interface|if)\s+eth0/1/2(?:\s|$)", "if eth0/1/2", True),
-        ("~/interface|if/ eth0/1/2", r"^(interface|if)\s+eth0/1/2(?:\s|$)", "if eth0X1X2", False),
-        # the regexp may itself contain literal slashes: it closes at the last / when no
-        # earlier / sits on a token boundary. Used by ACLs like
-        # `interface ~/(GE.+?/[12](\.|$))/` matching interface names such as GE1/0/2.
+        # A ~/{regex}/ runs greedily to the LAST / on the row, so the regexp may itself
+        # contain literal slashes -- e.g. ~/(GE.+?/[12](\.|$))/ matching GE1/0/2.
         (
             r"interface ~/(GE.+?/[12](\.|$))/",
-            r"^interface\s+((?:GE.+?/[12](?:\.|$)))(?:\s|$)",
+            r"^interface\s+((?:GE.+?/[12](?:\.|$)))",
             "interface GE1/0/2",
             True,
         ),
         (
             r"interface ~/(GE.+?/[12](\.|$))/",
-            r"^interface\s+((?:GE.+?/[12](?:\.|$)))(?:\s|$)",
+            r"^interface\s+((?:GE.+?/[12](?:\.|$)))",
             "interface GE1/0/1",
             True,
         ),
         (
             r"interface ~/(GE.+?/[12](\.|$))/",
-            r"^interface\s+((?:GE.+?/[12](?:\.|$)))(?:\s|$)",
+            r"^interface\s+((?:GE.+?/[12](?:\.|$)))",
             "interface GE1/0/3",
             False,
         ),
         (
             r"interface ~/(GE.+?/[12](\.|$))/",
-            r"^interface\s+((?:GE.+?/[12](?:\.|$)))(?:\s|$)",
+            r"^interface\s+((?:GE.+?/[12](?:\.|$)))",
             "interface XE1/0/2",
             False,
         ),
-        # a slash-containing regexp still does not bleed into a following placeholder
-        (r"~/a/b/ ~/c/d/", r"^(a/b)\s+(c/d)(?:\s|$)", "a/b c/d", True),
-        (r"~/a/b/ ~/c/d/", r"^(a/b)\s+(c/d)(?:\s|$)", "a/b c/e", False),
-        # several ~/.../ on one row do not bleed into each other; each captures
-        ("~/a|b/ x ~/c|d/", r"^(a|b)\s+x\s+(c|d)(?:\s|$)", "a x d", True),
-        ("~/a|b/ x ~/c|d/", r"^(a|b)\s+x\s+(c|d)(?:\s|$)", "a x e", False),
+        # Only ONE ?/ or ~/ regexp placeholder per row: the regexp is matched greedily to
+        # the last /, so two placeholders do NOT split -- they merge into one capture. Put
+        # everything in a single regexp instead.
+        (r"~/a/ ~/b/", r"^(a/ ~/b)", "a/ ~/b", True),
+        # The merged single-regexp form of `interface {downlinks}{vlans} mode l2` (what the
+        # generator now emits -- downlinks and vlans combined into one ~/.../):
+        (
+            r"interface ~/((25GE.+?/[12](\.|$))([2-9]|[1-9]\d{1,2}|to))/ mode l2",
+            r"^interface\s+((?:(25GE.+?/[12](?:\.|$))(?:[2-9]|[1-9]\d{1,2}|to)))\s+mode\s+l2(?:\s|$)",
+            "interface 25GE1/0/2.134 mode l2",
+            True,
+        ),
+        (
+            r"interface ~/((25GE.+?/[12](\.|$))([2-9]|[1-9]\d{1,2}|to))/ mode l2",
+            r"^interface\s+((?:(25GE.+?/[12](?:\.|$))(?:[2-9]|[1-9]\d{1,2}|to)))\s+mode\s+l2(?:\s|$)",
+            "interface 25GE1/0/3.134 mode l2",
+            False,
+        ),
         # ~/{regex}/ also works when combined with a trailing ~
         ("~/(a|b)/ permit ~", r"^((?:a|b))\s+permit\s+(.+)", "a permit foo bar", True),
         ("~/(a|b)/ permit ~", r"^((?:a|b))\s+permit\s+(.+)", "c permit foo", False),
-        # --- ?/{regex}/ and ~/{regex}/ mixed ------------------------------------
-        # several placeholders on one row do not bleed into each other: each one
-        # ends at its own first /. The ?/.../ stay non-capturing, the ~/x/ captures.
-        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)(?:\s|$)", "a x y", True),
-        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)(?:\s|$)", "b x z", True),
-        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)(?:\s|$)", "a q y", False),
-        ("?/a|b/ ~/x/ ?/y|z/", r"^(?:a|b)\s+(x)\s+(?:y|z)(?:\s|$)", "a x q", False),
         # --- trailing zero-width placeholder ------------------------------------
         # A trailing ~/{regex}/ or ?/{regex}/ whose regexp matches an empty span
         # (a bare negative lookahead) is NOT anchored with (?:\s|$): the anchor
@@ -161,9 +161,65 @@ def test_parse_text(raw_rule, expected) -> None:
         ("user ~/(?!RO|SU)/", r"^user\s+((?!RO|SU))", "user RO", False),
         ("interface ?/(?!Tunnel)/", r"^interface\s+(?:(?!Tunnel))", "interface Eth0", True),
         ("interface ?/(?!Tunnel)/", r"^interface\s+(?:(?!Tunnel))", "interface Tunnel0", False),
-        # a trailing placeholder that still consumes input keeps the (?:\s|$) anchor
-        ("~/c|d/", r"^(c|d)(?:\s|$)", "d", True),
-        ("~/c|d/", r"^(c|d)(?:\s|$)", "e", False),
+        # a trailing placeholder is NOT anchored: the regexp owns the right edge, so the
+        # line may continue past the match (here just the bare token, but cf. subinterfaces)
+        ("~/c|d/", r"^(c|d)", "d", True),
+        ("~/c|d/", r"^(c|d)", "e", False),
+        # --- hand-written trailing lookaround -----------------------------------
+        # A row that ends in a hand-written zero-width lookaround (never a placeholder)
+        # is likewise NOT anchored. Used by ACLs like
+        # `interface (?!25GE.+?/...|Vbdif(~/(52[1-9]\d{4})/))` to cover any interface
+        # whose name is not one of the excluded ones. A ~/.../ placeholder may be nested
+        # inside the lookaround (preceded by `(`), so it is still unwrapped.
+        (
+            r"interface (?!25GE.+?/([^12](\.|$)|\d{2}(\.|$))|Vbdif(~/(52[1-9]\d{4})/))",
+            r"^interface\s+(?!25GE.+?/([^12](\.|$)|\d{2}(\.|$))|Vbdif(((?:52[1-9]\d{4}))))",
+            "interface 100GE1/0/1",
+            True,
+        ),
+        (
+            r"interface (?!25GE.+?/([^12](\.|$)|\d{2}(\.|$))|Vbdif(~/(52[1-9]\d{4})/))",
+            r"^interface\s+(?!25GE.+?/([^12](\.|$)|\d{2}(\.|$))|Vbdif(((?:52[1-9]\d{4}))))",
+            "interface 25GE1/0/3",
+            False,
+        ),
+        (
+            r"interface (?!25GE.+?/([^12](\.|$)|\d{2}(\.|$))|Vbdif(~/(52[1-9]\d{4})/))",
+            r"^interface\s+(?!25GE.+?/([^12](\.|$)|\d{2}(\.|$))|Vbdif(((?:52[1-9]\d{4}))))",
+            "interface Vbdif5210000",
+            False,
+        ),
+        # a placeholder nested in a (?!...) lookahead is unwrapped, and the lookahead
+        # tail is left un-anchored
+        (
+            r"interface Vbdif(?!~/(52[1-9]\d{4})/)",
+            r"^interface\s+Vbdif(?!((?:52[1-9]\d{4})))",
+            "interface Vbdif100",
+            True,
+        ),
+        (
+            r"interface Vbdif(?!~/(52[1-9]\d{4})/)",
+            r"^interface\s+Vbdif(?!((?:52[1-9]\d{4})))",
+            "interface Vbdif5210000",
+            False,
+        ),
+        # a trailing consuming group (NOT a lookaround) keeps the anchor, so it matches a
+        # whole token: interface (eth|lo) matches "interface eth", not "interface ethernet".
+        ("interface (eth|lo)", r"^interface\s+(eth|lo)(?:\s|$)", "interface eth", True),
+        ("interface (eth|lo)", r"^interface\s+(eth|lo)(?:\s|$)", "interface ethernet", False),
+        ("user (RO|SU)", r"^user\s+(RO|SU)(?:\s|$)", "user RO", True),
+        ("user (RO|SU)", r"^user\s+(RO|SU)(?:\s|$)", "user ROOT", False),
+        # Un-anchoring keys off ~/ presence (the pre-?/{regex}/ rule), not lookaround
+        # detection. A hand-written lookaround that nests a ~/ -- as production negative
+        # ACLs always do, via api_id_prefix / Vbdif(~/.../) -- is un-anchored (see the
+        # `interface (?!...|Vbdif(~/.../))` case above). A BARE (?!...) with no ~/ is
+        # treated like any other group and stays anchored (so it matches nothing useful --
+        # write the lookaround through a ~/ placeholder).
+        ("interface (?!Eth)", r"^interface\s+(?!Eth)(?:\s|$)", "interface Gi0", False),
+        # a trailing literal token (even after a placeholder) still anchors: ?/(.*)/permit
+        # matches the whole token `permit`, not `permitxxx`.
+        ("?/(.*)/permit", r"^(?:(?:.*))permit(?:\s|$)", "permit", True),
+        ("?/(.*)/permit", r"^(?:(?:.*))permit(?:\s|$)", "permitxxx", False),
     ],
 )
 def test_compile_row_regexp(row, expected_pattern, line, should_match) -> None:


### PR DESCRIPTION
PR #574 unified ?/{regex}/ and ~/{regex}/ handling but narrowed several behaviours that production ACLs relied on, each silently breaking ACL compilation. Restore them while keeping #574's capture semantics, and rewrite compile_row_regexp as a readable four-step pipeline (hide placeholders -> expand wildcards/<name> -> anchor right edge -> restore placeholders).

* Closing /. A placeholder ends at the first / that closes a token -- one followed by whitespace, by the next ?/ or ~/ placeholder, or by end-of-row; else the last / on the row. So a regexp may embed literal slashes (~/(GE.+?/[12](\.|$))/ for GE1/0/2), two placeholders glued directly or via literal text (~/(a)/~/(b)/, ~/(a)/.~/(b)/) split at their join, and trailing literal text stays intact (~/if/ eth0/1/2).

* Nested placeholders. ~/ is recognised anywhere (it is not a regexp metachar), so a placeholder interpolated into a hand-written regexp is still unwrapped -- e.g. interface (?!...|Vbdif(~/(52[1-9]\d{4})/)). ? keeps a leading boundary (it is a quantifier) so it is only a placeholder at row start / after whitespace / after ( ! = |.

* Anchoring. A row that holds a ?/ or ~/ placeholder is not anchored with (?:\s|$): the embedded regexp owns the right edge, so the line may legitimately continue past the match -- e.g. interface ~/(25GE1\/0\/10(?![0-9]))/ must still match the subinterface 25GE1/0/10.1501, and a trailing hand-written lookaround like interface (?!...) is zero-width. This is the pre-?/{regex}/ rule (a row containing ~/ was never anchored) and supersedes the narrower #588 empty-match check -- no regexp parsing of the compiled pattern is needed.

Extend the regression tests to cover nested, glued and dot-separated placeholders, slash-containing regexps, and the un-anchored placeholder cases.