### PR TITLE
fix: aggregate cant_delete only across best ACL matches

### DIFF
--- a/annet/annlib/patching.py
+++ b/annet/annlib/patching.py
@@ -875,11 +875,15 @@ def make_patch(
 
 
 def _aggregate_cant_delete(matches):
-    """Combine cant_delete across ALL rules that matched the row, not just the selected one.
+    """Combine cant_delete across the rules that matched the row, not just the selected one.
 
     The row is protected (cant_delete=1) only if *every* matching generator
     asked to protect it; if at least one matching generator has no %cant_delete,
     the row stays deletable (cant_delete=0).
+
+    Caller must pass only the best matches (rules that share the top metric),
+    otherwise a less specific generic rule like `diffserv domain *` would
+    override a specific one like `diffserv domain default %cant_delete`.
     """
     flags = [flag for (rule, _is_cr_allowed), _other in matches for flag in rule["attrs"]["cant_delete"]]
     if not flags:
@@ -887,14 +891,33 @@ def _aggregate_cant_delete(matches):
     return [all(flags)]
 
 
+def _best_matches(matches_with_metric):
+    """Pick the matches that share the top metric (prio, string_similarity).
+
+    `_find_acl_matches` already sorts matches by metric in descending order, so
+    the best metric is at the head of the list.
+    """
+    if not matches_with_metric:
+        return []
+    top_metric = matches_with_metric[0][0]
+    return [item for metric, item in matches_with_metric if metric == top_metric]
+
+
 def match_row_to_acl(row, rules, exclusive=False):
-    matches = _find_acl_matches(row, rules)
-    if matches:
+    matches_with_metric = _find_acl_matches(row, rules)
+    if matches_with_metric:
+        matches = [item for _metric, item in matches_with_metric]
+        # cant_delete and exclusivity must only consider rules that matched the
+        # row equally well (same %prio and same string_similarity).  Otherwise
+        # a generic catch-all like `diffserv domain *` would drop the
+        # `%cant_delete` flag set by a more specific `diffserv domain default
+        # %cant_delete` and the row would be wrongly deleted.
+        best_matches = _best_matches(matches_with_metric)
         if exclusive:
             gen_cant_delete = {}
-            for match in matches:
-                names = match[0][0]["attrs"]["generator_names"]
-                flags = match[0][0]["attrs"]["cant_delete"]
+            for match in best_matches:
+                names = match[0]["attrs"]["generator_names"]
+                flags = match[0]["attrs"]["cant_delete"]
                 for name, flag in zip(names, flags):
                     if name not in gen_cant_delete:
                         gen_cant_delete[name] = flag
@@ -906,7 +929,7 @@ def match_row_to_acl(row, rules, exclusive=False):
                 raise AclNotExclusiveError("generators: '%s'" % generator_names)
         match, children_rules = _select_match(matches, rules)
         if match is not None:
-            aggregated = _aggregate_cant_delete(matches)
+            aggregated = _aggregate_cant_delete(best_matches)
             if aggregated is not None:
                 match = match.copy()
                 match["attrs"] = match["attrs"].copy()
@@ -951,7 +974,9 @@ def _find_acl_matches(row, rules):
                 )
                 res.append(item)
     res.sort(key=operator.itemgetter(0), reverse=True)
-    return [item[1] for item in res]
+    # Return (metric, item) pairs so callers can tell apart best matches from
+    # less specific ones (see `match_row_to_acl` / `_aggregate_cant_delete`).
+    return res
 
 
 def _find_rules_matches(row, rules):

--- a/tests/annet/test_cant_delete.py
+++ b/tests/annet/test_cant_delete.py
@@ -46,6 +46,30 @@ def test_cant_delete_subblock(config, acl, device):
     assert patch == {"interface ge1/1/1": OrderedDict([("undo removed", None)])}
 
 
+# Real-world scenario: an ACL has both a specific rule that protects
+# `diffserv domain default` via `%cant_delete` and a generic catch-all
+# `diffserv domain *` without `%cant_delete`.  Aggregating cant_delete across
+# *all* matching rules used to AND the two flags and drop protection from the
+# `default` domain, deleting it.  Only the best matches (same %prio and same
+# string_similarity) must contribute to the aggregation, so the specific rule
+# wins for `default` while the generic rule still allows deleting other domains.
+def test_cant_delete_specific_rule_wins_over_catch_all(device):
+    acl = compile_acl_text(
+        r"""
+        diffserv domain default %cant_delete
+        diffserv domain *
+        """,
+        device.hw.vendor,
+    )
+    config = r"""
+        diffserv domain default
+        diffserv domain other
+    """
+    patch = _make_patch(config, acl, device)
+    # `default` must stay (protected by the specific rule); `other` must be deleted.
+    assert patch == {"undo diffserv domain other": None}
+
+
 def _make_patch(config, acl, device):
     formatter = registry_connector.get().match(device.hw).make_formatter()
     empty_tree = tabparser.parse_to_tree("", formatter.split)


### PR DESCRIPTION
When two ACL rules matched the same row — e.g. `diffserv domain default %cant_delete` and the catch-all `diffserv domain *` — _aggregate_cant_delete AND-ed cant_delete across *all* of them and dropped protection from the specific row, deleting it.

Filter to only the best matches (those sharing the top metric of `%prio` and `string_similarity`) before aggregating `cant_delete` and checking exclusivity, so the more specific rule wins per row while the generic rule still applies to everything else.