### PR TITLE
`ALLOW_NONE`: explicitly configure if `None` keyword is allowed inside generator-yielded content

### DIFF
--- a/annet/generators/base.py
+++ b/annet/generators/base.py
@@ -60,6 +60,7 @@ def _split_and_strip(text):
 class BaseGenerator:
     TYPE: str
     TAGS: List[str] = []
+    ALLOW_NONE = False
 
     def supports_device(self, device) -> bool:  # pylint: disable=unused-argument
         return True

--- a/annet/generators/entire.py
+++ b/annet/generators/entire.py
@@ -77,7 +77,7 @@ class Entire(BaseGenerator):
         for text in run_res:
             if isinstance(text, tuple):
                 text = " ".join(map(_filter_str, flatten(text)))
-            if NONE_SEARCHER.search(text):
+            if not self.ALLOW_NONE and NONE_SEARCHER.search(text):
                 raise InvalidValueFromGenerator("Found 'None' in yield result: %s" % text)
             parts.append(text)
 

--- a/annet/generators/partial.py
+++ b/annet/generators/partial.py
@@ -63,9 +63,12 @@ class PartialGenerator(TreeGenerator):
                 text = _filter_str(text)
             self._append_text(text)
 
-        for row, annotation in zip(self._rows, self._annotations):
-            if NONE_SEARCHER.search(row):
-                raise InvalidValueFromGenerator("Found 'None' in yield result: %s" % add_annotation(row, annotation))
+        if not self.ALLOW_NONE:
+            for row, annotation in zip(self._rows, self._annotations):
+                if NONE_SEARCHER.search(row):
+                    raise InvalidValueFromGenerator(
+                        "Found 'None' in yield result: %s" % add_annotation(row, annotation)
+                    )
 
         if annotate:
             generated_rows = (add_annotation(x, y) for (x, y) in zip(self._rows, self._annotations))


### PR DESCRIPTION
This PR adds `ALLOW_NONE` option to generators, which provides `None` keyword admissibility explicitly per-generator.
This PR also configures defaults:
- `None` keyword is forbidden by default.

**Rationale**: make it possible to generate full python scripts, which use `None` keyword for state detection & transitions, without any dirty workarounds.