### PR TITLE
fix: keep cant_delete protection for reverse commands

### DIFF
--- a/annet/annlib/patching.py
+++ b/annet/annlib/patching.py
@@ -907,17 +907,26 @@ def match_row_to_acl(row, rules, exclusive=False):
     matches_with_metric = _find_acl_matches(row, rules)
     if matches_with_metric:
         matches = [item for _metric, item in matches_with_metric]
+        match, children_rules = _select_match(matches, rules)
         # cant_delete and exclusivity must only consider rules that matched the
         # row equally well (same %prio and same string_similarity).  Otherwise
         # a generic catch-all like `diffserv domain *` would drop the
         # `%cant_delete` flag set by a more specific `diffserv domain default
         # %cant_delete` and the row would be wrongly deleted.
         best_matches = _best_matches(matches_with_metric)
+        # A row like `undo shutdown` can match both the direct rule `undo
+        # shutdown %cant_delete` and the *reverse* form of a sibling rule
+        # `shutdown` with the very same metric.  These are different commands,
+        # so the reverse match must not dilute the `%cant_delete` set on the
+        # selected (direct) rule.  Keep only the best matches that matched in the
+        # same direction as the selected match before aggregating.
+        if match is not None:
+            best_matches = [m for m in best_matches if m[1]["is_reverse"] == match["is_reverse"]]
         if exclusive:
             gen_cant_delete = {}
-            for match in best_matches:
-                names = match[0][0]["attrs"]["generator_names"]
-                flags = match[0][0]["attrs"]["cant_delete"]
+            for best_match in best_matches:
+                names = best_match[0][0]["attrs"]["generator_names"]
+                flags = best_match[0][0]["attrs"]["cant_delete"]
                 for name, flag in zip(names, flags):
                     if name not in gen_cant_delete:
                         gen_cant_delete[name] = flag
@@ -927,7 +936,6 @@ def match_row_to_acl(row, rules, exclusive=False):
             if len(can_delete) > 1:
                 generator_names = ", ".join(can_delete.keys())
                 raise AclNotExclusiveError("generators: '%s'" % generator_names)
-        match, children_rules = _select_match(matches, rules)
         if match is not None:
             aggregated = _aggregate_cant_delete(best_matches)
             if aggregated is not None:

--- a/tests/annet/test_cant_delete.py
+++ b/tests/annet/test_cant_delete.py
@@ -70,6 +70,49 @@ def test_cant_delete_specific_rule_wins_over_catch_all(device):
     assert patch == {"undo diffserv domain other": None}
 
 
+# Regression: a reverse command like `undo shutdown` present on the device must
+# stay protected by `undo shutdown %cant_delete`.  The row `undo shutdown`
+# matches both the direct rule `undo shutdown %cant_delete` and the *reverse*
+# form of a sibling rule `shutdown` (no %cant_delete) with the very same metric.
+# Aggregating cant_delete across both best matches AND-ed the flags and dropped
+# protection, so the row was wrongly deleted (emitted as `shutdown`).  Only the
+# best matches sharing the selected (direct) match's direction must contribute.
+@pytest.mark.parametrize(
+    "acl_text",
+    [
+        # a single ACL with the protecting rule and a reverse-matching sibling
+        r"""
+        interface %cant_delete=1
+            undo shutdown %cant_delete=1
+            shutdown
+        """,
+        # sibling order must not matter
+        r"""
+        interface %cant_delete=1
+            shutdown
+            undo shutdown %cant_delete=1
+        """,
+        # two generators: one protects `undo shutdown`, the other emits the
+        # canonical `shutdown` whose reverse form matches the same row
+        r"""
+        interface %cant_delete %generator_names=gen1
+            undo shutdown %cant_delete=1 %generator_names=gen1
+        interface %generator_names=gen2
+            shutdown %generator_names=gen2
+        """,
+    ],
+)
+def test_cant_delete_protects_reverse_command(device, acl_text):
+    acl = compile_acl_text(acl_text, device.hw.vendor)
+    config = r"""
+        interface ge1/1/1
+            undo shutdown
+    """
+    patch = _make_patch(config, acl, device)
+    # `undo shutdown` must stay; nothing may be deleted.
+    assert patch == {}
+
+
 def _make_patch(config, acl, device):
     formatter = registry_connector.get().match(device.hw).make_formatter()
     empty_tree = tabparser.parse_to_tree("", formatter.split)


### PR DESCRIPTION
A reverse command present on the device (e.g. `undo shutdown`) could match an ACL in two directions with the same metric: the direct rule `undo shutdown %cant_delete` and the reverse form of a sibling rule `shutdown` without %cant_delete. _aggregate_cant_delete then AND-ed the two flags across both best matches and dropped protection, deleting the line.

Filter the best matches to those matching in the same direction as the selected match before aggregating cant_delete and checking exclusivity, so a reverse match of a different command no longer dilutes the %cant_delete set on the selected direct rule.