### PR TITLE
fix: H3C prefix-list patch generation

### DIFF
--- a/annet/rulebook/h3c/misc.py
+++ b/annet/rulebook/h3c/misc.py
@@ -47,9 +47,9 @@ def prefix_list(
     for op, rows in diff.items():
         for row in rows:
             # prefix list format:
-            # ip ip-prefix PRFX_CT_LU_ALLOWED_ROUTES index 15 ..
-            # ip ipv6-prefix PFXS_SPECIALv6 index 20 ..
-            _ip, _family, _name, _index, index, *_ = row["row"].split()
+            # ip prefix-list PRFX_CT_LU_ALLOWED_ROUTES index 15 ..
+            # ipv6 prefix-list PFXS_SPECIALv6 index 20 ..
+            _family, _prefix_list, _name, _index, index, *_ = row["row"].split()
             if index not in diff_by_index:
                 sub_diff: dict[str, list[dict[str, Any]]] = {op: [] for op in diff.keys()}
                 diff_by_index[index] = sub_diff
@@ -62,12 +62,12 @@ def prefix_list(
         # Since the rule key originally doesn’t include the index,
         # we need to add it; otherwise, the undo rule will be missing it.
         indexed_rule = copy.deepcopy(rule)
-        indexed_rule["reverse"] = "undo ip {}-prefix {} index {}"
+        indexed_rule["reverse"] = "undo {} prefix-list {} index {}"
 
         # The stub_index is referenced in the h3c.order rulebook
         # to ensure that the stub is added or removed first or last in order.
 
-        stub, stub_index = "", 99999999
+        stub, stub_index = "", 65535
 
         # If we’re only adding new commands (for example, creating entries) in the prefix list,
         # or deleting/moving them while keeping some parts unchanged,
@@ -76,11 +76,11 @@ def prefix_list(
         if (diff[Op.REMOVED] or diff[Op.MOVED]) and not diff[Op.UNCHANGED]:
             stub = "deny 0.0.0.0 32" if family == "ip" else "deny :: 128"
         if stub:
-            yield (True, f"ip {family}-prefix {name} index {stub_index} {stub}", None)
+            yield (True, f"{family} prefix-list {name} index {stub_index} {stub}", None)
         for index, sub_diff in diff_by_index.items():
             yield from common.undo_redo(indexed_rule, (family, name, index), sub_diff, **kwargs)
         if stub:
-            yield (False, f"undo ip {family}-prefix {name} index {stub_index}", None)
+            yield (False, f"undo {family} prefix-list {name} index {stub_index}", None)
 
 
 def static(

--- a/annet/rulebook/texts/h3c.order
+++ b/annet/rulebook/texts/h3c.order
@@ -32,7 +32,7 @@ ip vpn-instance */[OoMm][OoLl][BbAa].*/
 # в таком случае нужно расскомментить эту строчку, но она не позволяет снести plist целиком
 # сначала мы добавляем stub-правило в рулсет чтобы оно не позволяло prefix-list'у "пропасть"
 # индекс референсится в логике патчинга префикс-листа h3c.misc.prefix_list
-*/(ip|ipv6)/ prefix-list * index 99999999
+*/(ip|ipv6)/ prefix-list * index 65535
 undo */(ip|ipv6)/ prefix-list * index *   %order_reverse
 */(ip|ipv6)/ prefix-list
 
@@ -377,7 +377,7 @@ undo sflow %order_reverse
 # поскольку если префикс-лист должен уходить из конфигурации полностью
 # перед этим должны быть удалены все его референсы в конфиге
 # индекс референсится в логике патчинга префикс-листа h3c.misc.prefix_list
-undo */(ip|ipv6)/ prefix-list * index 99999999  %order_reverse
+undo */(ip|ipv6)/ prefix-list * index 65535  %order_reverse
 
 #remove template only after all references will be cleared
 undo radius-server template %order_reverse

--- a/annet/rulebook/texts/h3c.rul
+++ b/annet/rulebook/texts/h3c.rul
@@ -141,7 +141,7 @@ ip vpn-instance *
         route-distinguisher *
         export route-policy
 
-ip */(ip|ipv6)/-prefix * %logic=annet.rulebook.h3c.misc.prefix_list
+*/(ip|ipv6)/ prefix-list * %logic=annet.rulebook.h3c.misc.prefix_list
 ip as-path-filter * index *
 ip community-filter * * index *
 ip extcommunity-filter * * index *

--- a/tests/annet/test_patch/h3c_prefix_list.yaml
+++ b/tests/annet/test_patch/h3c_prefix_list.yaml
@@ -1,0 +1,27 @@
+# H3C deletes prefix-list entries by index only.
+
+- vendor: h3c
+  before: |
+    ipv6 prefix-list ipv6_local index 30 permit FD00:1:1201:1000:: 56
+  after: |
+    ipv6 prefix-list ipv6_local index 30 deny FD00:1:1201:1000:: 56
+  patch: |
+    system-view
+    ipv6 prefix-list ipv6_local index 65535 deny :: 128
+    undo ipv6 prefix-list ipv6_local index 30
+    ipv6 prefix-list ipv6_local index 30 deny FD00:1:1201:1000:: 56
+    undo ipv6 prefix-list ipv6_local index 65535
+    save force
+
+- vendor: h3c
+  before: |
+    ip prefix-list local index 10 permit 10.0.0.0 8
+    ip prefix-list local index 20 permit 172.16.0.0 12
+  after: |
+    ip prefix-list local index 10 permit 10.0.0.0 8
+    ip prefix-list local index 30 permit 192.168.0.0 16
+  patch: |
+    system-view
+    undo ip prefix-list local index 20
+    ip prefix-list local index 30 permit 192.168.0.0 16
+    save force


### PR DESCRIPTION
Fix H3C prefix-list patch generation.

This PR fixes patch generation for H3C prefix-lists.
Previously, the H3C rulebook partially reused Huawei-style prefix-list syntax (ip ip-prefix / ip ipv6-prefix). As a result, H3C commands like:
```
ipv6 prefix-list ipv6_local index 30 permit ...
```
could produce an invalid full-line undo command:
```
undo ipv6 prefix-list ipv6_local index 30 permit ...
```
On H3C, prefix-list entries can only be removed by index:
```
undo ipv6 prefix-list ipv6_local index 30
```
Changed the H3C stub index from invalid 99999999 to valid 65535.