### PR TITLE
fix: H3C route-policy prefix-list undo command

### DIFF
--- a/annet/rulebook/texts/h3c.rul
+++ b/annet/rulebook/texts/h3c.rul
@@ -306,6 +306,7 @@ bridge-domain *
         vxlan vni *
 
 route-policy * (?:permit|deny) node * %logic=annet.rulebook.h3c.misc.rp_node
+    if-match */(ip|ipv6)/ address prefix-list
     if-match cost
     if-match protocol
     apply community

--- a/tests/annet/test_patch/h3c_route_policy.yaml
+++ b/tests/annet/test_patch/h3c_route_policy.yaml
@@ -1,0 +1,35 @@
+- vendor: h3c
+  name: change IPv4 route-policy action
+  before: |
+    route-policy test_policy_v4 permit node 10
+      if-match ip address prefix-list test_prefix_list_v4
+  after: |
+    route-policy test_policy_v4 deny node 10
+      if-match ip address prefix-list test_prefix_list_v4
+  patch: |
+    system-view
+    route-policy test_policy_v4 permit node 10
+      undo if-match ip address prefix-list
+      quit
+    route-policy test_policy_v4 deny node 10
+      if-match ip address prefix-list test_prefix_list_v4
+      quit
+    save force
+
+- vendor: h3c
+  name: change IPv6 route-policy action
+  before: |
+    route-policy test_policy_v6 permit node 10
+      if-match ipv6 address prefix-list test_prefix_list_v6
+  after: |
+    route-policy test_policy_v6 deny node 10
+      if-match ipv6 address prefix-list test_prefix_list_v6
+  patch: |
+    system-view
+    route-policy test_policy_v6 permit node 10
+      undo if-match ipv6 address prefix-list
+      quit
+    route-policy test_policy_v6 deny node 10
+      if-match ipv6 address prefix-list test_prefix_list_v6
+      quit
+    save force


### PR DESCRIPTION
## Problem

When changing the action of an existing H3C `route-policy` node, for example from `permit` to `deny`, Annet recreates the node contents.

For the following command:

```text
if-match ip address prefix-list test_prefix_list_v4
```

Annet generated an incorrect removal command:

```text
undo if-match ip address prefix-list test_prefix_list_v4
```

H3C does not accept the prefix-list name in the undo form. The correct command is:

```text
undo if-match ip address prefix-list
```