### PR TITLE
fix: H3C deploy dialogs

### DIFF
--- a/annet/rulebook/texts/h3c.deploy
+++ b/annet/rulebook/texts/h3c.deploy
@@ -19,178 +19,31 @@
 
 undo bgp
     dialog: Warning: The BGP process will be deleted. Continue? [Y/N]: ::: Y
-undo peer *
-    dialog: Warning: All the configurations related to the BGP peer will be deleted. Continue? [Y/N]: ::: Y
-    dialog: Warning: This operation will reset the peer session. Continue? [Y/N]: ::: Y
+    dialog: Undo BGP process? [Y/N]: ::: Y
 peer * enable
     dialog: Warning: This operation will reset the peer session. Continue? [Y/N]: ::: Y
-peer * timer
-    dialog: Warning: Changing the parameter in this command resets the peer session. Continue? [Y/N]: ::: Y
-undo route-distinguisher *
-    dialog: Warning: RTs of VPN instance and IPv6 related configurations under BGP will be deleted. Continue? [Y/N]: ::: Y
-    dialog: Warning: All the VPN targets in the VPN instance IPv6 address family will be deleted. Continue? [Y/N]: ::: Y
-    dialog: Warning: All VPN targets of this EVPN instance and all EVPN address family-related configurations under BGP will be deleted. Continue? [Y/N]: ::: Y
-
+    dialog: Warning:This operation might reset the peer session. Continue? [Y/N]: ::: Y
+    dialog: Warning:This operation might reset the peer session in the peer group. Continue? [Y/N]: ::: Y
 save
-    dialog: /Warning: The current configuration will be written to the device. Continue\? \[Y/N\]:?/ ::: Y
-    dialog: Warning: The current configuration will be written to the device. Are you sure to continue? [Y/N]: ::: Y
-    dialog: Are you sure to continue?[Y/N] ::: Y
-    dialog: Are you sure to continue? [Y/N] ::: Y
-    dialog: Please input the file name(*.cfg, *.zip, *.dat): ::: vrpcfg.zip
-undo rsa peer-public-key
-    dialog: /Do you want to remove the public key named .*\? \[Y/N\]:/ ::: Y
-undo stelnet server enable
-    dialog: Warning: The operation will stop the STelnet server. Do you want to continue? [Y/N]: ::: Y
-undo telnet * server enable
-    dialog: Warning: The operation will stop the .*Telnet server. Continue? [Y/N]: ::: Y
-undo stelnet * server enable
-    dialog: Warning: The operation will stop the STelnet server. Do you want to continue? [Y/N]: ::: Y
-telnet ipv6 server-source all-interface
-    dialog: Warning: Telnet server source configuration will take effect in the next login. Do you want to continue? [Y/N]: ::: Y
-telnet server-source all-interface
-    dialog: Warning: Telnet server source configuration will take effect in the next login. Do you want to continue? [Y/N]: ::: Y
-    dialog: Warning: Telnet server source configuration will take effect in the next login. Continue? [Y/N]: ::: Y
-telnet ipv6 server-source all-interface
-    dialog: Warning: The IPv6 Telnet server source configuration will take effect in the next login. Continue? [Y/N]: ::: Y
-undo telnet server-source ~
-    dialog: Warning: The operation will delete the Telnet server source configuration and may cause the service to be unavailable. Do you want to continue? [Y/N]: ::: Y
-    dialog: Warning: The operation will delete the Telnet server source configuration and may cause the service to be unavailable. Continue? [Y/N]: ::: Y
-undo telnet ipv6 server-source ~
-    dialog: Warning: The operation will delete the Telnet server source configuration and may cause the service to be unavailable. Do you want to continue? [Y/N]: ::: Y
-    dialog: Warning: The operation will delete the Telnet server source configuration and may cause the service to be unavailable. Continue? [Y/N]: ::: Y
-telnet ipv6 server disable
-    dialog: Warning: The operation will stop the IPv6 Telnet server. Do you want to continue? [Y/N]: ::: Y
-    dialog: Warning: The operation will stop the IPv6 Telnet server. Continue? [Y/N]: ::: Y
-telnet server disable
-    dialog: Warning: The operation will stop the Telnet server. Do you want to continue? [Y/N]: ::: Y
-    dialog: Warning: The operation will stop the Telnet server. Continue? [Y/N]: ::: Y
-ssh ipv6 server-source all-interface
-    dialog: Warning: SSH server source configuration will take effect in the next login. Do you want to continue? [Y/N]: ::: Y
-    dialog: Warning: SSH server source configuration will take effect in the next login. Continue? [Y/N]: ::: Y
-ssh server-source all-interface
-    dialog: Warning: SSH server source configuration will take effect in the next login. Do you want to continue? [Y/N]: ::: Y
-    dialog: Warning: SSH server source configuration will take effect in the next login. Continue? [Y/N]: ::: Y
-undo ssh server-source ~
-    dialog: Warning: The operation will delete the SSH server source configuration and may cause the service to be unavailable. Do you want to continue? [Y/N]: ::: Y
-undo protocol inbound ssh port *
-    dialog: Warning: The operation will stop the ssh port 830 service. Do you want to continue? [Y/N]: ::: Y
-undo sftp server enable
-    dialog: Warning: The operation will stop the SFTP server. Do you want to continue? [Y/N]: ::: Y
-(ftp|FTP) *
-    dialog: Warning: FTP server source configuration will take effect in the next login. Do you want to continue? [Y/N]: ::: Y
-undo (ftp|FTP) server enable
-    dialog: Warning: The operation will stop the FTP server. Do you want to continue? [Y/N]: ::: Y
-undo (ftp|FTP) ipv6 server enable
-    dialog: Warning: The operation will stop the FTP server. Do you want to continue? [Y/N]: ::: Y
-undo (ftp|FTP) (server source|server-source)
-    dialog: Warning: The operation will delete the FTP server source configuration and may cause the service to be unavailable. Do you want to continue? [Y/N]: ::: Y
-    dialog: Warning: To make the server source configuration take effect, the FTP server will be restarted. Continue? [Y/N]: ::: Y
-undo (ftp|FTP) ipv6 (server source|server-source)
-    dialog: Warning: The operation will delete the FTP server source configuration and may cause the service to be unavailable. Do you want to continue? [Y/N]: ::: Y
-    dialog: Warning: To make the server source configuration take effect, the FTP server will be restarted. Continue? [Y/N]: ::: Y
-undo http server enable
-    dialog: Warning: The operation will stop HTTP service. Continue? [Y/N]: ::: Y
-undo sftp * server enable
-    dialog: Warning: The operation will stop the SFTP server. Do you want to continue? [Y/N]: ::: Y
-undo scp server enable
-    dialog: Warning: The operation will stop the SCP server. Continue? [Y/N]: ::: Y
-undo scp * server enable
-    dialog: Warning: The operation will stop the SCP server. Continue? [Y/N]: ::: Y
-undo dhcp enable
-    dialog: Warning: All DHCP functions will be disabled. Continue? [Y/N] ::: Y
-undo dhcpv6 enable
-    dialog: Warning: All DHCPv6 functions will be disabled. Continue? [Y/N]: ::: Y
-system tcam acl
-    dialog: Warning: Enabling the TCAM ACL will cause ACL resources to be replanned. Incorrectly using these commands will cause some services to be unavailable. Therefore, use these commands with the guidance of Huawei engineers. Continue? [Y/N] ::: Y
-local-user * privilege level
-    dialog: Warning: This operation may affect online users, are you sure to change the user privilege level ?[Y/N] ::: Y
-    dialog: Warning: This operation may affect online users and will change the user privilege level, Continue? [Y/N]: ::: Y
-local-user * password
-    dialog: Warning: The user using this account will be logged out, and needs to log in again. Do you want to continue? [Y/N] ::: Y
-
-stp *
-    dialog: Warning: The global STP state will be changed. Continue? [Y/N] ::: Y
-
-ntp server disable
-    dialog: /.*Continue\?/ ::: Y
-ntp * server disable
-    dialog: /.*Continue\?/ ::: Y
-
-ntp-service server disable
-    dialog: /.*Continue\?/ ::: Y
-ntp-service * server disable
-    dialog: /.*Continue\?/ ::: Y
-
-undo telnet server-source all-interface
-    dialog: /.*continue\?/ ::: Y
-undo telnet ipv6 server-source all-interface
-    dialog: /.*continue\?/ ::: Y
-telnet server disable
-    dialog: /.*continue\?/ ::: Y
-telnet ipv6 server disable
-    dialog: /.*continue\?/ ::: Y
-
-undo vlan
-    dialog: Warning: The configurations of the VLAN will be deleted. Continue? [Y/N]: ::: Y
-
-port link-type *
-    dialog: Warning: This command will delete VLANs on this port. Continue?[Y/N]: ::: Y
-
-port mode 200GE  ~
-    dialog: /Warning: This operation will delete current ports.*/ ::: Y
-
-port mode *
-    dialog: /Warning: The interfaces.* will be converted to .* mode/ ::: Y
-undo port mode *
-    dialog: /Warning: The interfaces.* will be converted to .* mode/ ::: Y
-
-mpls lsr-id *
-    dialog: Warning: All MPLS services will be deleted and services related to LSR-ID will fail. Continue? [Y/N]: ::: Y
-
-undo router-id
-    dialog: Warning: Changing the parameter in this command resets the peer session. Continue? [Y/N]: ::: Y
-
-router-id
-    dialog: Warning: Changing the parameter in this command resets the peer session. Continue? [Y/N]: ::: Y
-
-undo bfd
-    dialog: Warning: The BFD process will be deleted. Continue? [Y/N]: ::: Y
-
-undo dcn
-    dialog: Warning: This operation will disable DCN function. Continue? [Y/N]: ::: Y
-
+    dialog: The current configuration will be written to the device. Are you sure? [Y/N]: ::: Y
+    dialog: /Please input the file name\(\*\.cfg\).*/ ::: startup.cfg
+    dialog: Are you sure you want to continue the save operation? [Y/N]: ::: Y
+hardware-resource switch-mode *
+    dialog: Do you want to change the specified hardware resource working mode? [Y/N]: ::: Y
+hardware-resource routing-mode *
+    dialog: Do you want to change the specified hardware resource working mode? [Y/N]: ::: Y
+hardware-resource vxlan *
+    dialog: Do you want to change the specified hardware resource working mode? [Y/N]: ::: Y
+hardware-resource firmware-mode *
+    dialog: Do you want to change the specified hardware resource working mode? [Y/N]: ::: Y
+hardware-resource flex-mode *
+    dialog: Do you want to change the specified hardware resource working mode? [Y/N]: ::: Y
+hardware-resource linkscan-mode *
+    dialog: Do you want to change the specified hardware resource working mode? [Y/N]: ::: Y
 undo ospf *
-    dialog: Warning: The OSPF process will be deleted. Continue? [Y/N]: ::: Y
+    dialog: Undo OSPF process? [Y/N]: ::: Y
 
-undo mpls ldp transport-address
-    dialog: Warning: All the related sessions will be deleted if the operation is performed! Continue? [Y/N]: ::: Y
-
-ldp-sync enable
-    dialog: Warning: This will cause all the interfaces enabled the ISIS process to enter ldp-sync state. Continue? [Y/N]: ::: Y
-    dialog: Warning: This will cause all the interfaces enabled the OSPF process to enter ldp-sync state. Continue? [Y/N]: ::: Y
-
-association-type enable
-    dialog: Warning: The PCE sessions will be restarted. Continue? [Y/N]: ::: Y
-
-info-center max-logfile-number *
-    dialog: Warning: The operation will probably delete the redundant logs. Continue? [Y/N]: ::: Y
-
-rsa peer-public-key * 
-    dialog: Do you really want to replace it? [Y/N]: ::: Y
-
-ip binding vpn-instance
-    dialog: Warning: This operation will modify the router ID to 0.0.0.0, which may affect the establishment of BGP peer relationships. Continue? [Y/N]: ::: Y
-
-force transceiver *
-    dialog: /.*Continue\?/ ::: Y
-
-undo force transceiver *
-    dialog: /.*Continue\?/ ::: Y
-
-undo local-aaa-user change-password verify
-    dialog: Warning: This command will disable the function of verifying the old password when administrators changes their own passwords. Continue?[Y/N] ::: Y
-
-undo local-user ~
-    dialog: Warning: This operation may affect online users, are you sure to change the user privilege level ?[Y/N] ::: Y
+undo mpls ldp
+    dialog: Stop LDP service? [Y/N]: ::: Y
 
 # vim: set syntax=annrulebook:

--- a/annet/rulebook/texts/h3c.deploy
+++ b/annet/rulebook/texts/h3c.deploy
@@ -24,6 +24,9 @@ peer * enable
     dialog: Warning: This operation will reset the peer session. Continue? [Y/N]: ::: Y
     dialog: Warning:This operation might reset the peer session. Continue? [Y/N]: ::: Y
     dialog: Warning:This operation might reset the peer session in the peer group. Continue? [Y/N]: ::: Y
+undo peer * enable
+    dialog: Warning:This operation might reset the peer session. Continue? [Y/N]: ::: Y
+    dialog: Warning:This operation might reset the peer session in the peer group. Continue? [Y/N]: ::: Y
 save
     dialog: The current configuration will be written to the device. Are you sure? [Y/N]: ::: Y
     dialog: /Please input the file name\(\*\.cfg\).*/ ::: startup.cfg


### PR DESCRIPTION
## Problem

Deployments to the H3C S9850-32H timed out when executing the following command:

```text
peer <group> enable
```

The device returns the following prompt:

```text
Warning:This operation might reset the peer session in the peer group. Continue? [Y/N]:
```

The `h3c.deploy` rulebook contained rules copied from the Huawei rulebook, including different prompt messages, unsupported commands, commands with an incorrect argument order, and commands that do not require confirmation on H3C devices.

## Changes

- Added H3C prompts for `peer * enable`:

```text
Warning:This operation might reset the peer session. Continue? [Y/N]:
Warning:This operation might reset the peer session in the peer group. Continue? [Y/N]:
```

- Added prompts observed on H3C devices for:

```text
undo bgp
undo ospf *
undo mpls ldp
```

- Updated the save workflow to use H3C syntax:
  - the `.cfg` extension is used;
  - `startup.cfg` is used as the filename;
  - the Huawei-specific `vrpcfg.zip` filename was removed.

- Added interactive rules for the hardware resource modes supported by the S9850-32H:
  - `switch-mode`;
  - `routing-mode`;
  - `vxlan`;
  - `firmware-mode`;
  - `flex-mode`;
  - `linkscan-mode`.

- Removed Huawei-specific, unsupported, or non-interactive rules for:
  - BGP peer removal, peer timers, and router ID changes;
  - route distinguishers and VPN binding;
  - Telnet, SSH, FTP, SFTP, and SCP;
  - server source and source interface configuration;
  - DHCP and DHCPv6;
  - STP and NTP;
  - VLAN, `port mode`, and `port link-type`;
  - BFD, DCN, MPLS, and PCE;
  - local users and RSA;
  - TCAM and other platform-specific commands.

As a result, the H3C deploy rulebook now contains 11 relevant top-level interactive rules.

## Hardware Validation

The changes were manually validated in the following lab environment:

- Device: H3C S9850-32H
- OS: H3C Comware Software
- Software version: 7.1.070, Release 6710P03