### PR TITLE
fix: H3C community-list deployment ordering

### DIFF
--- a/annet/rulebook/texts/h3c.order
+++ b/annet/rulebook/texts/h3c.order
@@ -35,6 +35,7 @@ ip vpn-instance */[OoMm][OoLl][BbAa].*/
 */(ip|ipv6)/ prefix-list * index 65535
 undo */(ip|ipv6)/ prefix-list * index *   %order_reverse
 */(ip|ipv6)/ prefix-list
+ip community-list
 
 # common block для фабрики
 bfd peer-ip
@@ -280,6 +281,7 @@ undo bfd %order_reverse
 undo ip vpn-instance %order_reverse
 undo route-policy %order_reverse
 undo route-policy */VRF_.*/ %order_reverse
+undo ip community-list %order_reverse
 undo ip community-filter %order_reverse
 undo ip extcommunity-filter %order_reverse
 undo ip as-path-filter %order_reverse

--- a/annet/rulebook/texts/h3c.rul
+++ b/annet/rulebook/texts/h3c.rul
@@ -144,6 +144,7 @@ ip vpn-instance *
         export route-policy
 
 */(ip|ipv6)/ prefix-list * %logic=annet.rulebook.h3c.misc.prefix_list
+ip community-list ~
 ip as-path-filter * index *
 ip community-filter * * index *
 ip extcommunity-filter * * index *

--- a/tests/annet/test_patch/h3c_community_list.yaml
+++ b/tests/annet/test_patch/h3c_community_list.yaml
@@ -1,0 +1,27 @@
+- vendor: h3c
+  name: create community-list before referencing route-policy
+  before: ""
+  after: |
+    route-policy test_policy permit node 10
+      if-match community name test_community
+    ip community-list basic test_community permit 65000:10
+  patch: |
+    system-view
+    ip community-list basic test_community permit 65000:10
+    route-policy test_policy permit node 10
+      if-match community name test_community
+      quit
+    save force
+
+- vendor: h3c
+  name: remove referencing route-policy before community-list
+  before: |
+    route-policy test_policy permit node 10
+      if-match community name test_community
+    ip community-list basic test_community permit 65000:10
+  after: ""
+  patch: |
+    system-view
+    undo route-policy test_policy node 10
+    undo ip community-list basic test_community permit 65000:10
+    save force


### PR DESCRIPTION
During H3C deployment, a `route-policy` containing:

```
if-match community name <community-list>
```

was created before the referenced `ip community-list`.

As a result, the device reported:

```
Configuration successed but the clause is always matched:
The commumity list does not exist
```

Until the community list was created, the policy node could temporarily match all routes, potentially causing unintended route exports.

The root cause was the lack of explicit `ip community-list` rules in the H3C rulebook and command ordering. The command was handled by the fallback rule and placed after `route-policy` and BGP configuration.