### PR TITLE
fix: H3C BGP patch generation

### DIFF
--- a/annet/rulebook/h3c/bgp.py
+++ b/annet/rulebook/h3c/bgp.py
@@ -7,7 +7,11 @@ from annet.rulebook import common
 
 
 def peer(
-    rule: dict[str, Any], key: tuple[str, ...], diff: dict[str, list[dict[str, Any]]], **_: Any
+    rule: dict[str, Any],
+    key: tuple[str, ...],
+    diff: dict[str, list[dict[str, Any]]],
+    root_pre: dict[str, Any],
+    **_: Any,
 ) -> Iterator[tuple[bool, str, Any]]:  # pylint: disable=unused-argument
     """
     The peculiarity of peer commands is that
@@ -23,7 +27,24 @@ def peer(
     """
 
     assert not diff[Op.AFFECTED], "Peer commands could not contain subcommands"
-    for action in sorted(diff[Op.REMOVED], key=lambda act: "as-number" not in act["row"].split()):
+    removed_as_number = any(_is_as_number_row(action["row"]) for action in diff[Op.REMOVED])
+    added_as_number = any(_is_as_number_row(action["row"]) for action in diff[Op.ADDED])
+    is_as_number_replaced = removed_as_number and added_as_number
+    added_group = any(_is_group_row(action["row"]) for action in diff[Op.ADDED])
+
+    if added_group and _is_ip_addr(key[0]):
+        # Assigning an existing H3C peer to a group resets its peer-level settings.
+        # Restore settings that are unchanged in the target configuration as well.
+        _restore_unchanged_ip_peer_settings(root_pre, key[0])
+
+    if removed_as_number and _is_ip_addr(key[0]):
+        # `undo peer IP` removes all peer settings, including unchanged ones and address-family options.
+        # Suppress their redundant removals and restore desired settings when replacing the ASN.
+        _prepare_ip_peer_reset(root_pre, key[0], restore_unchanged=is_as_number_replaced)
+        # This is intentionally marked as direct: h3c.order places it immediately before the new as-number.
+        yield (is_as_number_replaced, "undo peer {}".format(*key), None)
+
+    for action in sorted(diff[Op.REMOVED], key=lambda act: not _is_as_number_row(act["row"])):
         tokens = action["row"].split()
         (_, addr_or_group_name, param, *__) = tokens
         if param == "as-number":
@@ -32,7 +53,7 @@ def peer(
             else:
                 # We can’t use common.default because the rule is defined as "peer *" and not "peer * *".
                 # Therefore, the default behavior here would be "undo peer PEERGROUP", which is not what we want.
-                yield (False, "undo peer {} as-number".format(*key), None)
+                yield (is_as_number_replaced, "undo peer {} as-number".format(*key), None)
             break
 
         if param in ["connect-interface", "ebgp-max-hop", "local-as", "substitute-as", "password", "preferred-value"]:
@@ -40,7 +61,7 @@ def peer(
         else:
             yield (False, "undo " + action["row"], None)
 
-    for action in sorted(diff[Op.ADDED], key=lambda act: "as-number" not in act["row"]):
+    for action in sorted(diff[Op.ADDED], key=lambda act: not _is_as_number_row(act["row"])):
         yield (True, action["row"], None)
 
 
@@ -78,6 +99,79 @@ def _is_ip_addr(addr_or_string: str) -> bool:
         else:
             break
     return bool(ret)
+
+
+def _prepare_ip_peer_reset(pre: dict[str, Any], peer: str, *, restore_unchanged: bool) -> None:
+    """Adjust peer operations after H3C removes the complete peer configuration."""
+    for rule_pre in pre.values():
+        for item_diff in rule_pre["items"].values():
+            if restore_unchanged:
+                for action in list(item_diff[Op.UNCHANGED]):
+                    children = action["children"]
+                    if children:
+                        _prepare_ip_peer_reset(children, peer, restore_unchanged=True)
+                        if _has_patch_operations(children):
+                            _move_action(item_diff, Op.UNCHANGED, Op.AFFECTED, action)
+                    elif _is_peer_row(action["row"], peer):
+                        _move_action(item_diff, Op.UNCHANGED, Op.ADDED, action)
+
+            for action in list(item_diff[Op.REMOVED]):
+                if not action["children"] and _is_peer_row(action["row"], peer):
+                    item_diff[Op.REMOVED].remove(action)
+
+            for action in list(item_diff[Op.AFFECTED]):
+                children = action["children"]
+                if children:
+                    _prepare_ip_peer_reset(children, peer, restore_unchanged=restore_unchanged)
+                    if not _has_patch_operations(children):
+                        _move_action(item_diff, Op.AFFECTED, Op.UNCHANGED, action)
+
+
+def _restore_unchanged_ip_peer_settings(pre: dict[str, Any], peer: str) -> None:
+    """Restore settings cleared when H3C assigns an existing peer to a group."""
+    for rule_pre in pre.values():
+        for item_diff in rule_pre["items"].values():
+            for action in list(item_diff[Op.UNCHANGED]):
+                children = action["children"]
+                if children:
+                    _restore_unchanged_ip_peer_settings(children, peer)
+                    if _has_patch_operations(children):
+                        _move_action(item_diff, Op.UNCHANGED, Op.AFFECTED, action)
+                elif _is_peer_row(action["row"], peer):
+                    _move_action(item_diff, Op.UNCHANGED, Op.ADDED, action)
+
+            for action in item_diff[Op.AFFECTED]:
+                if action["children"]:
+                    _restore_unchanged_ip_peer_settings(action["children"], peer)
+
+
+def _has_patch_operations(pre: dict[str, Any]) -> bool:
+    return any(
+        item_diff[op]
+        for rule_pre in pre.values()
+        for item_diff in rule_pre["items"].values()
+        for op in (Op.ADDED, Op.REMOVED, Op.AFFECTED, Op.MOVED)
+    )
+
+
+def _is_peer_row(row: str, peer: str) -> bool:
+    tokens = row.split()
+    return len(tokens) >= 2 and tokens[:2] == ["peer", peer]
+
+
+def _is_as_number_row(row: str) -> bool:
+    tokens = row.split()
+    return len(tokens) >= 3 and tokens[0] == "peer" and tokens[2] == "as-number"
+
+
+def _is_group_row(row: str) -> bool:
+    tokens = row.split()
+    return len(tokens) >= 4 and tokens[0] == "peer" and tokens[2] == "group"
+
+
+def _move_action(item_diff: dict[str, list[dict[str, Any]]], source: str, target: str, action: dict[str, Any]) -> None:
+    item_diff[source].remove(action)
+    item_diff[target].append(action)
 
 
 def _bfd_params_used(row: str) -> Iterator[str]:

--- a/annet/rulebook/texts/h3c.order
+++ b/annet/rulebook/texts/h3c.order
@@ -249,6 +249,9 @@ bgp
     # [NOCDEV-2043] Тут только декларируем пиров и группы
     # поскольку на них есть ссылки из family блоков
     group
+    # При смене ASN сначала удаляем старое значение, затем создаем пир заново.
+    undo peer * as-number
+    undo peer *
     peer * as-number *
     peer * local-as *
     peer * group *

--- a/tests/annet/test_patch/h3c_bgp_peer.yaml
+++ b/tests/annet/test_patch/h3c_bgp_peer.yaml
@@ -1,0 +1,575 @@
+- vendor: h3c
+  name: add a new IPv4 peer with all settings
+  before: |
+    bgp 64496
+  after: |
+    bgp 64496
+      group SPINES external
+      peer 192.0.2.3 as-number 64497
+      peer 192.0.2.3 local-as 64500
+      peer 192.0.2.3 group SPINES
+      peer 192.0.2.3 connect-interface LoopBack0
+      peer 192.0.2.3 description TEST
+      peer 192.0.2.3 bfd
+      address-family ipv4 unicast
+        peer 192.0.2.3 enable
+        peer 192.0.2.3 route-policy IMPORT import
+        peer 192.0.2.3 advertise-community
+  patch: |
+    system-view
+    bgp 64496
+      group SPINES external
+      peer 192.0.2.3 as-number 64497
+      peer 192.0.2.3 local-as 64500
+      peer 192.0.2.3 group SPINES
+      peer 192.0.2.3 connect-interface LoopBack0
+      address-family ipv4 unicast
+        peer 192.0.2.3 enable
+        peer 192.0.2.3 route-policy IMPORT import
+        peer 192.0.2.3 advertise-community
+        quit
+      peer 192.0.2.3 bfd
+      peer 192.0.2.3 description TEST
+      quit
+    save force
+
+- vendor: h3c
+  name: replace a bare IPv4 peer ASN
+  before: |
+    bgp 64496
+      peer 192.0.2.3 as-number 64497
+  after: |
+    bgp 64496
+      peer 192.0.2.3 as-number 64498
+  patch: |
+    system-view
+    bgp 64496
+      undo peer 192.0.2.3
+      peer 192.0.2.3 as-number 64498
+      quit
+    save force
+
+- vendor: h3c
+  name: restore all unchanged IPv4 peer settings after replacing its ASN
+  before: |
+    bgp 64496
+      group SPINES external
+      peer 192.0.2.3 as-number 64497
+      peer 192.0.2.3 local-as 64500
+      peer 192.0.2.3 group SPINES
+      peer 192.0.2.3 connect-interface LoopBack0
+      peer 192.0.2.3 description TEST
+      peer 192.0.2.3 bfd
+      address-family ipv4 unicast
+        peer 192.0.2.3 enable
+        peer 192.0.2.3 route-policy IMPORT import
+        peer 192.0.2.3 advertise-community
+  after: |
+    bgp 64496
+      group SPINES external
+      peer 192.0.2.3 as-number 64498
+      peer 192.0.2.3 local-as 64500
+      peer 192.0.2.3 group SPINES
+      peer 192.0.2.3 connect-interface LoopBack0
+      peer 192.0.2.3 description TEST
+      peer 192.0.2.3 bfd
+      address-family ipv4 unicast
+        peer 192.0.2.3 enable
+        peer 192.0.2.3 route-policy IMPORT import
+        peer 192.0.2.3 advertise-community
+  patch: |
+    system-view
+    bgp 64496
+      undo peer 192.0.2.3
+      peer 192.0.2.3 as-number 64498
+      peer 192.0.2.3 local-as 64500
+      peer 192.0.2.3 group SPINES
+      peer 192.0.2.3 connect-interface LoopBack0
+      address-family ipv4 unicast
+        peer 192.0.2.3 enable
+        peer 192.0.2.3 route-policy IMPORT import
+        peer 192.0.2.3 advertise-community
+        quit
+      peer 192.0.2.3 bfd
+      peer 192.0.2.3 description TEST
+      quit
+    save force
+
+- vendor: h3c
+  name: suppress removed settings while replacing an IPv4 peer ASN
+  before: |
+    bgp 64496
+      group SPINES external
+      peer 192.0.2.3 as-number 64497
+      peer 192.0.2.3 group SPINES
+      peer 192.0.2.3 description TEST
+      peer 192.0.2.3 bfd
+      address-family ipv4 unicast
+        peer 192.0.2.3 enable
+        peer 192.0.2.3 route-policy IMPORT import
+  after: |
+    bgp 64496
+      group SPINES external
+      peer 192.0.2.3 as-number 64498
+      peer 192.0.2.3 group SPINES
+      peer 192.0.2.3 description TEST
+      address-family ipv4 unicast
+        peer 192.0.2.3 enable
+  patch: |
+    system-view
+    bgp 64496
+      undo peer 192.0.2.3
+      peer 192.0.2.3 as-number 64498
+      peer 192.0.2.3 group SPINES
+      address-family ipv4 unicast
+        peer 192.0.2.3 enable
+        quit
+      peer 192.0.2.3 description TEST
+      quit
+    save force
+
+- vendor: h3c
+  name: apply changed and added settings while replacing an IPv4 peer ASN
+  before: |
+    bgp 64496
+      group SPINES external
+      peer 192.0.2.3 as-number 64497
+      peer 192.0.2.3 group SPINES
+      peer 192.0.2.3 description OLD
+      address-family ipv4 unicast
+        peer 192.0.2.3 enable
+        peer 192.0.2.3 route-policy OLD_IMPORT import
+  after: |
+    bgp 64496
+      group SPINES external
+      peer 192.0.2.3 as-number 64498
+      peer 192.0.2.3 group SPINES
+      peer 192.0.2.3 description NEW
+      peer 192.0.2.3 bfd
+      address-family ipv4 unicast
+        peer 192.0.2.3 enable
+        peer 192.0.2.3 route-policy NEW_IMPORT import
+        peer 192.0.2.3 advertise-community
+  patch: |
+    system-view
+    bgp 64496
+      undo peer 192.0.2.3
+      peer 192.0.2.3 as-number 64498
+      peer 192.0.2.3 group SPINES
+      address-family ipv4 unicast
+        peer 192.0.2.3 enable
+        peer 192.0.2.3 route-policy NEW_IMPORT import
+        peer 192.0.2.3 advertise-community
+        quit
+      peer 192.0.2.3 bfd
+      peer 192.0.2.3 description NEW
+      quit
+    save force
+
+- vendor: h3c
+  name: delete one IPv4 peer while preserving its address-family and another peer
+  before: |
+    bgp 64496
+      peer 192.0.2.3 as-number 64497
+      peer 192.0.2.3 description DELETE
+      peer 192.0.2.4 as-number 64499
+      address-family ipv4 unicast
+        peer 192.0.2.3 enable
+        peer 192.0.2.4 enable
+  after: |
+    bgp 64496
+      peer 192.0.2.4 as-number 64499
+      address-family ipv4 unicast
+        peer 192.0.2.4 enable
+  patch: |
+    system-view
+    bgp 64496
+      undo peer 192.0.2.3
+      quit
+    save force
+
+- vendor: h3c
+  name: delete the last IPv4 peer and its empty address-family
+  before: |
+    bgp 64496
+      peer 192.0.2.3 as-number 64497
+      peer 192.0.2.3 description DELETE
+      address-family ipv4 unicast
+        peer 192.0.2.3 enable
+  after: |
+    bgp 64496
+  patch: |
+    system-view
+    bgp 64496
+      undo address-family ipv4 unicast
+      undo peer 192.0.2.3
+      quit
+    save force
+
+- vendor: h3c
+  name: replace ASN for two IPv4 peers in one patch
+  before: |
+    bgp 64496
+      peer 192.0.2.3 as-number 64497
+      peer 192.0.2.3 description FIRST
+      peer 192.0.2.4 as-number 64499
+      peer 192.0.2.4 description SECOND
+      address-family ipv4 unicast
+        peer 192.0.2.3 enable
+        peer 192.0.2.4 enable
+  after: |
+    bgp 64496
+      peer 192.0.2.3 as-number 64498
+      peer 192.0.2.3 description FIRST
+      peer 192.0.2.4 as-number 64501
+      peer 192.0.2.4 description SECOND
+      address-family ipv4 unicast
+        peer 192.0.2.3 enable
+        peer 192.0.2.4 enable
+  patch: |
+    system-view
+    bgp 64496
+      undo peer 192.0.2.3
+      undo peer 192.0.2.4
+      peer 192.0.2.3 as-number 64498
+      peer 192.0.2.4 as-number 64501
+      address-family ipv4 unicast
+        peer 192.0.2.3 enable
+        peer 192.0.2.4 enable
+        quit
+      peer 192.0.2.3 description FIRST
+      peer 192.0.2.4 description SECOND
+      quit
+    save force
+
+- vendor: h3c
+  name: add a new IPv6 peer with all settings
+  before: |
+    bgp 64496
+  after: |
+    bgp 64496
+      group SPINES external
+      peer 2001:DB8::3 as-number 64497
+      peer 2001:DB8::3 local-as 64500
+      peer 2001:DB8::3 group SPINES
+      peer 2001:DB8::3 connect-interface LoopBack0
+      peer 2001:DB8::3 description TEST
+      peer 2001:DB8::3 bfd
+      address-family ipv6 unicast
+        peer 2001:DB8::3 enable
+        peer 2001:DB8::3 route-policy IMPORT import
+        peer 2001:DB8::3 advertise-community
+  patch: |
+    system-view
+    bgp 64496
+      group SPINES external
+      peer 2001:DB8::3 as-number 64497
+      peer 2001:DB8::3 local-as 64500
+      peer 2001:DB8::3 group SPINES
+      peer 2001:DB8::3 connect-interface LoopBack0
+      address-family ipv6 unicast
+        peer 2001:DB8::3 enable
+        peer 2001:DB8::3 route-policy IMPORT import
+        peer 2001:DB8::3 advertise-community
+        quit
+      peer 2001:DB8::3 bfd
+      peer 2001:DB8::3 description TEST
+      quit
+    save force
+
+- vendor: h3c
+  name: replace a bare IPv6 peer ASN
+  before: |
+    bgp 64496
+      peer 2001:DB8::3 as-number 64497
+  after: |
+    bgp 64496
+      peer 2001:DB8::3 as-number 64498
+  patch: |
+    system-view
+    bgp 64496
+      undo peer 2001:DB8::3
+      peer 2001:DB8::3 as-number 64498
+      quit
+    save force
+
+- vendor: h3c
+  name: restore all unchanged IPv6 peer settings after replacing its ASN
+  before: |
+    bgp 64496
+      group SPINES external
+      peer 2001:DB8::3 as-number 64497
+      peer 2001:DB8::3 local-as 64500
+      peer 2001:DB8::3 group SPINES
+      peer 2001:DB8::3 connect-interface LoopBack0
+      peer 2001:DB8::3 description TEST
+      peer 2001:DB8::3 bfd
+      address-family ipv6 unicast
+        peer 2001:DB8::3 enable
+        peer 2001:DB8::3 route-policy IMPORT import
+        peer 2001:DB8::3 advertise-community
+  after: |
+    bgp 64496
+      group SPINES external
+      peer 2001:DB8::3 as-number 64498
+      peer 2001:DB8::3 local-as 64500
+      peer 2001:DB8::3 group SPINES
+      peer 2001:DB8::3 connect-interface LoopBack0
+      peer 2001:DB8::3 description TEST
+      peer 2001:DB8::3 bfd
+      address-family ipv6 unicast
+        peer 2001:DB8::3 enable
+        peer 2001:DB8::3 route-policy IMPORT import
+        peer 2001:DB8::3 advertise-community
+  patch: |
+    system-view
+    bgp 64496
+      undo peer 2001:DB8::3
+      peer 2001:DB8::3 as-number 64498
+      peer 2001:DB8::3 local-as 64500
+      peer 2001:DB8::3 group SPINES
+      peer 2001:DB8::3 connect-interface LoopBack0
+      address-family ipv6 unicast
+        peer 2001:DB8::3 enable
+        peer 2001:DB8::3 route-policy IMPORT import
+        peer 2001:DB8::3 advertise-community
+        quit
+      peer 2001:DB8::3 bfd
+      peer 2001:DB8::3 description TEST
+      quit
+    save force
+
+- vendor: h3c
+  name: suppress removed settings while replacing an IPv6 peer ASN
+  before: |
+    bgp 64496
+      group SPINES external
+      peer 2001:DB8::3 as-number 64497
+      peer 2001:DB8::3 group SPINES
+      peer 2001:DB8::3 description TEST
+      peer 2001:DB8::3 bfd
+      address-family ipv6 unicast
+        peer 2001:DB8::3 enable
+        peer 2001:DB8::3 route-policy IMPORT import
+  after: |
+    bgp 64496
+      group SPINES external
+      peer 2001:DB8::3 as-number 64498
+      peer 2001:DB8::3 group SPINES
+      peer 2001:DB8::3 description TEST
+      address-family ipv6 unicast
+        peer 2001:DB8::3 enable
+  patch: |
+    system-view
+    bgp 64496
+      undo peer 2001:DB8::3
+      peer 2001:DB8::3 as-number 64498
+      peer 2001:DB8::3 group SPINES
+      address-family ipv6 unicast
+        peer 2001:DB8::3 enable
+        quit
+      peer 2001:DB8::3 description TEST
+      quit
+    save force
+
+- vendor: h3c
+  name: apply changed and added settings while replacing an IPv6 peer ASN
+  before: |
+    bgp 64496
+      group SPINES external
+      peer 2001:DB8::3 as-number 64497
+      peer 2001:DB8::3 group SPINES
+      peer 2001:DB8::3 description OLD
+      address-family ipv6 unicast
+        peer 2001:DB8::3 enable
+        peer 2001:DB8::3 route-policy OLD_IMPORT import
+  after: |
+    bgp 64496
+      group SPINES external
+      peer 2001:DB8::3 as-number 64498
+      peer 2001:DB8::3 group SPINES
+      peer 2001:DB8::3 description NEW
+      peer 2001:DB8::3 bfd
+      address-family ipv6 unicast
+        peer 2001:DB8::3 enable
+        peer 2001:DB8::3 route-policy NEW_IMPORT import
+        peer 2001:DB8::3 advertise-community
+  patch: |
+    system-view
+    bgp 64496
+      undo peer 2001:DB8::3
+      peer 2001:DB8::3 as-number 64498
+      peer 2001:DB8::3 group SPINES
+      address-family ipv6 unicast
+        peer 2001:DB8::3 enable
+        peer 2001:DB8::3 route-policy NEW_IMPORT import
+        peer 2001:DB8::3 advertise-community
+        quit
+      peer 2001:DB8::3 bfd
+      peer 2001:DB8::3 description NEW
+      quit
+    save force
+
+- vendor: h3c
+  name: delete one IPv6 peer while preserving its address-family and another peer
+  before: |
+    bgp 64496
+      peer 2001:DB8::3 as-number 64497
+      peer 2001:DB8::3 description DELETE
+      peer 2001:DB8::4 as-number 64499
+      address-family ipv6 unicast
+        peer 2001:DB8::3 enable
+        peer 2001:DB8::4 enable
+  after: |
+    bgp 64496
+      peer 2001:DB8::4 as-number 64499
+      address-family ipv6 unicast
+        peer 2001:DB8::4 enable
+  patch: |
+    system-view
+    bgp 64496
+      undo peer 2001:DB8::3
+      quit
+    save force
+
+- vendor: h3c
+  name: delete the last IPv6 peer and its empty address-family
+  before: |
+    bgp 64496
+      peer 2001:DB8::3 as-number 64497
+      peer 2001:DB8::3 description DELETE
+      address-family ipv6 unicast
+        peer 2001:DB8::3 enable
+  after: |
+    bgp 64496
+  patch: |
+    system-view
+    bgp 64496
+      undo address-family ipv6 unicast
+      undo peer 2001:DB8::3
+      quit
+    save force
+
+- vendor: h3c
+  name: replace ASN for two IPv6 peers in one patch
+  before: |
+    bgp 64496
+      peer 2001:DB8::3 as-number 64497
+      peer 2001:DB8::3 description FIRST
+      peer 2001:DB8::4 as-number 64499
+      peer 2001:DB8::4 description SECOND
+      address-family ipv6 unicast
+        peer 2001:DB8::3 enable
+        peer 2001:DB8::4 enable
+  after: |
+    bgp 64496
+      peer 2001:DB8::3 as-number 64498
+      peer 2001:DB8::3 description FIRST
+      peer 2001:DB8::4 as-number 64501
+      peer 2001:DB8::4 description SECOND
+      address-family ipv6 unicast
+        peer 2001:DB8::3 enable
+        peer 2001:DB8::4 enable
+  patch: |
+    system-view
+    bgp 64496
+      undo peer 2001:DB8::3
+      undo peer 2001:DB8::4
+      peer 2001:DB8::3 as-number 64498
+      peer 2001:DB8::4 as-number 64501
+      address-family ipv6 unicast
+        peer 2001:DB8::3 enable
+        peer 2001:DB8::4 enable
+        quit
+      peer 2001:DB8::3 description FIRST
+      peer 2001:DB8::4 description SECOND
+      quit
+    save force
+
+- vendor: h3c
+  name: replace peer-group ASN without removing the group
+  before: |
+    bgp 64496
+      group SPINES external
+      peer SPINES as-number 64497
+  after: |
+    bgp 64496
+      group SPINES external
+      peer SPINES as-number 64498
+  patch: |
+    system-view
+    bgp 64496
+      undo peer SPINES as-number
+      peer SPINES as-number 64498
+      quit
+    save force
+
+- vendor: h3c
+  name: remove peer-group ASN without removing the group
+  before: |
+    bgp 64496
+      group SPINES external
+      peer SPINES as-number 64497
+  after: |
+    bgp 64496
+      group SPINES external
+  patch: |
+    system-view
+    bgp 64496
+      undo peer SPINES as-number
+      quit
+    save force
+
+- vendor: h3c
+  name: restore unchanged settings for two IPv6 peers after replacing their group
+  before: |
+    bgp 64496
+      group OLD_SPINES external
+      peer OLD_SPINES as-number 64497
+      peer 2001:DB8::3 as-number 64497
+      peer 2001:DB8::3 group OLD_SPINES
+      peer 2001:DB8::3 description FIRST
+      peer 2001:DB8::3 bfd
+      peer 2001:DB8::4 as-number 64497
+      peer 2001:DB8::4 group OLD_SPINES
+      peer 2001:DB8::4 description SECOND
+      peer 2001:DB8::4 bfd
+      address-family ipv6 unicast
+        peer OLD_SPINES enable
+  after: |
+    bgp 64496
+      group NEW_SPINES external
+      peer NEW_SPINES as-number 64497
+      peer 2001:DB8::3 as-number 64497
+      peer 2001:DB8::3 group NEW_SPINES
+      peer 2001:DB8::3 description FIRST
+      peer 2001:DB8::3 bfd
+      peer 2001:DB8::4 as-number 64497
+      peer 2001:DB8::4 group NEW_SPINES
+      peer 2001:DB8::4 description SECOND
+      peer 2001:DB8::4 bfd
+      address-family ipv6 unicast
+        peer NEW_SPINES enable
+  patch: |
+    system-view
+    bgp 64496
+      undo peer 2001:DB8::3 group OLD_SPINES
+      undo peer 2001:DB8::4 group OLD_SPINES
+      undo peer OLD_SPINES as-number
+      group NEW_SPINES external
+      peer NEW_SPINES as-number 64497
+      peer 2001:DB8::3 as-number 64497
+      peer 2001:DB8::4 as-number 64497
+      peer 2001:DB8::3 group NEW_SPINES
+      peer 2001:DB8::4 group NEW_SPINES
+      address-family ipv6 unicast
+        undo peer OLD_SPINES enable
+        peer NEW_SPINES enable
+        quit
+      undo group OLD_SPINES
+      peer 2001:DB8::3 bfd
+      peer 2001:DB8::4 bfd
+      peer 2001:DB8::3 description FIRST
+      peer 2001:DB8::4 description SECOND
+      quit
+    save force


### PR DESCRIPTION
### ASN replacement

On H3C, `undo peer <IP>` removes the peer together with all its settings. When replacing a peer ASN, Annet now:

- removes the peer before configuring the new ASN;
- recreates the peer with the new ASN;
- restores unchanged peer-level and address-family settings;
- suppresses redundant removal commands for settings already deleted with the peer.

The command ordering was also updated so `undo peer` is executed before the new ASN is configured.

### Peer-group replacement

On H3C, assigning an existing peer to a new group:

```
peer <IP> group <new-group>
```

resets some peer-level settings, including `description` and `bfd`.

Previously, Annet treated these settings as unchanged and omitted them from the patch, leaving a residual diff after deployment.

Annet now restores unchanged settings for every peer assigned to a new group. This prevents the result from depending on how individual lines were classified by the diff algorithm.

### Hardware Validation

The changes were manually validated in the following lab environment:

- Device: H3C S9850-32H
- OS: H3C Comware Software
- Software version: 7.1.070, Release 6710P03