### PR TITLE
feat: Allow custom vendor redefinitions to allow reusing nvos logic

### DIFF
--- a/annet/vendors/library/pc.py
+++ b/annet/vendors/library/pc.py
@@ -17,16 +17,16 @@ class PCVendor(AbstractVendor):
     def match(self) -> list[str]:
         return ["PC"]
 
-    def _is_nvos(self, hw: HardwareView) -> bool:
-        return hw.soft.startswith("nvos")
+    def _is_nvos_config(self, hw: HardwareView, path: str) -> bool:
+        return hw.soft.startswith("nvos") and is_yaml_path(path)
 
     def deserialize_json_fragment(self, hw: HardwareView, path: str, text: str) -> dict[str, Any]:
-        if self._is_nvos(hw) and is_yaml_path(path):
+        if self._is_nvos_config(hw, path):
             return nvos_yaml_to_dict(text)
         return super().deserialize_json_fragment(hw, path, text)
 
     def serialize_json_fragment(self, hw: HardwareView, path: str, config: dict[str, Any]) -> str:
-        if self._is_nvos(hw) and is_yaml_path(path):
+        if self._is_nvos_config(hw, path):
             return dict_to_nvos_yaml(config)
         return super().serialize_json_fragment(hw, path, config)
 

--- a/annet/vendors/library/pc.py
+++ b/annet/vendors/library/pc.py
@@ -17,16 +17,16 @@ class PCVendor(AbstractVendor):
     def match(self) -> list[str]:
         return ["PC"]
 
-    def _is_nvos_config(self, hw: HardwareView, path: str) -> bool:
+    def is_nvos_config(self, hw: HardwareView, path: str) -> bool:
         return hw.soft.startswith("nvos") and is_yaml_path(path)
 
     def deserialize_json_fragment(self, hw: HardwareView, path: str, text: str) -> dict[str, Any]:
-        if self._is_nvos_config(hw, path):
+        if self.is_nvos_config(hw, path):
             return nvos_yaml_to_dict(text)
         return super().deserialize_json_fragment(hw, path, text)
 
     def serialize_json_fragment(self, hw: HardwareView, path: str, config: dict[str, Any]) -> str:
-        if self._is_nvos_config(hw, path):
+        if self.is_nvos_config(hw, path):
             return dict_to_nvos_yaml(config)
         return super().serialize_json_fragment(hw, path, config)
 

--- a/annet/vendors/registry.py
+++ b/annet/vendors/registry.py
@@ -46,8 +46,6 @@ class Registry:
     def register(self, cls: type[AbstractVendor]) -> type[AbstractVendor]:
         if not cls.NAME:
             raise RuntimeError(f"{cls.__name__} has empty NAME field")
-        if cls.NAME in self.vendors:
-            raise RuntimeError(f"{cls.__name__} with name {cls.NAME} already registered")
         self.vendors[cls.NAME] = cls()
 
         return cls


### PR DESCRIPTION
The https://github.com/annetutil/annet/pull/587 introduced a convenient hooks which deal with a nvue config structure for jsonfragment. I wanted to reuse `nvos_yaml` logic for cumulus boxes that need to be configured by nvue.

Sadly the information about whether a cumulus box is managed by nvue or not is not encoded into software version (which is kind of make sense - nos is cumulus in both cases). And even if I add this piece to a software-version string, some yaml configs on our Cumulus boxes should not be (de)serialised by the `nvos_yaml` logic.

Looking for the solution the best (okay minimal change) approach that I found is something like this:
```
from annet.vendors.registry import registry
from annet.vendors.library.pc import PCVendor

@registry.register
class CustomPCVendor(PCVendor):
    def is_nvos_config(self, _: HardwareView, path: str) -> bool:
        return path == "/etc/nvue.d/startup.yaml"
```

But this requires two changes on upstream side:
 * vendors/registry: Allow redifinition of vendor classes with same `cls.NAME`
 * vendors/pc: Refactor pc vendor's `_is_nvos(hw)` hook to `is_nvos_config(hw, path)`
