### PR TITLE
fix(cisco): capture the ASN in the router bgp rule

### DIFF
--- a/annet/rulebook/texts/cisco.rul
+++ b/annet/rulebook/texts/cisco.rul
@@ -74,7 +74,7 @@ interface */\w*Ethernet[0-9\/]+$/        %logic=annet.rulebook.common.permanent 
     storm-control * level
     spanning-tree portfast
 
-router bgp
+router bgp *
     router-id
     vrf *
         router-id


### PR DESCRIPTION
`router bgp` has no capture group, so _make_reverse produced a bare `no router bgp`.  IOS and NX-OS require the ASN - `no router bgp 65000` - and reject the short form, so deleting a BGP block emitted a command the device would not accept.

`router bgp *` captures the ASN and fills it into the reverse, matching what arista.rul, b4com.rul and nexus.rul already do.  Children are unaffected.