### PR TITLE
fix(h3c): drop the duplicate port link-mode ordering rule

### DIFF
--- a/annet/rulebook/texts/h3c.order
+++ b/annet/rulebook/texts/h3c.order
@@ -168,7 +168,6 @@ interface *
     undo ip address * * sub  %order_reverse
     undo ip address * *  %order_reverse
     description
-    port link-mode * %order_reverse
     ip binding
     ipv6 enable
     ipv6 nd ra prefix


### PR DESCRIPTION
`interface *` listed `port link-mode * %order_reverse` twice, at child index 0 and index 4, with identical pattern, params and no children.  get_order ranks candidate vectors by length, then weight, then the vector itself - which starts with the rule index - so two identical rules always resolve to the lower index and the second copy could never be selected.