### PR TITLE
fix(routeros): order the file block before user

### DIFF
--- a/annet/rulebook/texts/routeros.order
+++ b/annet/rulebook/texts/routeros.order
@@ -5,15 +5,15 @@
 #   будет стоять после блоков interface).
 
 
+file
+    print
+    set
+
 user
     group
         add
     ssh_key
         add
-
-file
-    print
-    set
 
 interface
     bridge

--- a/tests/annet/test_patch/routeros_localusers.yaml
+++ b/tests/annet/test_patch/routeros_localusers.yaml
@@ -41,13 +41,13 @@
     set full name=full policy=local,telnet,ssh,ftp,reboot,read,write,policy,test,winbox,password,web,sniff,sensitive,api,romon,dude,tikapp skin=default
     add name=nocmon policy=read,test,api,!local,!telnet,!ssh,!ftp,!reboot,!write,!policy,!winbox,!password,!web,!sniff,!sensitive,!romon,!dude,!tikapp skin=default
   patch: |
-    /user remove [ find address="" disabled=no group=full name=superuser ]
-    /user add address="" disabled=no group=full name=user4
-    /user add address="" disabled=no group=nocmon name=user5
-    /user ssh-keys import public-key-file=user4@Example.ssh_key.txt user=user4
-    /user ssh-keys import public-key-file=user5@example.com.ssh_key.txt user=user5
     /file remove [ find name=gg.txt ]
     /file print file=user4@Example.ssh_key.txt
     /file print file=user5@example.com.ssh_key.txt
     /file set user4@Example.ssh_key.txt contents="ssh-dss AAAAAAAA== user4@Example"
     /file set user5@example.com.ssh_key.txt contents="ssh-dss AAAABBBB== user5@example.com"
+    /user remove [ find address="" disabled=no group=full name=superuser ]
+    /user add address="" disabled=no group=full name=user4
+    /user add address="" disabled=no group=nocmon name=user5
+    /user ssh-keys import public-key-file=user4@Example.ssh_key.txt user=user4
+    /user ssh-keys import public-key-file=user5@example.com.ssh_key.txt user=user5


### PR DESCRIPTION
An ssh key is uploaded as a file and only then imported into a user, so `/file set <name>.ssh_key.txt contents=...` has to reach the device before `/user ssh-keys import public-key-file=<name>.ssh_key.txt`.  With `user` ordered ahead of `file` the patch did the import first and it failed on real hardware, because the referenced file did not exist yet.