### PR TITLE
fix: keep bare command in nested rule field when inheriting

### DIFF
--- a/annet/rulebook/patching.py
+++ b/annet/rulebook/patching.py
@@ -317,7 +317,9 @@ def _apply_not_inherit_to_child_rules(child_rulebook: PatchRulebook, vendor: str
 
             raw_row = syntax.get_row_with_params(row, raw_params, get_params_scheme(vendor))
 
-            rules[RULE] = raw_row
+            # RULE holds the bare command, the way _compile_patching fills it from
+            # attrs[ROW]: without params, and without the leading "!" of an ignore rule.
+            rules[RULE] = row[1:].strip() if rules[TYPE] == IGNORE else row
 
             if not _is_empty_rulebook(rules[CHILDREN]):
                 rules[CHILDREN] = _apply_not_inherit_to_child_rules(

--- a/tests/annet/test_inherit/__init__.py
+++ b/tests/annet/test_inherit/__init__.py
@@ -24,6 +24,9 @@ def check_patch_rulebook_equal(getting_rb, expected_rb):
         assert getting_data[row]["rules"]["type"] == expected_data[row]["rules"]["type"], (
             f"Rule '{row}': type do not match."
         )
+        assert getting_data[row]["rules"]["rule"] == expected_data[row]["rules"]["rule"], (
+            f"Rule '{row}': rule do not match."
+        )
         assert getting_data[row]["rules"]["attrs"] == expected_data[row]["rules"]["attrs"], (
             f"Rule '{row}': attrs do not match."
         )

--- a/tests/annet/test_inherit/test_patching/test_merge/test_common.yaml
+++ b/tests/annet/test_inherit/test_patching/test_merge/test_common.yaml
@@ -63,3 +63,22 @@ test_case_5:
     %inherit_from=parent
   parent: |
   expected: |
+
+# A rule that exists only in the child keeps its subtree verbatim: the "rule" field of
+# every nested rule must stay the bare command, without params and without the leading
+# "!" of an ignore rule.
+test_case_6:
+  child: |
+    %inherit_from=parent
+    rule 2
+        sub rule 2 %global
+        !ignored sub rule 2
+  parent: |
+    rule 1
+        sub rule 1
+  expected: |
+    rule 1
+        sub rule 1
+    rule 2
+        sub rule 2 %global
+        !ignored sub rule 2


### PR DESCRIPTION
_apply_not_inherit_to_child_rules rebuilds the raw row (command + params) for every rule under a child-only block and was assigning it to PatchRule["rule"]. _compile_patching fills that field from attrs["row"], i.e. the bare command with no params and with the leading "!" of an ignore rule already stripped, so after a merge nested rules ended up with "~ %global" or "!dcbx *" where the same rulebook without %inherit_from produces "~" and "dcbx *".

The field travels into _PatchRow.rules and is used as a tie-break string when sorting patch rows, so the mismatch could reorder otherwise-equal patch lines.

check_patch_rulebook_equal did not compare "rule" at all; it now does, which is what makes the new test_common.yaml case fail without this fix.