### PR TITLE
feat: delete JSON fragment objects with an explicit null

### DIFF
--- a/annet/annlib/jsontools.py
+++ b/annet/annlib/jsontools.py
@@ -72,6 +72,7 @@ def apply_json_fragment(
     *,
     acl: Sequence[str | JsonFragmentAcl] | None = None,
     filters: Sequence[str] | None = None,
+    delete_with_null: bool = False,
 ) -> Dict[str, Any]:
     """
     Replace parts of the old document with 'new_fragment'.
@@ -83,6 +84,14 @@ def apply_json_fragment(
     or `JsonFragmentAcl` instances. The `cant_delete` attribute lists JSON
     Pointer glob patterns whose matching old pointers must be preserved when
     applying this ACL.
+
+    With `delete_with_null`, a removed object is written back as an explicit
+    `null` instead of being dropped from the document. Scalars and lists are
+    always dropped. This is what SONiC needs: `config load` merges the file into
+    CONFIG_DB and only deletes a table or an entry that is present with a `null`
+    value, while a key that is simply absent is left in redis untouched. Hash
+    fields are not deletable this way at all, so nulling them would only mask
+    the removal from tooling that looks for it.
     """
     normalized_acl = _normalize_acl(acl)
     if normalized_acl is None:
@@ -124,7 +133,29 @@ def apply_json_fragment(
                 if isinstance(container, dict) and isinstance(last, str):
                     container.pop(last, None)
 
+    if delete_with_null:
+        _nullify_removed_objects(old, full_new_config)
+
     return full_new_config
+
+
+def _nullify_removed_objects(old: Any, new: Any) -> None:
+    """Mark every object that `old` had and `new` no longer has with an explicit `null`, in place.
+
+    Works off the documents rather than the ACL bookkeeping above, because a key
+    can leave the config two ways: the deletion loop pops it, or `_pointer_set`
+    replaces its whole parent with a fragment that no longer lists it.
+    """
+    if not isinstance(old, dict) or not isinstance(new, dict):
+        return
+    for key, old_value in old.items():
+        if key in new:
+            if isinstance(old_value, dict):
+                _nullify_removed_objects(old_value, new[key])
+        elif old_value is None or isinstance(old_value, dict):
+            # `old_value is None` keeps a null from a previous run stable instead
+            # of letting it collapse back into an absence.
+            new[key] = None
 
 
 def _pattern_matches_protected(pattern: str, protected_patterns: tuple[str, ...]) -> bool:

--- a/annet/generators/__init__.py
+++ b/annet/generators/__init__.py
@@ -421,6 +421,7 @@ def _run_json_fragment_generator(
         reload=reload_cmds,
         perf=pm.last_result,
         reload_prio=gen.reload_prio,
+        delete_with_null=gen.DELETE_WITH_NULL,
     )
 
 

--- a/annet/generators/jsonfragment.py
+++ b/annet/generators/jsonfragment.py
@@ -14,6 +14,13 @@ class JSONFragment(TreeGenerator):
 
     TYPE = "JSON_FRAGMENT"
 
+    # Write objects this generator stops producing back as an explicit `null`
+    # instead of dropping them from the file. SONiC's `config load` merges the
+    # file into CONFIG_DB and only deletes a table or an entry that is present
+    # with a `null` value, so without this a removed key is never cleaned up in
+    # redis. Turn it off for a file whose consumer replaces it wholesale.
+    DELETE_WITH_NULL = True
+
     def __init__(self, storage: Storage):
         super().__init__()
         self.storage = storage

--- a/annet/generators/result.py
+++ b/annet/generators/result.py
@@ -102,6 +102,7 @@ class RunGeneratorResult:
                 new_fragment,
                 acl=result_acl,
                 filters=filters,
+                delete_with_null=generator_result.delete_with_null,
             )
             if jsontools.format_json(new_config) == jsontools.format_json(previous_config):
                 # config is not changed, deprioritize reload_cmd

--- a/annet/types.py
+++ b/annet/types.py
@@ -134,6 +134,7 @@ class GeneratorJSONFragmentResult:
         reload: str,
         perf: GeneratorPerf,
         reload_prio: int,
+        delete_with_null: bool = True,
     ):
         self.name = name
         self.tags = tags
@@ -144,6 +145,7 @@ class GeneratorJSONFragmentResult:
         self.reload = reload
         self.perf = perf
         self.reload_prio = reload_prio
+        self.delete_with_null = delete_with_null
 
 
 GeneratorResult = GeneratorEntireResult | GeneratorPartialResult | GeneratorJSONFragmentResult

--- a/docs/usage/gen.rst
+++ b/docs/usage/gen.rst
@@ -75,3 +75,15 @@ For cases where one file contains configurations for many services. Must inherit
                 for ip in device.ifaces.ips:
                     with self.block(dns_ip):
                         yield {}
+
+An object the generator stops producing is written back as an explicit ``null``
+rather than dropped from the file. ``sudo config load -y`` merges the file into
+CONFIG_DB, and SONiC only deletes a table or an entry that is present with a
+``null`` value — a key that is simply absent stays in redis. Hash fields are not
+deletable this way at all, so those are dropped as before.
+
+Set ``DELETE_WITH_NULL = False`` if the file's consumer replaces it wholesale
+and the nulls would just be noise::
+
+    class Dns(JSONFragment):
+        DELETE_WITH_NULL = False

--- a/tests/annet/test_jsonfragments.py
+++ b/tests/annet/test_jsonfragments.py
@@ -244,6 +244,8 @@ def test_new_json_fragment_files():
             reload="sonic-reload",
             perf=GeneratorPerf(1.0, None, None),
             reload_prio=100,
+            # deletions as plain absences; see test_new_json_fragment_files_delete_with_null
+            delete_with_null=False,
         )
 
     old_files = {
@@ -407,6 +409,119 @@ def test_new_json_fragment_files():
             "sonic-reload",
         ),
     }
+
+
+def test_new_json_fragment_files_delete_with_null():
+    def make_interface_fragment(config: dict[str, Any]) -> GeneratorJSONFragmentResult:
+        return GeneratorJSONFragmentResult(
+            name="interfaces",
+            tags=["interfaces"],
+            path="/etc/sonic/config_db.json",
+            acl=["/INTERFACE", "/VLAN_INTERFACE"],
+            acl_safe=["/INTERFACE/*/description"],
+            config=config,
+            reload="sonic-reload",
+            perf=GeneratorPerf(1.0, None, None),
+            reload_prio=100,
+        )
+
+    old_files = {
+        "/etc/sonic/config_db.json": {
+            "INTERFACE": {
+                "Ethernet0": {"admin_status": "up", "description": "Ether0"},
+                "Ethernet8": {"admin_status": "up", "description": "Ether8"},
+            },
+            "VLAN_INTERFACE": {
+                "Ethernet0": {"vrf_name": "default"},
+            },
+        },
+    }
+
+    gen_res = RunGeneratorResult()
+    gen_res.add_json_fragment(
+        make_interface_fragment(
+            {
+                "INTERFACE": {
+                    "Ethernet0": {"admin_status": "up"},  # "description" field dropped
+                    # no "Ethernet8" entry
+                },
+                # no "VLAN_INTERFACE" table
+            }
+        ),
+    )
+
+    assert gen_res.new_json_fragment_files(old_files) == {
+        "/etc/sonic/config_db.json": (
+            {
+                "INTERFACE": {
+                    "Ethernet0": {"admin_status": "up"},  # hash field just disappears
+                    "Ethernet8": None,  # entry nulled
+                },
+                "VLAN_INTERFACE": None,  # table nulled
+            },
+            "sonic-reload",
+        ),
+    }
+
+
+def test_new_json_fragment_files_delete_with_null_is_stable():
+    """A null left by a previous run must survive the next one unchanged."""
+
+    def make_interface_fragment(config: dict[str, Any]) -> GeneratorJSONFragmentResult:
+        return GeneratorJSONFragmentResult(
+            name="interfaces",
+            tags=["interfaces"],
+            path="/etc/sonic/config_db.json",
+            acl=["/INTERFACE", "/VLAN_INTERFACE"],
+            acl_safe=["/INTERFACE/*/description"],
+            config=config,
+            reload="sonic-reload",
+            perf=GeneratorPerf(1.0, None, None),
+            reload_prio=100,
+        )
+
+    # the device now holds what the previous run uploaded
+    old_files = {
+        "/etc/sonic/config_db.json": {
+            "INTERFACE": {"Ethernet0": {"admin_status": "up"}, "Ethernet8": None},
+            "VLAN_INTERFACE": None,
+        },
+    }
+
+    gen_res = RunGeneratorResult()
+    gen_res.add_json_fragment(make_interface_fragment({"INTERFACE": {"Ethernet0": {"admin_status": "up"}}}))
+
+    new_files = gen_res.new_json_fragment_files(old_files)
+    assert new_files["/etc/sonic/config_db.json"][0] == old_files["/etc/sonic/config_db.json"]
+
+
+def test_apply_json_fragment_delete_with_null_keeps_scalars_and_lists_absent():
+    old = {
+        "VLAN": {
+            "Vlan605": {"vlanid": "605", "dhcpv6_servers": ["fe80::1"]},
+        },
+    }
+    result = apply_json_fragment(
+        old,
+        {"VLAN": {"Vlan605": {"vlanid": "605"}}},
+        acl=["/VLAN/Vlan*/*"],
+        delete_with_null=True,
+    )
+    # a list-valued hash field is dropped rather than nulled: SONiC cannot
+    # delete hash fields via `config load` anyway
+    assert result == {"VLAN": {"Vlan605": {"vlanid": "605"}}}
+
+
+def test_apply_json_fragment_delete_with_null_respects_cant_delete():
+    old = {
+        "VLAN": {
+            "Vlan605": {"vlanid": "605"},
+        },
+    }
+    acl = [JsonFragmentAcl(pointer="/VLAN/Vlan*/vlanid", cant_delete=("/VLAN",))]
+    result = apply_json_fragment(old, {}, acl=acl, delete_with_null=True)
+    # /VLAN is protected, Vlan605 is not — so it is nulled, not dropped
+    assert result == {"VLAN": {"Vlan605": None}}
 
 
 def test_new_json_fragment_files_append_list():


### PR DESCRIPTION
SONiC's `config load` merges the uploaded config into CONFIG_DB and only deletes a table or an entry that is present with a `null` value. A key that is simply absent is left in redis untouched, so a JSONFragment generator that stops producing a table could never clean it up.

Write removed objects back as `null` instead of dropping them. Scalars and lists keep disappearing: SONiC cannot delete hash fields this way at all, and nulling them would only hide the removal from tooling that looks for it.

The nulling works off the old and new documents rather than the ACL bookkeeping, because a key can leave the config two ways — the deletion loop pops it, or `_pointer_set` replaces its whole parent with a fragment that no longer lists it. The latter is what a table-level ACL such as `/DNS_NAMESERVER` does, and it is the common case.

On by default; set `DELETE_WITH_NULL = False` on a generator whose file is replaced wholesale by its consumer. `apply_json_fragment()` keeps its previous behaviour unless `delete_with_null=True` is passed.