### PR TITLE
feat: make native JSON scalars optional for JSONFragment generators

### DIFF
--- a/annet/generators/jsonfragment.py
+++ b/annet/generators/jsonfragment.py
@@ -21,6 +21,10 @@ class JSONFragment(TreeGenerator):
     # redis. Turn it off for a file whose consumer replaces it wholesale.
     DELETE_WITH_NULL = True
 
+    # Emit int/float/bool/None as native JSON scalars. Turn it off to render
+    # every scalar as a string, the way generators behaved before 4.5.0.
+    NATIVE_SCALARS = True
+
     def __init__(self, storage: Storage):
         super().__init__()
         self.storage = storage
@@ -102,15 +106,13 @@ class JSONFragment(TreeGenerator):
 
     def process_scalar_value(self, value: Any) -> Any:
         if value is None:
+            # Deliberately not stringified even with NATIVE_SCALARS off: pre-4.5.0
+            # rendered this as the string "None", and DELETE_WITH_NULL has since
+            # given `null` a meaning of its own.
             return value
-        elif isinstance(value, bool):
+        if self.NATIVE_SCALARS and isinstance(value, (bool, int, float)):
             return value
-        elif isinstance(value, int):
-            return value
-        elif isinstance(value, float):
-            return value
-        else:
-            return str(value)
+        return str(value)
 
     def process_value(self, value: Any) -> Any:
         if isinstance(value, (list, set, frozenset)):

--- a/docs/usage/gen.rst
+++ b/docs/usage/gen.rst
@@ -87,3 +87,10 @@ and the nulls would just be noise::
 
     class Dns(JSONFragment):
         DELETE_WITH_NULL = False
+
+Scalars a generator yields keep their JSON type, so ``yield {"mtu": 9000}``
+renders as a number. Set ``NATIVE_SCALARS = False`` to render every scalar as a
+string instead, the way generators behaved before 4.5.0::
+
+    class Dns(JSONFragment):
+        NATIVE_SCALARS = False

--- a/tests/annet/test_jsonfragments.py
+++ b/tests/annet/test_jsonfragments.py
@@ -5,7 +5,7 @@ import pytest
 import annet.diff
 from annet.annlib.jsontools import JsonFragmentAcl, apply_json_fragment
 from annet.annlib.netdev.views.hardware import HardwareView
-from annet.generators import _normalize_json_fragment_acl
+from annet.generators import JSONFragment, _normalize_json_fragment_acl
 from annet.generators.result import RunGeneratorResult
 from annet.types import GeneratorJSONFragmentResult, GeneratorPerf
 
@@ -835,3 +835,64 @@ def test_apply_json_fragment_cant_delete_main_user_scenario():
     # B then A: B leaves Vlans with vlanid; A then erases /VLAN entirely.
     after_b_then_a = apply_json_fragment(after_b, {}, acl=acl_a)
     assert after_b_then_a == {}
+
+
+class _ScalarGen(JSONFragment):
+    """Yields one entry covering every scalar kind a generator can emit."""
+
+    def path(self, device: Any) -> str:
+        return "/etc/sonic/config_db.json"
+
+    def acl(self, device: Any) -> str:
+        return "/TABLE"
+
+    def reload(self, device: Any) -> str:
+        return ""
+
+    def run(self, device: Any) -> Any:
+        with self.block("TABLE"):
+            with self.block("key"):
+                yield {
+                    "count": 8,
+                    "enabled": True,
+                    "ratio": 1.5,
+                    "name": "spine1",
+                    "absent": None,
+                    "members": [1, "two", False],
+                }
+
+
+class _StringScalarGen(_ScalarGen):
+    NATIVE_SCALARS = False
+
+
+def test_native_scalars_kept_by_default() -> None:
+    assert _ScalarGen(storage=None)(device=None) == {
+        "TABLE": {
+            "key": {
+                "count": 8,
+                "enabled": True,
+                "ratio": 1.5,
+                "name": "spine1",
+                "absent": None,
+                "members": [1, "two", False],
+            }
+        }
+    }
+
+
+def test_native_scalars_off_stringifies_everything_but_null() -> None:
+    assert _StringScalarGen(storage=None)(device=None) == {
+        "TABLE": {
+            "key": {
+                "count": "8",
+                "enabled": "True",
+                "ratio": "1.5",
+                "name": "spine1",
+                # `null` survives: turning the flag off must not resurrect the
+                # pre-4.5.0 "None" string, which DELETE_WITH_NULL would misread.
+                "absent": None,
+                "members": ["1", "two", "False"],
+            }
+        }
+    }


### PR DESCRIPTION
JSON number. That is right for a store with real types, but SONiC keeps every CONFIG_DB hash field as a string: the values are identical, only their spelling changed. Rolling that across a live fleet produces a large diff on many devices and buys nothing.

Add a NATIVE_SCALARS tumbler, on by default so #628 stays the default. Turn it off per generator to render every scalar as a string the way generators behaved before 4.5.0.

None is left alone in both modes. Pre-4.5.0 rendered it as the string "None", which was a bug in its own right, and DELETE_WITH_NULL has since given `null` a meaning that "None" would silently defeat.