### PR TITLE
fix(h3c): drop the duplicate undo peer ordering rule

### DIFF
--- a/annet/rulebook/texts/h3c.order
+++ b/annet/rulebook/texts/h3c.order
@@ -271,7 +271,6 @@ bgp
     undo peer * description %order_reverse
     undo peer * * * %order_reverse
     undo peer * * %order_reverse
-    undo peer * %order_reverse
     undo group * %order_reverse
     peer * ~
 


### PR DESCRIPTION
`bgp` listed `undo peer *` twice: once unparameterised at child index 7, added so a peer is torn down before being recreated on an ASN change, and once as `undo peer * %order_reverse` at index 17 in the cleanup block.

The second copy is unreachable.  Both rules match `undo peer X` with the same weight, but the unparameterised one yields a mirrored negative index (-7) while the %order_reverse one yields +17, and get_order picks the smallest - so every `undo peer` command already resolves to index 7.  Checked against `undo peer X`, `undo peer X description`, `undo peer GROUP as-number`, `undo peer X enable`, `undo peer X a b`, `undo group X` and `peer X as-number N`: all sort keys are unchanged apart from indices shifting down one where the line was removed, which preserves relative order.