### PR TITLE
fix: keep block order when rules mix %diff_logic

### DIFF
--- a/annet/annlib/rulebook/common.py
+++ b/annet/annlib/rulebook/common.py
@@ -297,8 +297,9 @@ def call_diff_logic(
 ) -> list[DiffItem]:
     """
     Группируем команды в старом и новом конфиге согласно выставленным
-    в рулбуке атрибутам %diff_logic и вызывает их поочереди согласно
-    порядку команд в old и new, предпочитая old (т.е. сначала удаления)
+    в рулбуке атрибутам %diff_logic и вызываем их по очереди, после чего
+    склеиваем результаты обратно в порядке команд в old и new, предпочитая
+    old (т.е. сначала удаления)
     """
     diff_logics: odict[typing.Any, typing.Any] = odict()
     for row in old:
@@ -311,10 +312,32 @@ def call_diff_logic(
         if logic not in diff_logics:
             diff_logics[logic] = (odict(), odict())
         diff_logics[logic][1][row] = new[row]
-    ret = []
-    for logic, (old, new) in diff_logics.items():
-        ret.extend(logic(old=old, new=new, diff_pre=diff_pre, _pops=pops))
-    return ret
+
+    if len(diff_logics) == 1:
+        ((logic, (logic_old, logic_new)),) = diff_logics.items()
+        return list(logic(old=logic_old, new=logic_new, diff_pre=diff_pre, _pops=pops))
+
+    positions = _row_positions(old, new)
+    indexed: list[tuple[int, DiffItem]] = []
+    for logic, (logic_old, logic_new) in diff_logics.items():
+        position = 0
+        for item in logic(old=logic_old, new=logic_new, diff_pre=diff_pre, _pops=pops):
+            position = positions.get(item.row, position)
+            indexed.append((position, item))
+    indexed.sort(key=lambda pair: pair[0])
+    return [item for _, item in indexed]
+
+
+def _row_positions(old: odict[str, typing.Any], new: odict[str, typing.Any]) -> dict[str, int]:
+    positions: dict[str, int] = {}
+    for index, row in enumerate(old):
+        if row not in new:
+            positions[row] = index
+    for index, row in enumerate(new):
+        positions[row] = index
+    for row, index in list(positions.items()):
+        positions.setdefault(row.lower(), index)
+    return positions
 
 
 def _ignore_case(diff_pre: odict[str, typing.Any], cfg: odict[str, typing.Any]) -> odict[str, typing.Any]:

--- a/tests/annet/test_patching.py
+++ b/tests/annet/test_patching.py
@@ -7,7 +7,7 @@ import pytest
 from annet.annlib.rbparser import syntax
 from annet.patching import PatchTree, make_diff
 from annet.rulebook.common import default, default_diff, ordered_diff
-from annet.rulebook.patching import _make_reverse
+from annet.rulebook.patching import _make_reverse, compile_patching_text
 from annet.types import Op
 from annet.vendors.tabparser import CommonFormatter
 
@@ -83,6 +83,46 @@ def test_ordered_diff_block(config_tree, reversed_tree, rb):
             _make_match(rb, "a"),
         ),
         (Op.MOVED, "z", [], _make_match(rb, "z")),
+    ]
+
+
+def custom_diff_logic(old, new, diff_pre, _pops=(Op.AFFECTED,)):
+    """Behaves exactly like the default logic, it is only a distinct function object"""
+    return default_diff(old, new, diff_pre, _pops)
+
+
+def test_diff_keeps_block_order_with_mixed_diff_logic():
+    """A rule with its own %diff_logic must not regroup the block it matches in - #638"""
+    rb_text = dedent("""
+        ip access-list ~
+            ?/(\\d+)/ permit ~   %diff_logic=tests.annet.test_patching.custom_diff_logic
+            ~
+    """).strip()
+    rb = {"patching": compile_patching_text(rb_text, "cisco")}
+
+    def acl(*rows):
+        return odict([("ip access-list extended TEST", odict((row, odict()) for row in rows))])
+
+    old = acl("10 permit ip any any")
+    new = acl(
+        "20 deny ip host 0.0.0.0 any",
+        "30 permit tcp any any eq 22",
+        "60 remark GRE",
+        "70 permit gre any any",
+        "230 deny ip any any log",
+    )
+
+    [(op, row, children, _match)] = make_diff(old, new, rb, [])
+    assert (op, row) == (Op.AFFECTED, "ip access-list extended TEST")
+    # the permits are matched by the custom rule and the rest by the plain one,
+    # but both groups keep their places in the block
+    assert [(child_op, child_row) for child_op, child_row, _, _ in children] == [
+        (Op.REMOVED, "10 permit ip any any"),
+        (Op.ADDED, "20 deny ip host 0.0.0.0 any"),
+        (Op.ADDED, "30 permit tcp any any eq 22"),
+        (Op.ADDED, "60 remark GRE"),
+        (Op.ADDED, "70 permit gre any any"),
+        (Op.ADDED, "230 deny ip any any log"),
     ]
 
 


### PR DESCRIPTION
call_diff_logic groups a block's rows by their %diff_logic function and used to concatenate the per-group results. Order was preserved inside a group, but lost across groups: a block whose rows are partly matched by a rule with a custom %diff_logic came out regrouped - all rows of one logic first, then all rows of the other.

Group the rows as before, since ordered_diff and friends must see their whole row set at once, but merge the results back by config position - removed rows by their old index, the rest by their new index, the same convention base_diff uses inside a group. Blocks with a single logic take a fast path and are returned untouched.

Fixes #638