### PR TITLE
refactor(rulebook): inline the Literal key constants

### DIFF
--- a/annet/annlib/rbparser/ordering.py
+++ b/annet/annlib/rbparser/ordering.py
@@ -29,53 +29,26 @@ from annet.rulebook.types import (
 from annet.vendors import registry_connector
 
 
-# ===RULE===
-RULES: Literal["rules"] = "rules"
-ATTRS: Literal["attrs"] = "attrs"
-CHILDREN: Literal["children"] = "children"
-TYPE: Literal["type"] = "type"
-NORMAL: Literal["normal"] = "normal"
-
-# ===PARAMS===
-PARAMS: Literal["params"] = "params"
-ORDER_REVERSE: Literal["order_reverse"] = "order_reverse"
-GLOBAL: Literal["global"] = "global"
-SCOPE: Literal["scope"] = "scope"
-SPLIT: Literal["split"] = "split"
-DIRECT_REGEXP: Literal["direct_regexp"] = "direct_regexp"
-REVERSE_REGEXP: Literal["reverse_regexp"] = "reverse_regexp"
-CONTEXT: Literal["context"] = "context"
-RAW_RULE: Literal["raw_rule"] = "raw_rule"
-ROW: Literal["row"] = "row"
-NOT_INHERIT: Literal["not_inherit"] = "not_inherit"
-INSERT_TO_END_GROUP: Literal["insert_to_end_group"] = "insert_to_end_group"
-
-# ===GROUP===
-ROWS: Literal["rows"] = "rows"
-ANCHOR: Literal["anchor"] = "anchor"
-COUNT: Literal["count"] = "count"
-
-
 def get_params_scheme() -> ParamsScheme:
     """Returning the params scheme"""
     return {
-        ORDER_REVERSE: {
+        "order_reverse": {
             "validator": valid_bool,
             "default": False,
         },
-        GLOBAL: {
+        "global": {
             "validator": valid_bool,
             "default": False,
         },
-        SCOPE: {
+        "scope": {
             "validator": valid_string_list,
             "default": None,
         },
-        SPLIT: {
+        "split": {
             "validator": valid_bool,
             "default": False,
         },
-        CONTEXT: {
+        "context": {
             "validator": str,
             "default": None,
         },
@@ -96,28 +69,30 @@ def compile_ordering_text(text: OrderingText, vendor: str) -> OrderRulebook:
 def _compile_ordering(tree: syntax.ParsedTree, reverse_prefix: str) -> OrderRulebook:
     ordering: OrderRulebook = []
     for rule_id, attrs in tree:
-        if attrs[TYPE] == NORMAL:
+        if attrs["type"] == "normal":
             ordering.append(
                 (
                     rule_id,
                     {
-                        ATTRS: OrderRuleAttrs(
+                        "attrs": OrderRuleAttrs(
                             {
-                                DIRECT_REGEXP: syntax.compile_row_regexp(attrs[ROW]),
-                                REVERSE_REGEXP: (
-                                    syntax.compile_row_regexp(reverse_prefix + " " + attrs[ROW])
-                                    if not attrs[ROW].startswith(reverse_prefix + " ")
-                                    else syntax.compile_row_regexp(re.sub(r"^%s\s+" % (reverse_prefix), "", attrs[ROW]))
+                                "direct_regexp": syntax.compile_row_regexp(attrs["row"]),
+                                "reverse_regexp": (
+                                    syntax.compile_row_regexp(reverse_prefix + " " + attrs["row"])
+                                    if not attrs["row"].startswith(reverse_prefix + " ")
+                                    else syntax.compile_row_regexp(
+                                        re.sub(r"^%s\s+" % (reverse_prefix), "", attrs["row"])
+                                    )
                                 ),
-                                ORDER_REVERSE: attrs[PARAMS][ORDER_REVERSE],
-                                GLOBAL: attrs[PARAMS][GLOBAL],
-                                SCOPE: attrs[PARAMS][SCOPE],
-                                RAW_RULE: attrs[RAW_RULE],
-                                CONTEXT: attrs[CONTEXT],
-                                SPLIT: attrs[PARAMS][SPLIT],
+                                "order_reverse": attrs["params"]["order_reverse"],
+                                "global": attrs["params"]["global"],
+                                "scope": attrs["params"]["scope"],
+                                "raw_rule": attrs["raw_rule"],
+                                "context": attrs["context"],
+                                "split": attrs["params"]["split"],
                             }
                         ),
-                        CHILDREN: _compile_ordering(attrs[CHILDREN], reverse_prefix),
+                        "children": _compile_ordering(attrs["children"], reverse_prefix),
                     },
                 )
             )
@@ -145,68 +120,68 @@ def merge_order_rulebooks(
     non_anchor_queue: GroupRows = []
 
     if group_anchor is None:
-        start_group_rows, end_group_rows = _split_rows_by_insert_to_end_group_param(group_data[ROWS])
+        start_group_rows, end_group_rows = _split_rows_by_insert_to_end_group_param(group_data["rows"])
         _add_group_to_merged_rulebook(merged_rulebook, start_group_rows, parent_scopes)
         non_anchor_queue = end_group_rows
         group_anchor, group_data = _get_next_group(child_groups)
 
-    start_group_rows, end_group_rows = _split_rows_by_insert_to_end_group_param(group_data[ROWS])
+    start_group_rows, end_group_rows = _split_rows_by_insert_to_end_group_param(group_data["rows"])
 
     for row, parent_data in parent_pre_merge:
         if (group_anchor is None and _is_empty_child_group_data(group_data)) or row != group_anchor:
-            node = (parent_data[RAW_RULE], parent_data[RULES])
+            node = (parent_data["raw_rule"], parent_data["rules"])
             check_rulebook_scope_compatibility([node], parent_scopes)
             merged_rulebook.append(node)
             continue
 
-        anchor_data = group_data[ANCHOR]
+        anchor_data = group_data["anchor"]
 
         # for mypy: anchor_data cannot be None due to prior if-condition check
         assert anchor_data is not None
 
         _add_group_to_merged_rulebook(merged_rulebook, anchor_queue, parent_scopes)
 
-        merged_row = _get_merged_row(parent_data[PARAMS], anchor_data[PARAMS], row)
+        merged_row = _get_merged_row(parent_data["params"], anchor_data["params"], row)
         merged_attrs = _merge_attrs(
-            parent_data[RULES][ATTRS], anchor_data[RULES][ATTRS], anchor_data[PARAMS], merged_row
+            parent_data["rules"]["attrs"], anchor_data["rules"]["attrs"], anchor_data["params"], merged_row
         )
 
-        curr_scopes = merged_attrs[SCOPE]
+        curr_scopes = merged_attrs["scope"]
         if parent_scopes is not None and curr_scopes is not None:
             check_scope_compatibility(curr_scopes, parent_scopes, merged_row)
 
         merged_children = merge_order_rulebooks(
-            parent_data[RULES][CHILDREN],
-            anchor_data[RULES][CHILDREN],
+            parent_data["rules"]["children"],
+            anchor_data["rules"]["children"],
             vendor,
             get_effective_scopes(curr_scopes, parent_scopes),
         )
 
-        merged_rulebook.append((merged_row, {ATTRS: merged_attrs, CHILDREN: merged_children}))
+        merged_rulebook.append((merged_row, {"attrs": merged_attrs, "children": merged_children}))
 
         _add_group_to_merged_rulebook(merged_rulebook, start_group_rows, parent_scopes)
 
         anchor_queue = end_group_rows
 
         group_anchor, group_data = _get_next_group(child_groups)
-        start_group_rows, end_group_rows = _split_rows_by_insert_to_end_group_param(group_data[ROWS])
+        start_group_rows, end_group_rows = _split_rows_by_insert_to_end_group_param(group_data["rows"])
 
     _add_group_to_merged_rulebook(merged_rulebook, anchor_queue, parent_scopes)
 
     _add_group_to_merged_rulebook(merged_rulebook, non_anchor_queue, parent_scopes)
 
     if start_group_rows or end_group_rows or group_anchor is not None:
-        anchor_data = group_data.get(ANCHOR)
+        anchor_data = group_data.get("anchor")
         if anchor_data is not None:
-            rule = anchor_data[RAW_RULE]
+            rule = anchor_data["raw_rule"]
         else:
             rule = None
         raise RulebookSyntaxError(
             "The relative order of rules must stay the same in both parent and child rulebooks.\n"
             f"Rule in child rulebook '{rule}'.\n"
             f"Group anchor '{group_anchor}'.\n"
-            f"Rules with insert_to_end_group param in group:\n\t{[row[RAW_RULE] for row in end_group_rows]}\n"
-            f"Rules without insert_to_end_group param in group:\n\t{[row[RAW_RULE] for row in start_group_rows]}\n"
+            f"Rules with insert_to_end_group param in group:\n\t{[row['raw_rule'] for row in end_group_rows]}\n"
+            f"Rules without insert_to_end_group param in group:\n\t{[row['raw_rule'] for row in start_group_rows]}\n"
             "To fix this:\n"
             "\t1. Check the order of rules in the parent rulebook.\n"
             "\t2. Make sure they appear in exactly the same relative order in the child rulebook.\n"
@@ -220,7 +195,7 @@ def dump_order_rulebook(rulebook: OrderRulebook, level: int = 0) -> OrderingText
     lines = []
     for row, data in rulebook:
         lines.append(f"{'    ' * level}{row}")
-        children_lines = dump_order_rulebook(data[CHILDREN], level + 1)
+        children_lines = dump_order_rulebook(data["children"], level + 1)
         if children_lines:
             lines.append(children_lines)
     return "\n".join(lines)
@@ -233,12 +208,12 @@ def _apply_not_inherit_to_pre_merges(
     ignored_rules = set()
     applied_child_pre_merge = []
     for child_row, child_data in child_pre_merge:
-        if not raw_param_to_bool(child_data[PARAMS].get(NOT_INHERIT)):
+        if not raw_param_to_bool(child_data["params"].get("not_inherit")):
             applied_child_pre_merge.append((child_row, child_data))
             continue
 
         ignored_rules.add(child_row)
-        if child_data[RULES][CHILDREN]:
+        if child_data["rules"]["children"]:
             applied_child_pre_merge.append((child_row, child_data))
 
     applied_parent_pre_merge = []
@@ -254,14 +229,14 @@ def _apply_not_inherit_to_rulebook(rulebook: OrderRulebook) -> OrderRulebook:
     applied_rulebook: OrderRulebook = []
     for raw_row, data in rulebook:
         row, raw_params = syntax.get_row_and_raw_params(raw_row)
-        not_inherit = raw_params.pop(NOT_INHERIT, None)
+        not_inherit = raw_params.pop("not_inherit", None)
         raw_row = syntax.get_row_with_params(row, raw_params, get_params_scheme())
-        data[ATTRS][RAW_RULE] = raw_row
+        data["attrs"]["raw_rule"] = raw_row
         if not raw_param_to_bool(not_inherit):
             pass
-        elif not data[CHILDREN]:
+        elif not data["children"]:
             continue
-        data[CHILDREN] = _apply_not_inherit_to_rulebook(data[CHILDREN])
+        data["children"] = _apply_not_inherit_to_rulebook(data["children"])
         applied_rulebook.append((raw_row, data))
     return applied_rulebook
 
@@ -276,7 +251,7 @@ def _split_rows_by_insert_to_end_group_param(rows: GroupRows) -> tuple[GroupRows
     start_group = []
     end_group = []
     for row_data in rows:
-        if row_data[INSERT_TO_END_GROUP]:
+        if row_data["insert_to_end_group"]:
             end_group.append(row_data)
         else:
             start_group.append(row_data)
@@ -305,7 +280,7 @@ def _merge_attrs(
             # A dynamic key cannot be recognized by mypy as a string literal
             merged_attrs[param] = child_attrs[param]  # type: ignore[literal-required]
 
-    merged_attrs[RAW_RULE] = raw_row
+    merged_attrs["raw_rule"] = raw_row
 
     return merged_attrs
 
@@ -315,12 +290,12 @@ def _get_pre_merge(rulebook: OrderRulebook) -> OrderPreMerge:
     pre_merge = []
     for raw_row, rules in rulebook:
         row, raw_params = syntax.get_row_and_raw_params(raw_row)
-        insert_to_end_group = raw_params.pop(INSERT_TO_END_GROUP, None)
-        raw_params.pop(SCOPE, None)
-        scope = rules[ATTRS].get(SCOPE)
+        insert_to_end_group = raw_params.pop("insert_to_end_group", None)
+        raw_params.pop("scope", None)
+        scope = rules["attrs"].get("scope")
         if scope is not None:
             raw_scope_value = ",".join(scope)
-            row = f"{row} %{SCOPE}={raw_scope_value}"
+            row = f"{row} %scope={raw_scope_value}"
         data = OrderPreMergeData(
             params=raw_params,
             rules=rules,
@@ -354,7 +329,7 @@ def _get_empty_anchor_data() -> AnchorData:
 
 def _is_empty_child_group_data(group_data: GroupData) -> bool:
     """Checks whether the provided group is empty"""
-    return group_data[ANCHOR] is None and not group_data[ROWS]
+    return group_data["anchor"] is None and not group_data["rows"]
 
 
 def _get_child_groups(parent_pre_merge: OrderPreMerge, child_pre_merge: OrderPreMerge) -> Generator[Group, None, None]:
@@ -366,31 +341,31 @@ def _get_child_groups(parent_pre_merge: OrderPreMerge, child_pre_merge: OrderPre
     anchors_data = _get_anchors_data(parent_pre_merge)
     for row, data in child_pre_merge:
         if row not in anchors_data:
-            group_data[ROWS].append(data)
+            group_data["rows"].append(data)
             continue
 
-        count = anchors_data[row][COUNT]
-        split = anchors_data[row][SPLIT]
-        child_split = data[RULES][ATTRS][SPLIT]
+        count = anchors_data[row]["count"]
+        split = anchors_data[row]["split"]
+        child_split = data["rules"]["attrs"]["split"]
 
         if child_split != split and split:
             raise RulebookSyntaxError(
                 f"Rule '{row}' has different %split parameters in the parent and children rulebooks. "
-                f"In parent rulebook: {split}, in children rulebook: {data[RULES][ATTRS][SPLIT]}."
+                f"In parent rulebook: {split}, in children rulebook: {child_split}."
             )
         if count == 0:
             if not split and not child_split:
                 raise RulebookSyntaxError(
                     f"Rule '{row}' has no %split parameter but is listed multiple times in the children rulebook."
                 )
-            group_data[ROWS].append(data)
+            group_data["rows"].append(data)
         else:
-            anchors_data[row][COUNT] -= 1
+            anchors_data[row]["count"] -= 1
             if not _is_empty_child_group_data(group_data):
                 yield anchor, group_data
                 group_data = _get_empty_child_group_data()
             anchor = row
-            group_data[ANCHOR] = data
+            group_data["anchor"] = data
 
     if not _is_empty_child_group_data(group_data):
         yield anchor, group_data
@@ -404,10 +379,10 @@ def _get_anchors_data(parent_pre_merge: OrderPreMerge) -> AnchorsData:
     anchors_data: AnchorsData = {}
     for row, data in parent_pre_merge:
         anchor_data: AnchorData = anchors_data.get(row, _get_empty_anchor_data())
-        anchor_data[COUNT] = anchor_data[COUNT] + 1
-        anchor_data[SPLIT] = data[RULES][ATTRS][SPLIT]
+        anchor_data["count"] = anchor_data["count"] + 1
+        anchor_data["split"] = data["rules"]["attrs"]["split"]
         anchors_data[row] = anchor_data
-        if anchors_data[row][COUNT] > 1 and not anchors_data[row][SPLIT]:
+        if anchors_data[row]["count"] > 1 and not anchors_data[row]["split"]:
             raise RulebookSyntaxError(
                 f"Rule '{row}' has no %split parameter but is listed multiple times in the parent rulebook."
             )
@@ -418,7 +393,7 @@ def _add_group_to_merged_rulebook(
     merged_rulebook: OrderRulebook, rows: GroupRows, parent_scopes: list[str] | None
 ) -> None:
     """Adds rules from the group to merged_rulebook"""
-    rulebook: OrderRulebook = [(row_data[RAW_RULE], row_data[RULES]) for row_data in rows]
+    rulebook: OrderRulebook = [(row_data["raw_rule"], row_data["rules"]) for row_data in rows]
     applied_rulebook = _apply_not_inherit_to_rulebook(rulebook)
     check_rulebook_scope_compatibility(applied_rulebook, parent_scopes)
     merged_rulebook.extend(applied_rulebook)
@@ -427,10 +402,10 @@ def _add_group_to_merged_rulebook(
 def check_rulebook_scope_compatibility(rulebook: OrderRulebook, parent_scopes: list[str] | None) -> None:
     """Checks compatibility of rulebook scope"""
     for row, rules in rulebook:
-        curr_scopes = rules[ATTRS][SCOPE]
+        curr_scopes = rules["attrs"]["scope"]
         if curr_scopes is not None and parent_scopes is not None:
             check_scope_compatibility(curr_scopes, parent_scopes, row)
-        check_rulebook_scope_compatibility(rules[CHILDREN], get_effective_scopes(curr_scopes, parent_scopes))
+        check_rulebook_scope_compatibility(rules["children"], get_effective_scopes(curr_scopes, parent_scopes))
 
 
 def get_effective_scopes(curr_scopes: list[str] | None, parent_scopes: list[str] | None) -> list[str] | None:
@@ -458,13 +433,13 @@ def _check_pre_merge_for_duplicate_rules(pre_merge: OrderPreMerge, context: Lite
     """
     count: defaultdict[str, Any] = defaultdict(dict)
     for row, data in pre_merge:
-        split = data[RULES][ATTRS][SPLIT]
-        count[row][COUNT] = count[row].get(COUNT, 0) + 1
-        if count[row].get(SPLIT) is None:
-            count[row][SPLIT] = split
-        elif count[row][SPLIT] != split:
+        split = data["rules"]["attrs"]["split"]
+        count[row]["count"] = count[row].get("count", 0) + 1
+        if count[row].get("split") is None:
+            count[row]["split"] = split
+        elif count[row]["split"] != split:
             raise RulebookSyntaxError(f"Rule '{row}' has different %split parameters in the {context} rulebook.")
-        if not split and count[row][COUNT] > 1:
+        if not split and count[row]["count"] > 1:
             raise RulebookSyntaxError(
                 f"Rule '{row}' has no %split parameter but is listed multiple times in the {context} rulebook."
             )

--- a/annet/rulebook/__init__.py
+++ b/annet/rulebook/__init__.py
@@ -65,11 +65,6 @@ if sys.version_info >= (3, 12):
         RULEBOOK_READ_EXCEPTIONS = (FileNotFoundError, _traversal_error)
 
 
-RUL: Literal["rul"] = "rul"
-ORDER: Literal["order"] = "order"
-DEPLOY: Literal["deploy"] = "deploy"
-
-
 class RulebookProvider(ABC):
     def get_rulebook(self, hw: HardwareView) -> Rulebook:
         raise NotImplementedError
@@ -90,14 +85,14 @@ def get_rulebook(hw: HardwareView) -> Rulebook:
 class DefaultRulebookProvider(RulebookProvider):
     DEFAULT_RULEBOOK_MODULE = "annet.rulebook.texts"
     merge_rulebooks: dict[Extension, Callable[..., AnyRulebook]] = {
-        RUL: merge_patch_rulebooks,
-        ORDER: merge_order_rulebooks,
-        DEPLOY: merge_deploy_rulebooks,
+        "rul": merge_patch_rulebooks,
+        "order": merge_order_rulebooks,
+        "deploy": merge_deploy_rulebooks,
     }
     compile_rulebooks: dict[Extension, Callable[..., AnyRulebook]] = {
-        RUL: compile_patching_text,
-        ORDER: compile_ordering_text,
-        DEPLOY: compile_deploying_text,
+        "rul": compile_patching_text,
+        "order": compile_ordering_text,
+        "deploy": compile_deploying_text,
     }
 
     def __init__(self) -> None:
@@ -121,7 +116,7 @@ class DefaultRulebookProvider(RulebookProvider):
             # The first rulebook should be named exactly the same as hw.vendor
             rulebook_path=".".join((self.rulebook_module, rul_vendor_name)),
             vendor=rul_vendor_name,
-            extension=RUL,
+            extension="rul",
             hw=hw,
         )
         patching_text: PatchingText = dump_patch_rulebook(patching)
@@ -132,7 +127,7 @@ class DefaultRulebookProvider(RulebookProvider):
             ordering = self._get_rulebook_by_extension(
                 rulebook_path=".".join((self.rulebook_module, vendor)),
                 vendor=vendor,
-                extension=ORDER,
+                extension="order",
                 hw=hw,
             )
             ordering_text = dump_order_rulebook(ordering)
@@ -146,7 +141,7 @@ class DefaultRulebookProvider(RulebookProvider):
             deploying = self._get_rulebook_by_extension(
                 rulebook_path=".".join((self.rulebook_module, vendor)),
                 vendor=vendor,
-                extension=DEPLOY,
+                extension="deploy",
                 hw=hw,
             )
             deploying_text = dump_deploy_rulebook(deploying)

--- a/annet/rulebook/common.py
+++ b/annet/rulebook/common.py
@@ -1,6 +1,6 @@
 import functools
 import importlib
-from typing import Any, Callable, Literal, cast
+from typing import Any, Callable, cast
 
 from valkit.common import valid_bool
 
@@ -8,9 +8,6 @@ from annet.annlib.rbparser.exceptions import RulebookSyntaxError
 from annet.annlib.rulebook import common  # pylint: disable=unused-import # noqa: F401,F403
 from annet.annlib.rulebook.common import *  # pylint: disable=wildcard-import,unused-wildcard-import # noqa: F401,F403
 from annet.rulebook.types import OrderRuleAttrs, PatchRuleAttrs, RawParams, Row
-
-
-CONTEXT: Literal["context"] = "context"
 
 
 @functools.lru_cache()
@@ -34,7 +31,7 @@ def validate_context_compatibility(
     parent_attrs: PatchRuleAttrs | OrderRuleAttrs, child_attrs: PatchRuleAttrs | OrderRuleAttrs, row: Row
 ) -> None:
     """Checks compatibility of rule contexts"""
-    if parent_attrs[CONTEXT] != child_attrs[CONTEXT]:
+    if parent_attrs["context"] != child_attrs["context"]:
         raise RulebookSyntaxError(
             f"Merge error for rule '{row}'. Rule contexts must match in parent and child rulebooks."
         )

--- a/annet/rulebook/deploying.py
+++ b/annet/rulebook/deploying.py
@@ -1,6 +1,6 @@
 import functools
 from collections import OrderedDict as odict
-from typing import Any, Literal
+from typing import Any
 
 from valkit.common import valid_bool, valid_number, valid_string_list
 from valkit.python import valid_object_path
@@ -33,56 +33,29 @@ DEFAULT_TIMEOUT = 30
 DEFAULT_SEND_NL = True
 DEFAULT_APPLY_LOGIC = "annet.rulebook.common.apply"
 
-# ===PARAMS===
-VALIDATOR: Literal["validator"] = "validator"
-DEFAULT: Literal["default"] = "default"
-TIMEOUT: Literal["timeout"] = "timeout"
-SEND_NL: Literal["send_nl"] = "send_nl"
-APPLY_LOGIC: Literal["apply_logic"] = "apply_logic"
-IFCONTEXT: Literal["ifcontext"] = "ifcontext"
-REGEXP: Literal["regexp"] = "regexp"
-APPLY_LOGIC_NAME: Literal["apply_logic_name"] = "apply_logic_name"
-NOT_INHERIT: Literal["not_inherit"] = "not_inherit"
-SUPPRESS_ERRORS: Literal["suppress_errors"] = "suppress_errors"
-
-# ===RULE===
-RULES: Literal["rules"] = "rules"
-ATTRS: Literal["attrs"] = "attrs"
-CHILDREN: Literal["children"] = "children"
-PARAMS: Literal["params"] = "params"
-TYPE: Literal["type"] = "type"
-NORMAL: Literal["normal"] = "normal"
-ROW: Literal["row"] = "row"
-
-# ===DIALOGS===
-DIALOGS: Literal["dialogs"] = "dialogs"
-DIALOG_PREFIX: Literal["dialog:"] = "dialog:"
-MESSAGE: Literal["message"] = "message"
-ANSWER: Literal["answer"] = "answer"
-
 
 def get_params_scheme() -> ParamsScheme:
     """Returning the params scheme"""
     return {
-        TIMEOUT: {
-            VALIDATOR: lambda arg: valid_number(arg, min=1, type=float),
-            DEFAULT: DEFAULT_TIMEOUT,
+        "timeout": {
+            "validator": lambda arg: valid_number(arg, min=1, type=float),
+            "default": DEFAULT_TIMEOUT,
         },
-        SEND_NL: {
-            VALIDATOR: valid_bool,
-            DEFAULT: True,
+        "send_nl": {
+            "validator": valid_bool,
+            "default": True,
         },
-        APPLY_LOGIC: {
-            VALIDATOR: valid_object_path,
-            DEFAULT: DEFAULT_APPLY_LOGIC,
+        "apply_logic": {
+            "validator": valid_object_path,
+            "default": DEFAULT_APPLY_LOGIC,
         },
-        IFCONTEXT: {
-            VALIDATOR: valid_string_list,
-            DEFAULT: [],
+        "ifcontext": {
+            "validator": valid_string_list,
+            "default": [],
         },
-        SUPPRESS_ERRORS: {
-            VALIDATOR: valid_bool,
-            DEFAULT: False,
+        "suppress_errors": {
+            "validator": valid_bool,
+            "default": False,
         },
     }
 
@@ -90,9 +63,9 @@ def get_params_scheme() -> ParamsScheme:
 def get_dialog_params_scheme() -> ParamsScheme:
     """Returning the dialog params scheme"""
     return {
-        SEND_NL: {
-            VALIDATOR: valid_bool,
-            DEFAULT: True,
+        "send_nl": {
+            "validator": valid_bool,
+            "default": True,
         },
     }
 
@@ -112,19 +85,19 @@ def compile_deploying_text(text: DeployingText, vendor: str) -> DeployRulebook:
 def _compile_deploying(tree: dict[str, Any], reverse_prefix: str) -> DeployRulebook:
     deploying: DeployRulebook = odict()
     for rule_id, attrs in tree.items():
-        if attrs[TYPE] == NORMAL and not attrs[ROW].startswith(DIALOG_PREFIX):
-            dialogs = compile_messages(attrs[CHILDREN])
+        if attrs["type"] == "normal" and not attrs["row"].startswith("dialog:"):
+            dialogs = compile_messages(attrs["children"])
             deploying[rule_id] = {
-                ATTRS: {
-                    REGEXP: syntax.compile_row_regexp(attrs[ROW]),
-                    TIMEOUT: attrs[PARAMS][TIMEOUT],
-                    APPLY_LOGIC: import_rulebook_function(attrs[PARAMS][APPLY_LOGIC]),
-                    APPLY_LOGIC_NAME: attrs[PARAMS][APPLY_LOGIC],
-                    DIALOGS: dialogs,
-                    IFCONTEXT: attrs[PARAMS][IFCONTEXT],
-                    SUPPRESS_ERRORS: attrs[PARAMS][SUPPRESS_ERRORS],
+                "attrs": {
+                    "regexp": syntax.compile_row_regexp(attrs["row"]),
+                    "timeout": attrs["params"]["timeout"],
+                    "apply_logic": import_rulebook_function(attrs["params"]["apply_logic"]),
+                    "apply_logic_name": attrs["params"]["apply_logic"],
+                    "dialogs": dialogs,
+                    "ifcontext": attrs["params"]["ifcontext"],
+                    "suppress_errors": attrs["params"]["suppress_errors"],
                 },
-                CHILDREN: _compile_deploying(attrs[CHILDREN], reverse_prefix),
+                "children": _compile_deploying(attrs["children"], reverse_prefix),
             }
     return deploying
 
@@ -139,8 +112,8 @@ def match_deploy_rule(rules: DeployRulebook, cmd_path: tuple[str], context: dict
         row = cmd_path[depth]
         matches = []
         for rule in rules.values():
-            regexp = rule[ATTRS][REGEXP]
-            ifcontext = rule[ATTRS][IFCONTEXT]
+            regexp = rule["attrs"]["regexp"]
+            ifcontext = rule["attrs"]["ifcontext"]
             if regexp.match(row) and syntax.match_context(ifcontext, context):
                 matches.append((rule, string_similarity(row, regexp.pattern)))
 
@@ -153,19 +126,19 @@ def match_deploy_rule(rules: DeployRulebook, cmd_path: tuple[str], context: dict
         if depth == len(cmd_path) - 1:
             return biggest_match
 
-        return _match_deploy_rule(rules=biggest_match[CHILDREN], depth=depth + 1, cmd_path=cmd_path, context=context)
+        return _match_deploy_rule(rules=biggest_match["children"], depth=depth + 1, cmd_path=cmd_path, context=context)
 
     default_match: DeployRule = {
-        ATTRS: {
-            REGEXP: syntax.compile_row_regexp("~"),
-            TIMEOUT: DEFAULT_TIMEOUT,
-            APPLY_LOGIC: import_rulebook_function(DEFAULT_APPLY_LOGIC),
-            APPLY_LOGIC_NAME: DEFAULT_APPLY_LOGIC,
-            DIALOGS: odict(),
-            IFCONTEXT: [],
-            SUPPRESS_ERRORS: False,
+        "attrs": {
+            "regexp": syntax.compile_row_regexp("~"),
+            "timeout": DEFAULT_TIMEOUT,
+            "apply_logic": import_rulebook_function(DEFAULT_APPLY_LOGIC),
+            "apply_logic_name": DEFAULT_APPLY_LOGIC,
+            "dialogs": odict(),
+            "ifcontext": [],
+            "suppress_errors": False,
         },
-        CHILDREN: odict(),
+        "children": odict(),
     }
 
     if len(cmd_path) == 0:
@@ -203,13 +176,13 @@ def merge_deploy_rulebooks(
             assert parent_data is not None
             add_parent_to_merge_rulebook(merged_rulebook, parent_data, row, parent_ifcontext)
             continue
-        elif parent_data is None or raw_param_to_bool(child_data[PARAMS].get(NOT_INHERIT)):
+        elif parent_data is None or raw_param_to_bool(child_data["params"].get("not_inherit")):
             add_child_to_merge_rulebook(merged_rulebook, child_data, row, parent_ifcontext)
             continue
-        parent_params = parent_data[PARAMS]
-        parent_rules = parent_data[RULES]
-        child_params = child_data[PARAMS]
-        child_rules = child_data[RULES]
+        parent_params = parent_data["params"]
+        parent_rules = parent_data["rules"]
+        child_params = child_data["params"]
+        child_rules = child_data["rules"]
         merged_row = get_merged_row(row, parent_params, child_params)
         merged_rule = get_merged_rule(parent_rules, child_rules, child_params, vendor, merged_row, parent_ifcontext)
         merged_rulebook[merged_row] = merged_rule
@@ -221,8 +194,8 @@ def dump_deploy_rulebook(rulebook: DeployRulebook, level: int = 0) -> DeployingT
     lines = []
     for row, rules in rulebook.items():
         lines.append(f"{'    ' * level}{row}")
-        children = rules[CHILDREN]
-        dialogs = rules[ATTRS][DIALOGS]
+        children = rules["children"]
+        dialogs = rules["attrs"]["dialogs"]
         if dialogs:
             lines.append(dump_dialogs(dialogs, level + 1))
         if children:
@@ -235,7 +208,7 @@ def dump_dialogs(dialogs: Dialogs, level: int) -> str:
     lines = []
     for message, answer in dialogs.items():
         answer_with_params = syntax.get_row_with_params(answer.text, message.raw_params, get_dialog_params_scheme())
-        lines.append(f"{'    ' * level}{DIALOG_PREFIX} {message.text} ::: {answer_with_params}")
+        lines.append(f"{'    ' * level}dialog: {message.text} ::: {answer_with_params}")
     return "\n".join(lines)
 
 
@@ -256,19 +229,19 @@ def get_merged_rule(
     parent_ifcontext: list[str],
 ) -> DeployRule:
     """Merges parent_rules and child_rules"""
-    parent_attrs = parent_rules[ATTRS]
-    parent_children = parent_rules[CHILDREN]
-    child_attrs = child_rules[ATTRS]
-    child_children = child_rules[CHILDREN]
+    parent_attrs = parent_rules["attrs"]
+    parent_children = parent_rules["children"]
+    child_attrs = child_rules["attrs"]
+    child_children = child_rules["children"]
 
     merged_attrs = get_merged_attrs(parent_attrs, child_attrs, child_params)
-    curr_ifcontext = merged_attrs[IFCONTEXT]
+    curr_ifcontext = merged_attrs["ifcontext"]
     if curr_ifcontext and parent_ifcontext:
         check_ifcontext_compatibility(curr_ifcontext, parent_ifcontext, row)
     merged_children = merge_deploy_rulebooks(
         parent_children, child_children, vendor, get_effective_ifcontext(curr_ifcontext, parent_ifcontext)
     )
-    return {ATTRS: merged_attrs, CHILDREN: merged_children}
+    return {"attrs": merged_attrs, "children": merged_children}
 
 
 def get_merged_attrs(
@@ -282,10 +255,10 @@ def get_merged_attrs(
             # A dynamic key cannot be recognized by mypy as a string literal
             merged_attrs[param] = child_attrs[param]  # type: ignore[literal-required]
 
-    if APPLY_LOGIC in child_params:
-        merged_attrs[APPLY_LOGIC_NAME] = child_attrs[APPLY_LOGIC_NAME]
+    if "apply_logic" in child_params:
+        merged_attrs["apply_logic_name"] = child_attrs["apply_logic_name"]
 
-    merged_attrs[DIALOGS] = merge_dialogs(parent_attrs[DIALOGS], child_attrs[DIALOGS])
+    merged_attrs["dialogs"] = merge_dialogs(parent_attrs["dialogs"], child_attrs["dialogs"])
 
     return merged_attrs
 
@@ -302,18 +275,18 @@ def merge_dialogs(parent_dialogs: Dialogs, child_dialogs: Dialogs) -> Dialogs:
         if child_data is None:
             # for mypy: In this situation, parent_data cannot be None.
             assert parent_data is not None
-            merged_dialogs[parent_data[MESSAGE]] = parent_data[ANSWER]
+            merged_dialogs[parent_data["message"]] = parent_data["answer"]
             continue
-        elif raw_param_to_bool(child_data[MESSAGE].raw_params.get(NOT_INHERIT)):
+        elif raw_param_to_bool(child_data["message"].raw_params.get("not_inherit")):
             continue
         elif parent_data is None:
-            merged_dialogs[child_data[MESSAGE]] = child_data[ANSWER]
+            merged_dialogs[child_data["message"]] = child_data["answer"]
             continue
         merged_message, merged_answer = get_merged_dialog(
-            parent_data[MESSAGE],
-            parent_data[ANSWER],
-            child_data[MESSAGE],
-            child_data[ANSWER],
+            parent_data["message"],
+            parent_data["answer"],
+            child_data["message"],
+            child_data["answer"],
         )
         merged_dialogs[merged_message] = merged_answer
     return merged_dialogs
@@ -329,7 +302,7 @@ def get_merged_dialog(
     merged_message = MakeMessageMatcher(parent_message.text)
     merged_message.raw_params = merged_params
 
-    if SEND_NL in child_message.raw_params:
+    if "send_nl" in child_message.raw_params:
         send_nl = child_answer.send_nl
     else:
         send_nl = parent_answer.send_nl
@@ -346,8 +319,8 @@ def get_dialog_pre_merge(dialogs: Dialogs) -> DialogPreMerge:
     pre_merge: DialogPreMerge = odict()
     for message, answer in dialogs.items():
         pre_merge[message] = {
-            MESSAGE: message,
-            ANSWER: answer,
+            "message": message,
+            "answer": answer,
         }
     return pre_merge
 
@@ -356,30 +329,30 @@ def add_parent_to_merge_rulebook(
     merged_rulebook: DeployRulebook, parent_data: DeployPreMergeData, row: Row, parent_ifcontext: list[str]
 ) -> None:
     """Add parent rule to merged_rulebook"""
-    raw_row = syntax.get_row_with_params(row, parent_data[PARAMS], get_params_scheme())
-    check_rulebook_ifcontext_compatibility(odict({raw_row: parent_data[RULES]}), parent_ifcontext)
-    merged_rulebook[raw_row] = parent_data[RULES]
+    raw_row = syntax.get_row_with_params(row, parent_data["params"], get_params_scheme())
+    check_rulebook_ifcontext_compatibility(odict({raw_row: parent_data["rules"]}), parent_ifcontext)
+    merged_rulebook[raw_row] = parent_data["rules"]
 
 
 def add_child_to_merge_rulebook(
     merged_rulebook: DeployRulebook, child_data: DeployPreMergeData, row: Row, parent_ifcontext: list[str]
 ) -> None:
     """Add child rule to merged_rulebook"""
-    not_inherit = raw_param_to_bool(child_data[PARAMS].get(NOT_INHERIT))
-    children = child_data[RULES][CHILDREN]
-    dialogs = child_data[RULES][ATTRS][DIALOGS]
+    not_inherit = raw_param_to_bool(child_data["params"].get("not_inherit"))
+    children = child_data["rules"]["children"]
+    dialogs = child_data["rules"]["attrs"]["dialogs"]
     if not_inherit and not children and not dialogs:
         return None
 
     if children:
-        child_data[RULES][CHILDREN] = _apply_not_inherit_to_child_rules(children)
+        child_data["rules"]["children"] = _apply_not_inherit_to_child_rules(children)
 
     if dialogs:
-        child_data[RULES][ATTRS][DIALOGS] = _apply_not_inherit_to_dialogs(dialogs)
+        child_data["rules"]["attrs"]["dialogs"] = _apply_not_inherit_to_dialogs(dialogs)
 
-    row_with_params = syntax.get_row_with_params(row, child_data[PARAMS], get_params_scheme())
-    check_rulebook_ifcontext_compatibility(odict({row_with_params: child_data[RULES]}), parent_ifcontext)
-    merged_rulebook[row_with_params] = child_data[RULES]
+    row_with_params = syntax.get_row_with_params(row, child_data["params"], get_params_scheme())
+    check_rulebook_ifcontext_compatibility(odict({row_with_params: child_data["rules"]}), parent_ifcontext)
+    merged_rulebook[row_with_params] = child_data["rules"]
 
 
 def _apply_not_inherit_to_child_rules(rulebook: DeployRulebook) -> DeployRulebook:
@@ -387,13 +360,13 @@ def _apply_not_inherit_to_child_rules(rulebook: DeployRulebook) -> DeployRuleboo
     applied_rulebook = odict()
     for raw_row, rules in rulebook.items():
         row, raw_params = syntax.get_row_and_raw_params(raw_row)
-        not_inherit = raw_param_to_bool(raw_params.get(NOT_INHERIT))
-        if not_inherit and not rules[CHILDREN] and not rules[ATTRS][DIALOGS]:
+        not_inherit = raw_param_to_bool(raw_params.get("not_inherit"))
+        if not_inherit and not rules["children"] and not rules["attrs"]["dialogs"]:
             continue
-        if rules[CHILDREN]:
-            rules[CHILDREN] = _apply_not_inherit_to_child_rules(rules[CHILDREN])
-        if rules[ATTRS][DIALOGS]:
-            rules[ATTRS][DIALOGS] = _apply_not_inherit_to_dialogs(rules[ATTRS][DIALOGS])
+        if rules["children"]:
+            rules["children"] = _apply_not_inherit_to_child_rules(rules["children"])
+        if rules["attrs"]["dialogs"]:
+            rules["attrs"]["dialogs"] = _apply_not_inherit_to_dialogs(rules["attrs"]["dialogs"])
         raw_row = syntax.get_row_with_params(row, raw_params, get_params_scheme())
 
         applied_rulebook[raw_row] = rules
@@ -405,7 +378,7 @@ def _apply_not_inherit_to_dialogs(dialogs: Dialogs) -> Dialogs:
     """Applies the logic of the %not_inherit param to all dialogs"""
     applied_dialogs = odict()
     for message, answer in dialogs.items():
-        if raw_param_to_bool(message.raw_params.get(NOT_INHERIT)):
+        if raw_param_to_bool(message.raw_params.get("not_inherit")):
             continue
         applied_dialogs[message] = answer
     return applied_dialogs
@@ -414,11 +387,11 @@ def _apply_not_inherit_to_dialogs(dialogs: Dialogs) -> Dialogs:
 def check_rulebook_ifcontext_compatibility(rulebook: DeployRulebook, parent_ifcontext: list[str]) -> None:
     """Checks compatibility of rulebook ifcontext"""
     for row, rules in rulebook.items():
-        curr_ifcontext = rules[ATTRS][IFCONTEXT]
+        curr_ifcontext = rules["attrs"]["ifcontext"]
         if curr_ifcontext and parent_ifcontext:
             check_ifcontext_compatibility(curr_ifcontext, parent_ifcontext, row)
         check_rulebook_ifcontext_compatibility(
-            rules[CHILDREN], get_effective_ifcontext(curr_ifcontext, parent_ifcontext)
+            rules["children"], get_effective_ifcontext(curr_ifcontext, parent_ifcontext)
         )
 
 
@@ -441,12 +414,12 @@ def _get_rule_pre_merge(rulebook: DeployRulebook) -> DeployPreMerge:
     pre_merge: DeployPreMerge = odict()
     for raw_row, rules in rulebook.items():
         row, raw_params = syntax.get_row_and_raw_params(raw_row)
-        raw_params.pop(IFCONTEXT, None)
-        raw_ifcontext_value = ",".join(rules[ATTRS][IFCONTEXT])
+        raw_params.pop("ifcontext", None)
+        raw_ifcontext_value = ",".join(rules["attrs"]["ifcontext"])
         if raw_ifcontext_value:
-            row = f"{row} %{IFCONTEXT}={raw_ifcontext_value}"
+            row = f"{row} %ifcontext={raw_ifcontext_value}"
         pre_merge[row] = {
-            RULES: rules,
-            PARAMS: raw_params,
+            "rules": rules,
+            "params": raw_params,
         }
     return pre_merge

--- a/annet/rulebook/patching.py
+++ b/annet/rulebook/patching.py
@@ -2,7 +2,7 @@ import functools
 import re
 import warnings
 from collections import OrderedDict as odict
-from typing import Any, Generator, Literal, cast
+from typing import Any, Generator, cast
 
 from valkit.common import valid_bool, valid_string_list
 from valkit.python import valid_object_path
@@ -42,80 +42,51 @@ REWRITE_PATCH_LOGIC = "annet.rulebook.common.rewrite"
 REWRITE_DIFF_LOGIC = "annet.rulebook.common.rewrite_diff"
 MULTILINE_DIFF_LOGIC = "annet.rulebook.common.multiline_diff"
 
-# ===SCOPE===
-SCOPE: Literal["scope"] = "scope"
-LOCAL: Literal["local"] = "local"
-GLOBAL: Literal["global"] = "global"
-
-# ===PARAMS===
-PARAMS: Literal["params"] = "params"
-LOGIC: Literal["logic"] = "logic"
-DIFF_LOGIC: Literal["diff_logic"] = "diff_logic"
-COMMENT: Literal["comment"] = "comment"
-MULTILINE: Literal["multiline"] = "multiline"
-ORDERED: Literal["ordered"] = "ordered"
-CONTEXT: Literal["context"] = "context"
-REWRITE: Literal["rewrite"] = "rewrite"
-PARENT: Literal["parent"] = "parent"
-FORCE_COMMIT: Literal["force_commit"] = "force_commit"
-IGNORE_CASE: Literal["ignore_case"] = "ignore_case"
-ROW: Literal["row"] = "row"
-NOT_INHERIT: Literal["not_inherit"] = "not_inherit"
-
-# ===RULE===
-RULES: Literal["rules"] = "rules"
-RULE: Literal["rule"] = "rule"
-TYPE: Literal["type"] = "type"
-NORMAL: Literal["normal"] = "normal"
-IGNORE: Literal["ignore"] = "ignore"
-ATTRS: Literal["attrs"] = "attrs"
-CHILDREN: Literal["children"] = "children"
-
 
 def get_params_scheme(vendor: str) -> ParamsScheme:
     """Returning the params scheme"""
     return {
-        GLOBAL: {
+        "global": {
             "validator": valid_bool,
             "default": False,
         },
-        LOGIC: {
+        "logic": {
             "validator": valid_object_path,
             "default": DEFAULT_PATCH_LOGIC,
         },
-        DIFF_LOGIC: {
+        "diff_logic": {
             "validator": valid_object_path,
             "default": registry_connector.get()[vendor].diff(False),
         },
-        COMMENT: {
+        "comment": {
             "validator": valid_string_list,
             "default": [],
         },
-        MULTILINE: {
+        "multiline": {
             "validator": valid_bool,
             "default": False,
         },
-        ORDERED: {
+        "ordered": {
             "validator": valid_bool,
             "default": False,
         },
-        CONTEXT: {
+        "context": {
             "validator": str,
             "default": None,
         },
-        REWRITE: {
+        "rewrite": {
             "validator": valid_bool,
             "default": False,
         },
-        PARENT: {
+        "parent": {
             "validator": valid_bool,
             "default": False,
         },
-        FORCE_COMMIT: {
+        "force_commit": {
             "validator": valid_bool,
             "default": False,
         },
-        IGNORE_CASE: {
+        "ignore_case": {
             "validator": valid_bool,
             "default": False,
         },
@@ -140,52 +111,52 @@ def _compile_patching(tree: dict[str, Any], reverse_prefix: str, vendor: str) ->
     for raw_rule, attrs in tree.items():
         regexp = _attrs_to_regexp(attrs)
         attrs = _regexp_to_attrs(regexp, attrs)
-        if attrs[TYPE] == IGNORE:
+        if attrs["type"] == "ignore":
             rule = PatchRule(
-                type=attrs[TYPE],
-                rule=attrs[ROW],
+                type=attrs["type"],
+                rule=attrs["row"],
                 attrs=PatchIgnoreRuleAttrs(
                     regexp=regexp,
-                    diff_logic=import_rulebook_function(attrs[PARAMS][DIFF_LOGIC]),
-                    parent=bool(attrs[CHILDREN]),
-                    context=attrs[CONTEXT],
+                    diff_logic=import_rulebook_function(attrs["params"]["diff_logic"]),
+                    parent=bool(attrs["children"]),
+                    context=attrs["context"],
                 ),
                 children=_create_empty_rulebook(),
             )
         else:
-            _validate_params_compatibility(attrs[PARAMS], raw_rule, vendor)
+            _validate_params_compatibility(attrs["params"], raw_rule, vendor)
 
-            if attrs[PARAMS][ORDERED]:
-                attrs[PARAMS][DIFF_LOGIC] = registry_connector.get()[vendor].diff(True)
-                attrs[PARAMS][LOGIC] = ORDERED_PATCH_LOGIC
-            elif attrs[PARAMS][REWRITE]:
-                attrs[PARAMS][DIFF_LOGIC] = REWRITE_DIFF_LOGIC
-                attrs[PARAMS][LOGIC] = REWRITE_PATCH_LOGIC
-            elif attrs[PARAMS][MULTILINE]:
-                attrs[PARAMS][DIFF_LOGIC] = MULTILINE_DIFF_LOGIC
+            if attrs["params"]["ordered"]:
+                attrs["params"]["diff_logic"] = registry_connector.get()[vendor].diff(True)
+                attrs["params"]["logic"] = ORDERED_PATCH_LOGIC
+            elif attrs["params"]["rewrite"]:
+                attrs["params"]["diff_logic"] = REWRITE_DIFF_LOGIC
+                attrs["params"]["logic"] = REWRITE_PATCH_LOGIC
+            elif attrs["params"]["multiline"]:
+                attrs["params"]["diff_logic"] = MULTILINE_DIFF_LOGIC
             rule = PatchRule(
-                type=attrs[TYPE],
-                rule=attrs[ROW],
+                type=attrs["type"],
+                rule=attrs["row"],
                 attrs=PatchNormalRuleAttrs(
                     **{
-                        "logic": import_rulebook_function(attrs[PARAMS][LOGIC]),
-                        "diff_logic": import_rulebook_function(attrs[PARAMS][DIFF_LOGIC]),
+                        "logic": import_rulebook_function(attrs["params"]["logic"]),
+                        "diff_logic": import_rulebook_function(attrs["params"]["diff_logic"]),
                         "regexp": regexp,
-                        "reverse": _make_reverse(attrs[ROW], reverse_prefix, flags=regexp.flags),
-                        "comment": attrs[PARAMS][COMMENT],
-                        "multiline": attrs[PARAMS][MULTILINE],
-                        "parent": attrs[PARAMS][PARENT] or bool(attrs[CHILDREN]),
-                        "force_commit": attrs[PARAMS][FORCE_COMMIT],
-                        "ignore_case": attrs[PARAMS][IGNORE_CASE],
-                        "ordered": attrs[PARAMS][ORDERED],
-                        "context": attrs[CONTEXT],
+                        "reverse": _make_reverse(attrs["row"], reverse_prefix, flags=regexp.flags),
+                        "comment": attrs["params"]["comment"],
+                        "multiline": attrs["params"]["multiline"],
+                        "parent": attrs["params"]["parent"] or bool(attrs["children"]),
+                        "force_commit": attrs["params"]["force_commit"],
+                        "ignore_case": attrs["params"]["ignore_case"],
+                        "ordered": attrs["params"]["ordered"],
+                        "context": attrs["context"],
                     }
                 ),
                 children=None,
             )
-            if not attrs[PARAMS][GLOBAL]:
-                rule[CHILDREN] = _compile_patching(attrs[CHILDREN], reverse_prefix, vendor)
-        rules[GLOBAL if attrs[PARAMS][GLOBAL] else LOCAL][raw_rule] = rule
+            if not attrs["params"]["global"]:
+                rule["children"] = _compile_patching(attrs["children"], reverse_prefix, vendor)
+        rules["global" if attrs["params"]["global"] else "local"][raw_rule] = rule
     return rules
 
 
@@ -215,14 +186,14 @@ def _make_reverse(row: str, reverse_prefix: str, flags: int = 0) -> str:
 
 def _attrs_to_regexp(attrs: dict[str, Any]) -> re.Pattern[str]:
     flags = 0
-    ignore_case = attrs[PARAMS][IGNORE_CASE]
+    ignore_case = attrs["params"]["ignore_case"]
     if ignore_case:
         flags |= re.IGNORECASE
-    return syntax.compile_row_regexp(attrs[ROW], flags=flags)
+    return syntax.compile_row_regexp(attrs["row"], flags=flags)
 
 
 def _regexp_to_attrs(regexp: re.Pattern[str], attrs: dict[str, Any]) -> dict[str, Any]:
-    attrs[PARAMS][IGNORE_CASE] = bool(regexp.flags & re.IGNORECASE)
+    attrs["params"]["ignore_case"] = bool(regexp.flags & re.IGNORECASE)
     return attrs
 
 
@@ -241,7 +212,7 @@ def merge_patch_rulebooks(parent_rulebook: PatchRulebook, child_rulebook: PatchR
             # for mypy (In this case, parent_data cannot be None)
             assert parent_data is not None
             _add_parent_to_merge_rulebook(merged_rulebook, parent_data, row, vendor)
-        elif raw_param_to_bool(child_data[PARAMS].get(NOT_INHERIT)) or parent_data is None:
+        elif raw_param_to_bool(child_data["params"].get("not_inherit")) or parent_data is None:
             _add_child_to_merge_rulebook(merged_rulebook, child_data, row, vendor)
 
         else:
@@ -264,10 +235,10 @@ def merge_patch_rulebooks(parent_rulebook: PatchRulebook, child_rulebook: PatchR
 def dump_patch_rulebook(rulebook: PatchRulebook, level: int = 0) -> PatchingText:
     """Parses the rulebook into a text format"""
     lines = []
-    for scope in [rulebook[LOCAL], rulebook[GLOBAL]]:
+    for scope in [rulebook["local"], rulebook["global"]]:
         for row, data in scope.items():
             lines.append(f"{'    ' * level}{row}")
-            children = data.get(CHILDREN)
+            children = data.get("children")
             if children is not None and not _is_empty_rulebook(children):
                 children_lines = dump_patch_rulebook(children, level + 1)
                 if children_lines:
@@ -279,56 +250,56 @@ def _add_child_to_merge_rulebook(
     merged_rulebook: PatchRulebook, child_data: PatchPreMergeData, row: Row, vendor: str
 ) -> None:
     """Add child rule to merged_rulebook"""
-    if raw_param_to_bool(child_data[PARAMS].get(NOT_INHERIT)):
-        if GLOBAL in child_data[PARAMS]:
+    if raw_param_to_bool(child_data["params"].get("not_inherit")):
+        if "global" in child_data["params"]:
             raise RulebookSyntaxError(r"Usage of %not_inherit param together with %global param is not allowed.")
-        elif _is_empty_rulebook(child_data[RULES][CHILDREN]):
+        elif _is_empty_rulebook(child_data["rules"]["children"]):
             return None
 
-    if not _is_empty_rulebook(child_data[RULES][CHILDREN]):
-        child_data[RULES][CHILDREN] = _apply_not_inherit_to_child_rules(
-            cast(PatchRulebook, child_data[RULES][CHILDREN]),
+    if not _is_empty_rulebook(child_data["rules"]["children"]):
+        child_data["rules"]["children"] = _apply_not_inherit_to_child_rules(
+            cast(PatchRulebook, child_data["rules"]["children"]),
             vendor,
         )
 
-    row_with_params = syntax.get_row_with_params(row, child_data[PARAMS], get_params_scheme(vendor))
+    row_with_params = syntax.get_row_with_params(row, child_data["params"], get_params_scheme(vendor))
 
-    if child_data[RULES][TYPE] != IGNORE:
-        child_data[RULES][ATTRS][PARENT] = not _is_empty_rulebook(child_data[RULES][CHILDREN])
+    if child_data["rules"]["type"] != "ignore":
+        child_data["rules"]["attrs"]["parent"] = not _is_empty_rulebook(child_data["rules"]["children"])
 
-    merged_rulebook[child_data[SCOPE]][row_with_params] = child_data[RULES]
+    merged_rulebook[child_data["scope"]][row_with_params] = child_data["rules"]
 
 
 def _apply_not_inherit_to_child_rules(child_rulebook: PatchRulebook, vendor: str) -> PatchRulebook:
     """Applies the logic of the %not_inherit param to all rules in the child_rulebook"""
     applied_rulebook = _create_empty_rulebook()
-    for scope in (LOCAL, GLOBAL):
+    for scope in ("local", "global"):
         for raw_row, rules in child_rulebook[scope].items():
             row, raw_params = syntax.get_row_and_raw_params(raw_row)
 
-            if raw_param_to_bool(raw_params.get(NOT_INHERIT)):
-                if GLOBAL in raw_params:
+            if raw_param_to_bool(raw_params.get("not_inherit")):
+                if "global" in raw_params:
                     raise RulebookSyntaxError(
                         r"Usage of %not_inherit param together with %global param is not allowed."
                     )
-                if _is_empty_rulebook(rules[CHILDREN]):
+                if _is_empty_rulebook(rules["children"]):
                     continue
-                del raw_params[NOT_INHERIT]
+                del raw_params["not_inherit"]
 
             raw_row = syntax.get_row_with_params(row, raw_params, get_params_scheme(vendor))
 
-            # RULE holds the bare command, the way _compile_patching fills it from
-            # attrs[ROW]: without params, and without the leading "!" of an ignore rule.
-            rules[RULE] = row[1:].strip() if rules[TYPE] == IGNORE else row
+            # "rule" holds the bare command, the way _compile_patching fills it from
+            # attrs["row"]: without params, and without the leading "!" of an ignore rule.
+            rules["rule"] = row[1:].strip() if rules["type"] == "ignore" else row
 
-            if not _is_empty_rulebook(rules[CHILDREN]):
-                rules[CHILDREN] = _apply_not_inherit_to_child_rules(
-                    cast(PatchRulebook, rules[CHILDREN]),
+            if not _is_empty_rulebook(rules["children"]):
+                rules["children"] = _apply_not_inherit_to_child_rules(
+                    cast(PatchRulebook, rules["children"]),
                     vendor,
                 )
 
-            if rules[TYPE] != IGNORE:
-                rules[ATTRS][PARENT] = not _is_empty_rulebook(rules[CHILDREN])
+            if rules["type"] != "ignore":
+                rules["attrs"]["parent"] = not _is_empty_rulebook(rules["children"])
 
             applied_rulebook[scope][raw_row] = rules
 
@@ -339,20 +310,20 @@ def _add_parent_to_merge_rulebook(
     merged_rulebook: PatchRulebook, parent_data: PatchPreMergeData, row: Row, vendor: str
 ) -> None:
     """Add parent rule to merged_rulebook"""
-    row_with_params = syntax.get_row_with_params(row, parent_data[PARAMS], get_params_scheme(vendor))
-    merged_rulebook[parent_data[SCOPE]][row_with_params] = parent_data[RULES]
+    row_with_params = syntax.get_row_with_params(row, parent_data["params"], get_params_scheme(vendor))
+    merged_rulebook[parent_data["scope"]][row_with_params] = parent_data["rules"]
 
 
 def _create_empty_rulebook() -> PatchRulebook:
     """Create empty patch rulebook"""
-    return {LOCAL: odict(), GLOBAL: odict()}
+    return {"local": odict(), "global": odict()}
 
 
 def _is_empty_rulebook(rulebook: PatchRulebook | None) -> bool:
     """Validate patch rulebook is empty"""
     if rulebook is None:
         return True
-    return not rulebook[LOCAL] and not rulebook[GLOBAL]
+    return not rulebook["local"] and not rulebook["global"]
 
 
 def _ensure_rulebook(rulebook: PatchRulebook | None = None) -> PatchRulebook:
@@ -367,7 +338,7 @@ def _ensure_rulebook(rulebook: PatchRulebook | None = None) -> PatchRulebook:
 def _get_pre_merge(rulebook: PatchRulebook) -> PatchPreMerge:
     """Created pre_merge object for merge rulebook"""
     pre_merge = {}
-    for scope in (LOCAL, GLOBAL):
+    for scope in ("local", "global"):
         for raw_row, rules in rulebook[scope].items():
             row, params = syntax.get_row_and_raw_params(raw_row)
             pre_merge[row] = PatchPreMergeData(
@@ -402,47 +373,47 @@ def _get_merged_row(parent_params: RawParams, child_params: RawParams, row: Row,
 
 def _get_merged_scope(parent_scope: PatchScope, child_scope: PatchScope, child_params: RawParams) -> PatchScope:
     """Merges parent_scope and child_scope"""
-    return parent_scope if child_params.get(GLOBAL) is None else child_scope
+    return parent_scope if child_params.get("global") is None else child_scope
 
 
 def _get_merged_rule(
     parent_rules: PatchRule, child_rules: PatchRule, child_params: RawParams, scope: PatchScope, row: Row, vendor: str
 ) -> PatchRule:
     """Merges parent_rules and child_rules"""
-    merged_type = child_rules[TYPE]
-    merged_rule = child_rules[RULE]
+    merged_type = child_rules["type"]
+    merged_rule = child_rules["rule"]
 
-    if scope == GLOBAL:
+    if scope == "global":
         merged_children = None
-        if not _is_empty_rulebook(child_rules[CHILDREN]) or not _is_empty_rulebook(parent_rules[CHILDREN]):
+        if not _is_empty_rulebook(child_rules["children"]) or not _is_empty_rulebook(parent_rules["children"]):
             warnings.warn(f"Global rule '{row}' has child rules - ignoring child rules.")
     else:
-        parent_children = parent_rules[CHILDREN]
-        child_children = child_rules[CHILDREN]
+        parent_children = parent_rules["children"]
+        child_children = child_rules["children"]
         merged_children = merge_patch_rulebooks(
             _ensure_rulebook(parent_children), _ensure_rulebook(child_children), vendor
         )
 
     merged_attrs = _merge_attrs(
-        parent_rules[ATTRS],
-        child_rules[ATTRS],
+        parent_rules["attrs"],
+        child_rules["attrs"],
         child_params,
         row,
         merged_type,
     )
-    if (parent_rules[ATTRS][PARENT] or child_rules[ATTRS][PARENT]) and merged_type == IGNORE:
-        merged_attrs[PARENT] = True
-    elif not _is_empty_rulebook(merged_children) and scope == LOCAL:
-        merged_attrs[PARENT] = True
+    if (parent_rules["attrs"]["parent"] or child_rules["attrs"]["parent"]) and merged_type == "ignore":
+        merged_attrs["parent"] = True
+    elif not _is_empty_rulebook(merged_children) and scope == "local":
+        merged_attrs["parent"] = True
     else:
-        merged_attrs[PARENT] = False
+        merged_attrs["parent"] = False
 
     return PatchRule(
         **{
-            TYPE: merged_type,
-            RULE: merged_rule,
-            CHILDREN: merged_children,
-            ATTRS: merged_attrs,
+            "type": merged_type,
+            "rule": merged_rule,
+            "children": merged_children,
+            "attrs": merged_attrs,
         }
     )
 
@@ -460,32 +431,32 @@ def _merge_attrs(
             # A dynamic key cannot be recognized by mypy as a string literal
             merged_attrs[param] = child_attrs[param]  # type: ignore[literal-required]
 
-    if rule_type == IGNORE:
+    if rule_type == "ignore":
         return merged_attrs
 
     # After the checks above, merged_attrs, child_attrs, and parent_attrs
     # are guaranteed to be of type PatchNormalRuleAttrs
-    if ORDERED in child_params:
-        merged_attrs[LOGIC] = child_attrs[LOGIC]  # type: ignore[typeddict-item]
-        merged_attrs[DIFF_LOGIC] = child_attrs[DIFF_LOGIC]
-    elif REWRITE in child_params:
-        merged_attrs[LOGIC] = child_attrs[LOGIC]  # type: ignore[typeddict-item]
-        merged_attrs[DIFF_LOGIC] = child_attrs[DIFF_LOGIC]
-    elif MULTILINE in child_params:
-        merged_attrs[DIFF_LOGIC] = child_attrs[DIFF_LOGIC]
+    if "ordered" in child_params:
+        merged_attrs["logic"] = child_attrs["logic"]  # type: ignore[typeddict-item]
+        merged_attrs["diff_logic"] = child_attrs["diff_logic"]
+    elif "rewrite" in child_params:
+        merged_attrs["logic"] = child_attrs["logic"]  # type: ignore[typeddict-item]
+        merged_attrs["diff_logic"] = child_attrs["diff_logic"]
+    elif "multiline" in child_params:
+        merged_attrs["diff_logic"] = child_attrs["diff_logic"]
 
     return merged_attrs
 
 
 def _validate_params_compatibility(params: Params, row: str, vendor: str) -> None:
     """Checks compatibility of ordered/rewrite/multiline params with logic/diff_logic params at compile time"""
-    used_default_logic_path = params[LOGIC] == DEFAULT_PATCH_LOGIC
-    used_default_diff_logic_path = params[DIFF_LOGIC] == registry_connector.get()[vendor].diff(False)
+    used_default_logic_path = params["logic"] == DEFAULT_PATCH_LOGIC
+    used_default_diff_logic_path = params["diff_logic"] == registry_connector.get()[vendor].diff(False)
 
     conflicts = [
-        (ORDERED, (used_default_logic_path, used_default_diff_logic_path), (LOGIC, DIFF_LOGIC)),
-        (REWRITE, (used_default_logic_path, used_default_diff_logic_path), (LOGIC, DIFF_LOGIC)),
-        (MULTILINE, (used_default_diff_logic_path,), (DIFF_LOGIC,)),
+        ("ordered", (used_default_logic_path, used_default_diff_logic_path), ("logic", "diff_logic")),
+        ("rewrite", (used_default_logic_path, used_default_diff_logic_path), ("logic", "diff_logic")),
+        ("multiline", (used_default_diff_logic_path,), ("diff_logic",)),
     ]
     for param, checks, conflicting_params in conflicts:
         if params[param] and not all(checks):
@@ -498,9 +469,9 @@ def _validate_params_compatibility(params: Params, row: str, vendor: str) -> Non
 def _validate_merged_params_compatibility(params: RawParams, row: str) -> None:
     """Checks compatibility of ordered/rewrite/multiline params with logic/diff_logic params at merge time"""
     conflicts = [
-        (ORDERED, (LOGIC, DIFF_LOGIC)),
-        (REWRITE, (LOGIC, DIFF_LOGIC)),
-        (MULTILINE, (DIFF_LOGIC,)),
+        ("ordered", ("logic", "diff_logic")),
+        ("rewrite", ("logic", "diff_logic")),
+        ("multiline", ("diff_logic",)),
     ]
     for param, conflicting_params in conflicts:
         if param not in params:


### PR DESCRIPTION
The rulebook modules declared 68 constants of the form NAME: Literal["value"] = "value" and used them as dict keys. They were needed because a plain module-level NAME = "value" infers as str, and mypy rejects a str key on a TypedDict - but a bare string literal in the subscript works just as well, and the TypedDict itself already rejects an unknown key. Inline them at all 427 sites and drop the definitions, along with the now-empty section headers and the unused Literal imports.

mypy keeps the literal types through the awkward spots: the conditional subscript rules["global" if ... else "local"], the tuple loop for scope in ("local", "global"), and the TypedDict(**{...}) calls.

The keys that index the untyped parse tree and params dicts, such as attrs["params"]["diff_logic"] and the get_params_scheme() keys, are no longer coupled to their readers by a shared name - nothing checked them before either, since both sides are dict[str, Any]. Typing the parse tree would make them checkable for real.

No behaviour change. One f-string in _get_child_groups interpolated data[RULES][ATTRS][SPLIT], which is the child_split local computed three lines above, and now says so.