### PR TITLE
feat(rulebooks): add new rules, dialogs and ordering

### DIFF
--- a/annet/rulebook/juniper/misc.py
+++ b/annet/rulebook/juniper/misc.py
@@ -1,0 +1,71 @@
+from collections import OrderedDict
+from typing import Any
+
+from annet.annlib.types import OpType
+from annet.rulebook.juniper import default_diff
+
+
+def level2_interface_diff(
+    old: OrderedDict[str, Any],
+    new: OrderedDict[str, Any],
+    diff_pre: OrderedDict[str, Any],
+    _pops: tuple[OpType, ...],
+) -> Any:
+    """
+    Блок:
+        protocols
+            isis
+                interface ae0.0
+                    level 2
+                        metric 20
+                        post-convergence-lfa
+    ```
+    Но коробка может отдать `level 2 metric 20`, если терм один
+    При расчете дифа если видим, что начинается с level 2, руками level 2 превращаем в блок
+    """
+
+    updated_old: OrderedDict[str, Any] = OrderedDict()
+    for k, v in old.items():
+        items = list(map(str.strip, k.split(" ")))
+
+        if len(items) > 2 and items[0] == "level" and items[1] == "2":
+            if "level 2" in diff_pre and "subtree" in diff_pre["level 2"] and k in diff_pre:
+                key = " ".join(items[2:])
+                updated_old.setdefault("level 2", OrderedDict())[key] = OrderedDict()
+                diff_pre["level 2"]["subtree"][key] = diff_pre[k]
+                diff_pre["level 2"]["subtree"][key]["match"]["attrs"]["reverse"] = f"delete {key}"
+            else:
+                return default_diff(old, new, diff_pre, _pops)
+        else:
+            updated_old[k] = v
+
+    return default_diff(updated_old, new, diff_pre, _pops)
+
+
+def syslog_archive_diff(
+    old: OrderedDict[str, Any],
+    new: OrderedDict[str, Any],
+    diff_pre: OrderedDict[str, Any],
+    _pops: tuple[OpType, ...],
+) -> Any:
+    """
+    Блок:
+    ```
+    archive
+        size 10m
+        files 10
+        world-readable
+    ```
+    Но коробка может отдать `archive size 10m files 10 world-readable`
+    При расчете дифа если видим, что слева archive в одну строку, а справа нет, то справа схлопываем блок
+    """
+
+    for k, v in old.items():
+        if k.startswith("archive") and not v and "archive" in new and new["archive"]:
+            items = new.pop("archive")
+            key = " ".join(["archive", *items.keys()])
+
+            new[key] = OrderedDict()
+            diff_pre[key] = diff_pre.pop("archive")
+
+    return default_diff(old, new, diff_pre, _pops)

--- a/annet/rulebook/texts/aruba.rul
+++ b/annet/rulebook/texts/aruba.rul
@@ -51,8 +51,11 @@ arm
     g-channels
     min-tx-power
     max-tx-power
+    160mhz-support
     free-channel-index
     band-steering-mode
+    backoff-time
+    air-time-fairness-mode
 
 rf dot11g-radio-profile
     max-distance
@@ -67,6 +70,16 @@ rf dot11a-radio-profile
     min-tx-power
     free-channel-index
     interference-immunity
+
+ip dhcp pool$
+    dhcp-relay$
+    dhcp-server
+    dns-cache$
+    dns-server
+    domain-name
+    lease-time
+    subnet
+    subnet-mask
 
 wlan access-rule ~
     rule ~          %ordered
@@ -89,9 +102,13 @@ rf-band
 name
 virtual-controller-ip
 
+virtual-controller-country
+
 wlan tacacs-server tacacs
     key
     timeout
+
+ble-configure %ignore_case
 
 no ~ %global
 ~ %global

--- a/annet/rulebook/texts/cisco.deploy
+++ b/annet/rulebook/texts/cisco.deploy
@@ -20,8 +20,16 @@
 crypto key generate rsa %timeout=60
     dialog: Do you really want to replace them? [yes/no]: ::: no
     dialog: How many bits in the modulus [512]: ::: 2048
+
+no username ~
+    dialog: This operation will remove all username related configurations with same name.Do you want to continue? [confirm] ::: Y
 no username * privilege * secret * *
     dialog: This operation will remove all username related configurations with same name.Do you want to continue? [confirm] ::: Y  %send_nl=0
 
 copy running-config startup-config
     dialog: Destination filename [startup-config]? ::: startup-config
+
+interface */\w*Ethernet[0-9\/]+$/
+    spanning-tree portfast %suppress_errors
+
+no snmp-server sysobjectid type stack-oid %suppress_errors

--- a/annet/rulebook/texts/cisco.order
+++ b/annet/rulebook/texts/cisco.order
@@ -3,6 +3,8 @@
 # - Если команда начинается с undo и прописан параметр %order_reverse - команда считается
 #   обратной, но занимает место между прямыми там, где указано.
 
+
+logging console
 banner login %order_reverse
 
 # Фичи должны быть включены прежде всего
@@ -10,10 +12,48 @@ feature
 # За ним сервисы
 service
 
+lldp run
+
+setup express
+
+# Генерим ключи до проливки aaa, а для этого нужны domain-name и hostname
+
+hostname *
+
+ip domain-name *
+
+crypto key generate ~ %order_reverse
+
+clock ~
+
+archive
+
+dot1x system-auth-control
+
+errdisable ~
+
+mac ~
+
+vtp ~
+
+mls ~
+
+port-channel ~
+
+ip ~
+
+logging ~
+
+snmp-server ~
+
 aaa new-model
 aaa ~
 
+enable ~
+
 no password strength-check
+
+parser view
 username
 tacacs-server
 
@@ -46,6 +86,8 @@ ntp commit
 vlan
 vlan group
 
+mac access-list ~
+
 spanning-tree
 
 # перед тем, как менять mtu на интерфейсах, надо выставить максимальный
@@ -60,20 +102,37 @@ ipv6 dhcp relay
 
 vrf context
 
+dot11 ssid *
+    vlan
+    authentication
+    mbssid guest-mode
+    wpa-psk
+
 interface */Vlan\d+/
 interface *
     no switchport
     encapsulation
+    vrf member
     ip vrf forwarding
     vrf forwarding
     ip
     ipv6
     no ipv6 nd %order_reverse
     ipv6 nd
+    bridge-group
+    no bridge-group * source-learning %order_reverse
+    no bridge-group * unicast-flooding %order_reverse
+    encryption
+    mbssid
+    ssid
     ~
     channel-group
 
 interface */\S+\.\d+/
+
+# удалять eth-trunk можно только после того, как вычистим member interfaces
+
+no dot11 ssid %order_reverse
 
 # удалять eth-trunk можно только после того, как вычистим member interfaces
 undo interface */port-channel\d+/  %order_reverse
@@ -84,3 +143,7 @@ router bgp
     neighbor */[\da-f\.\:]+/ peer-group
 
 line
+
+ip igmp snooping
+
+ip igmp snooping vlan

--- a/annet/rulebook/texts/cisco.rul
+++ b/annet/rulebook/texts/cisco.rul
@@ -23,6 +23,13 @@ vrf context *
 
 vlan group * vlan-list %logic=annet.rulebook.cisco.vlandb.simple
 vlan */[^\d].*/
+
+ipv6 route ~                 %ignore_case
+
+spanning-tree vlan 1-4094 priority \d+
+
+mac access-list *
+
 vlan %logic=annet.rulebook.cisco.vlandb.simple
     name
 
@@ -102,6 +109,15 @@ route-policy *
     ~              %rewrite %global
 
 %endif
+
+wlccp wds priority ~ %logic=annet.rulebook.common.ignore_changes
+
+interface */Dot11Radio[0-9]/
+    speed
+    power local
+
+dot11 ssid *
+    wpa-psk
 
 line ~
     exec-timeout

--- a/annet/rulebook/texts/huawei.deploy
+++ b/annet/rulebook/texts/huawei.deploy
@@ -19,8 +19,12 @@
 
 undo bgp
     dialog: Warning: The BGP process will be deleted. Continue? [Y/N]: ::: Y
+    dialog: Warning: All BGP configurations will be deleted. Continue? [Y/N]: ::: Y
 undo peer *
     dialog: Warning: All the configurations related to the BGP peer will be deleted. Continue? [Y/N]: ::: Y
+    dialog: Warning: This operation will reset the peer session. Continue? [Y/N]: ::: Y
+
+undo peer * group *
     dialog: Warning: This operation will reset the peer session. Continue? [Y/N]: ::: Y
 peer * enable
     dialog: Warning: This operation will reset the peer session. Continue? [Y/N]: ::: Y
@@ -28,8 +32,38 @@ peer * timer
     dialog: Warning: Changing the parameter in this command resets the peer session. Continue? [Y/N]: ::: Y
 undo route-distinguisher *
     dialog: Warning: RTs of VPN instance and IPv6 related configurations under BGP will be deleted. Continue? [Y/N]: ::: Y
+    dialog: Warning: All the VPN targets in the VPN instance IPv4 address family will be deleted. Continue? [Y/N]: ::: Y
     dialog: Warning: All the VPN targets in the VPN instance IPv6 address family will be deleted. Continue? [Y/N]: ::: Y
     dialog: Warning: All VPN targets of this EVPN instance and all EVPN address family-related configurations under BGP will be deleted. Continue? [Y/N]: ::: Y
+
+commit %timeout=180
+
+peer *
+    # TODO: replace with more specific question
+    dialog: [Y/N] ::: Y
+    dialog: [y/n] ::: Y
+    dialog: [Yes/All/No/Cancel] ::: Y
+
+peer * group *
+    dialog: Warning: Changing the parameter in this command will reset the peer session which is not configured with graceful-restart. Continue? [Y/N]: ::: Y
+
+undo peer * graceful-restart timer restart *
+    dialog: Warning: Changing the parameter in this command will reset the peer session which is configured with graceful-restart. Continue? [Y/N]: ::: Y
+
+peer * graceful-restart timer restart *
+    dialog: Warning: Changing the parameter in this command will reset the peer session which is configured with graceful-restart. Continue? [Y/N]: ::: Y
+
+undo peer * capability-advertise graceful-restart
+    dialog: Warning: Changing the parameter in this command will reset the peer session which is not configured with graceful-restart. Continue? [Y/N]: ::: Y
+
+peer * capability-advertise graceful-restart
+    dialog: Warning: Changing the parameter in this command will reset the peer session which is not configured with graceful-restart. Continue? [Y/N]: ::: Y
+
+graceful-restart
+    dialog: Warning: Changing the parameter in this command resets the peer session. Continue? [Y/N]: ::: Y
+
+route-distinguisher *
+    dialog: Warning: This operation will may cause services to be interrupted. Continue? [Y/N]: ::: Y
 
 save
     dialog: /Warning: The current configuration will be written to the device. Continue\? \[Y/N\]:?/ ::: Y
@@ -37,24 +71,35 @@ save
     dialog: Are you sure to continue?[Y/N] ::: Y
     dialog: Are you sure to continue? [Y/N] ::: Y
     dialog: Please input the file name(*.cfg, *.zip, *.dat): ::: vrpcfg.zip
+    dialog: /Please input the file name *\(.+\):?/ ::: vrpcfg.zip
+    dialog: Warning: The current configuration will be written to the device. Continue? [Y/N] ::: Y
 undo rsa peer-public-key
     dialog: /Do you want to remove the public key named .*\? \[Y/N\]:/ ::: Y
     dialog: /% Do you really want to remove the public key named .*\? \[y/n\]:/ ::: y
 undo stelnet server enable
     dialog: Warning: The operation will stop the STelnet server. Do you want to continue? [Y/N]: ::: Y
+
+undo telnet server enable
+    dialog: /Warning: The operation will stop the .*Telnet server. Continue\? \[Y\/N\]:/ ::: Y
 undo telnet * server enable
     dialog: Warning: The operation will stop the .*Telnet server. Continue? [Y/N]: ::: Y
+    dialog: /Warning: The operation will stop the .*Telnet server. Continue\? \[Y\/N\]:/ ::: Y
 undo stelnet * server enable
     dialog: Warning: The operation will stop the STelnet server. Do you want to continue? [Y/N]: ::: Y
 telnet ipv6 server-source all-interface
     dialog: Warning: Telnet server source configuration will take effect in the next login. Do you want to continue? [Y/N]: ::: Y
     dialog: Warning: The IPv6 Telnet server source configuration will take effect in the next login. Continue? [Y/N]: ::: Y
+    dialog: /(?i).*continue\?.?\[y\/n\]:?/ ::: Y
 telnet server-source all-interface
     dialog: Warning: Telnet server source configuration will take effect in the next login. Do you want to continue? [Y/N]: ::: Y
     dialog: Warning: Telnet server source configuration will take effect in the next login. Continue? [Y/N]: ::: Y
+    dialog: /(?i).*continue\?.?\[y\/n\]:?/ ::: Y
 undo telnet server-source ~
     dialog: Warning: The operation will delete the Telnet server source configuration and may cause the service to be unavailable. Do you want to continue? [Y/N]: ::: Y
     dialog: Warning: The operation will delete the Telnet server source configuration and may cause the service to be unavailable. Continue? [Y/N]: ::: Y
+
+undo telnet server-source
+    dialog: Warning: Telnet server source configuration will take effect in the next login. Continue? [Y/N]: ::: Y
 undo telnet ipv6 server-source ~
     dialog: Warning: The operation will delete the Telnet server source configuration and may cause the service to be unavailable. Do you want to continue? [Y/N]: ::: Y
     dialog: Warning: The operation will delete the Telnet server source configuration and may cause the service to be unavailable. Continue? [Y/N]: ::: Y
@@ -64,18 +109,76 @@ ssh ipv6 server-source all-interface
 ssh server-source all-interface
     dialog: Warning: SSH server source configuration will take effect in the next login. Do you want to continue? [Y/N]: ::: Y
     dialog: Warning: SSH server source configuration will take effect in the next login. Continue? [Y/N]: ::: Y
+
+undo ssh server rsa-key min-length %suppress_errors
 undo ssh server-source ~
     dialog: Warning: The operation will delete the SSH server source configuration and may cause the service to be unavailable. Do you want to continue? [Y/N]: ::: Y
+
+undo ssh server-source
+    dialog: Warning: SSH server source configuration will take effect in the next login. Continue? [Y/N]: ::: Y
+    dialog: Warning: The operation will delete the SSH server source configuration and may cause the service to be unavailable. Continue? [Y/N]: ::: Y
 undo protocol inbound ssh port *
     dialog: Warning: The operation will stop the ssh port 830 service. Do you want to continue? [Y/N]: ::: Y
+
+snmp-agent trap enable:
+    dialog: Warning: All switches of SNMP trap/notification will be open. Continue? [Y/N]: ::: Y
+
+authentication-mode ~
+    dialog: Please enter old password: ::: Default43pass
+
+radius-server (accounting|authentication) ~
+    dialog: Warning: The shared-key complexity is low. It is recommended that the password contain at least sixteen characters and be a combination of at least two of the following categories: Uppercase letters <A-Z>; Lowercase letters <a-z>; Numerals <0-9>; Symbols (all characters not defined as letters or numerals), such as !,$,#, and %. Continue? [Y/N]: ::: Y
+
+set forward capability enhanced
+    dialog: Warning: Current configuration should be committed and saved, and it will take effect after reboot. Continue? [Y/N]: ::: Y
+
+undo if-match ~
+    dialog: /Warning: The last if-match clause of the node .* is deleted. All the routes that are filtered using this node match this node and are .*/ ::: Y
+
+radius-server shared-key cipher *
+    dialog: Warning: The shared-key complexity is low. It is recommended that the password contain at least sixteen characters and be a combination of at least two of the following categories: Uppercase letters <A-Z>; Lowercase letters <a-z>; Numerals <0-9>; Symbols (all characters not defined as letters or numerals), such as !,$,#, and %. Continue? [Y/N]: ::: Y
+
+igmp-snooping querier enable
+    dialog: Warning: Please confirm that no other querier is configured on the network, otherwise this command may cause querier re-election, continue?[Y/N]: ::: Y
+
+undo igmp snooping enable
+    dialog: Warning: This command will delete all IGMP snooping related configurations. Continue? [Y/N]: ::: Y
+
+undo igmp-snooping enable
+    dialog: Warning: IGMP-Snooping will be disabled on the device, all related configurations will be removed completely, continue?[Y/N]: ::: Y
+
+bgp yang-mode enable
+    dialog: /Warning: All the configurations of the BGP VPN instance and its peers and peer groups will be changed to configurations that can be delivered using the YANG model. Continue\? \[Y/N\]:?/ ::: Y
+
+undo mac-access-profile
+    dialog: /Warning: Changing the authentication profile will cause online users to go offline\. Continue\? \[Y/N\]:?/ ::: Y
+
+mac-access-profile ~
+    dialog: /Warning: Changing the authentication profile will cause online users to go offline\. Continue\? \[Y/N\]:?/ ::: Y
+
+undo authentication-profile
+    dialog: /Warning: Changing the authentication profile will cause online users to go offline\. Continue\? \[Y/N\]:?/ ::: Y
+
+authentication-profile ~
+    dialog: /Warning: Changing the authentication profile will cause online users to go offline\. Continue\? \[Y/N\]:?/ ::: Y
+
+    mac-access-profile ~
+        dialog: /Warning: Changing the authentication profile will cause online users to go offline\. Continue\? \[Y/N\]:?/ ::: Y
+
+    undo mac-access-profile
+        dialog: /Warning: Changing the authentication profile will cause online users to go offline\. Continue\? \[Y/N\]:?/ ::: Y
+    dialog: /Warning: The operation will stop the ssh port \d* service\. Continue\? \[Y/N\]:?/ ::: Y
 undo sftp server enable
     dialog: Warning: The operation will stop the SFTP server. Do you want to continue? [Y/N]: ::: Y
 (ftp|FTP) *
     dialog: Warning: FTP server source configuration will take effect in the next login. Do you want to continue? [Y/N]: ::: Y
+    dialog: Warning: FTP server source configuration will take effect in the next login. Continue? [Y/N]: ::: Y
 undo (ftp|FTP) server enable
     dialog: Warning: The operation will stop the FTP server. Do you want to continue? [Y/N]: ::: Y
+    dialog: Warning: The operation will stop the FTP server. Continue? [Y/N]: ::: Y
 undo (ftp|FTP) ipv6 server enable
     dialog: Warning: The operation will stop the FTP server. Do you want to continue? [Y/N]: ::: Y
+    dialog: Warning: The operation will stop the FTP server. Continue? [Y/N]: ::: Y
 undo (ftp|FTP) (server source|server-source)
     dialog: Warning: The operation will delete the FTP server source configuration and may cause the service to be unavailable. Do you want to continue? [Y/N]: ::: Y
     dialog: Warning: To make the server source configuration take effect, the FTP server will be restarted. Continue? [Y/N]: ::: Y
@@ -84,6 +187,7 @@ undo (ftp|FTP) ipv6 (server source|server-source)
     dialog: Warning: To make the server source configuration take effect, the FTP server will be restarted. Continue? [Y/N]: ::: Y
 undo http server enable
     dialog: Warning: The operation will stop HTTP service. Continue? [Y/N]: ::: Y
+    dialog: Warning: The operation will stop HTTP service. Continue? [Y/N] ::: Y
 undo sftp * server enable
     dialog: Warning: The operation will stop the SFTP server. Do you want to continue? [Y/N]: ::: Y
 undo scp server enable
@@ -102,9 +206,48 @@ local-user * privilege level
 local-user * password
     dialog: Warning: The user using this account will be logged out, and needs to log in again. Do you want to continue? [Y/N] ::: Y
 
+snmp-agent sys-info version all disable
+    dialog: Warning: All SNMP versions will be disabled. continue? [Y/N]: ::: Y
+    dialog: Warning: All SNMP versions will be disabled. Do you want to continue? [Y/N]: ::: Y
+
+snmp-agent protocol source-status all-interface
+    # TODO: replace with more specific question
+    dialog: [Y/N] ::: Y
+    dialog: [y/n] ::: Y
+    dialog: [Yes/All/No/Cancel] ::: Y
+
+undo port split dimension interface *
+    dialog: Warning: This operation will delete current port(s) and create new port(s). Continue? [Y/N] ::: Y
+    dialog: /Warning: This operation causes the port .* to be deleted. Its configurations are lost and services are interrupted. Continue\?.*/ ::: Y
+    dialog: /and all configurations of the current port\(*s\)* will be cleared\. After the operation is done, it may takes a few seconds before viewing the port information\. Continue\?\s+\[Y\/N\]/ ::: Y
+    dialog: /Warning: This operation causes multiple ports of .* to be deleted\. Their configurations are lost and services are interrupted\. Continue\?.*/ ::: Y
+    dialog: /Warning: This operation causes the port .* to be deleted. Its configurations are lost and services are interrupted. Continue\?.*/ ::: Y
+
+port split dimension interface * %suppress_errors
+    dialog: Warning: This operation will delete current port(s) and create new port(s). Continue? [Y/N] ::: Y
+    dialog: /Warning: This operation causes the port .* to be deleted. Its configurations are lost and services are interrupted. Continue\?.*/ ::: Y
+    dialog: /Warning: This operation causes multiple ports of .* to be deleted. Their configurations are lost and services are interrupted. Continue\?.*/ ::: Y
+    dialog: /and all configurations of the current port\(*s\)* will be cleared\. After the operation is done, it may takes a few seconds before viewing the port information\. Continue\?\s+\[Y\/N\]/ ::: Y
+
+port split refresh
+    dialog: Are you sure to continue? [Y/N] ::: Y
+
+undo radius-server shared-key
+    dialog: Warning: Are you sure you want to delete the shared key?[Y/N] ::: Y
+
+undo local-user * privilege level
+    dialog: Warning: This operation may affect online users and will change the user privilege level, Continue? [Y/N]: ::: Y
+
+local-user * service-type *
+    dialog: Warning: If the service type of local users is configured multiple times, the new configuration overwrites the previous one. The new configuration may cause local user authentication to fail. Continue? [Y/N]  :::  Y
+    dialog: Warning: The newly configured service-type will overwrite the original service-type. Continue? [Y/N] ::: Y
+    dialog: Please enter old password: ::: Default43pass
+
 stp *
     dialog: Warning: The global STP state will be changed. Continue? [Y/N] ::: Y
 
+    dialog: Warning: This operation will result in loops, since LNP is enabled on the device. Continue?[Y/N]: ::: Y
+    dialog: /Warning: The global STP state will be changed. Continue\? ?\[Y\/N\]:?/ ::: Y
 ntp server disable
     dialog: /(?i).*continue\?\s?\[y\/n\]:?/ ::: Y
 ntp * server disable
@@ -112,9 +255,13 @@ ntp * server disable
 
 ntp-service server disable
     dialog: /(?i).*continue\?\s?\[y\/n\]:?/ ::: Y
+    dialog: /(?i).*Continue\?\s\[Y\/N\]:?/ ::: Y
+    dialog: /(?i).*continue\?\[y\/n\]:?/ ::: Y
 ntp-service * server disable
     dialog: /(?i).*continue\?\s?\[y\/n\]:?/ ::: Y
 
+    dialog: /(?i).*Continue\?\s\[Y\/N\]:?/ ::: Y
+    dialog: /(?i).*continue\?\[y\/n\]:?/ ::: Y
 undo telnet server-source all-interface
     dialog: /(?i).*continue\?.?\[y\/n\]:?/ ::: Y
 undo telnet ipv6 server-source all-interface
@@ -128,19 +275,36 @@ telnet ipv6 server disable
     dialog: Warning: The operation will stop the IPv6 Telnet server. Do you want to continue? [Y/N]: ::: Y
     dialog: Warning: The operation will stop the IPv6 Telnet server. Continue? [Y/N]: ::: Y
 
+vlan *
+    dialog: /Warning: The specified VLAN does not exist. You can create it later. Continue\?.*:?/ ::: Y
+
 undo vlan
     dialog: Warning: The configurations of the VLAN will be deleted. Continue? [Y/N]: ::: Y
 
+transceiver non-certified-alarm disable
+    dialog: Warning: After this command is run, no alarm is generated when a third-party optical module is installed. Huawei will not be liable for any problems or defects in the use of third-party optical modules! Continue? [Y/N]: ::: Y
+
+    dialog: /Warning: The configurations of the VLAN will be deleted. Continue\?.*:/ ::: Y
 port link-type *
     dialog: Warning: This command will delete VLANs on this port. Continue?[Y/N]: ::: Y
+
+port mode 200GE interface * %timeout=40 %suppress_errors
+    dialog: /Warning: This operation will delete current port.*/ ::: Y
 
 port mode 200GE  ~
     dialog: /Warning: This operation will delete current ports.*/ ::: Y
 
 port mode *
     dialog: /Warning: The interfaces.* will be converted to .* mode/ ::: Y
+
+port mode * interface * %suppress_errors
+    dialog: /Warning: The interfaces.* will be converted to .* mode/ ::: Y
 undo port mode *
     dialog: /Warning: The interfaces.* will be converted to .* mode/ ::: Y
+
+poe legacy enable
+    dialog: Warning: Is there a valid PD connected to this interface? Yes or No?[Y/N]: ::: Y
+    dialog: Warning: The configuration takes effect only in at or pre-bt mode. Continue?[Y/N]: ::: Y
 
 mpls lsr-id *
     dialog: Warning: All MPLS services will be deleted and services related to LSR-ID will fail. Continue? [Y/N]: ::: Y
@@ -160,8 +324,14 @@ undo dcn
 undo ospf *
     dialog: Warning: The OSPF process will be deleted. Continue? [Y/N]: ::: Y
 
+undo isis *
+    dialog: Warning: The IS-IS process will be deleted. Continue? [Y/N]: ::: Y
+
 undo mpls ldp transport-address
     dialog: Warning: All the related sessions will be deleted if the operation is performed! Continue? [Y/N]: ::: Y
+
+undo mpls
+    dialog: Warning: All the MPLS configurations will be deleted. Continue? [Y/N]: ::: Y
 
 ldp-sync enable
     dialog: Warning: This will cause all the interfaces enabled the ISIS process to enter ldp-sync state. Continue? [Y/N]: ::: Y
@@ -173,16 +343,45 @@ association-type enable
 info-center max-logfile-number *
     dialog: Warning: The operation will probably delete the redundant logs. Continue? [Y/N]: ::: Y
 
+ecc local-key-pair create %timeout=120
+    dialog: [Y/N] ::: Y
+    dialog: [y/n] ::: Y
+    dialog: [Yes/All/No/Cancel] ::: Y
+    dialog: [Y(yes)/N(no)/C(cancel)] ::: Y
+    dialog: = 512] ::: 512
+    dialog: = 521] ::: 521
+
+rsa local-key-pair create %timeout=360
+    dialog: [Y/N] ::: Y
+    dialog: [y/n] ::: Y
+    dialog: [Yes/All/No/Cancel] ::: Y
+    dialog: [Y(yes)/N(no)/C(cancel)] ::: Y
+    dialog: = 512] ::: 2048
+    dialog: = 2048] ::: 2048
+    dialog: = 3072] ::: 2048
+
+# диалоги скопированы из .rul как есть, в идеале бы конечно бы последить в логах за тем какие реально возникают варианты диалогов для этой команды
+
 rsa peer-public-key * 
     dialog: Do you really want to replace it? [Y/N]: ::: Y
     dialog: /% You already have RSA public key named .*.\r\n% Do you really want to replace it\? \[y/n\]:/ ::: y
 
+undo ip address
+    dialog: /Warning: This operation will change the router ID of VPN.*:/ ::: Y
+
 ip binding vpn-instance
     dialog: Warning: This operation will modify the router ID to 0.0.0.0, which may affect the establishment of BGP peer relationships. Continue? [Y/N]: ::: Y
+
+connect-interface *
+    dialog: Warning: This operation will reset the bmp session. Continue? [Y/N]: ::: Y
+
+load-balance profile *
+    dialog: Warning: The profile default has been used, and this command will rename it. Continue? [Y/N]: ::: Y
 
 force transceiver *
     dialog: /.*Continue\?/ ::: Y
 
+    dialog: After the transceiver type is changed, the transceiver may not work properly. Continue? [Y/N]: ::: Y
 undo force transceiver *
     dialog: /.*Continue\?/ ::: Y
 
@@ -196,3 +395,10 @@ hwtacacs-server shared-key cipher *
     dialog: Warning: The shared-key complexity is low. It is recommended that the password contain at least sixteen characters and be a combination of at least two of the following categories: Uppercase letters <A-Z>; Lowercase letters <a-z>; Numerals <0-9>; Symbols (all characters not defined as letters or numerals), such as !,$,#, and %. Continue? [Y/N]: ::: Y
 
 # vim: set syntax=annrulebook:
+
+
+undo ipv6
+    dialog: Warning: This operation will interrupt all IPv6 services. Continue?[Y/N]: ::: Y
+
+undo bgp yang-mode enable
+    dialog: Warning: BGP will be modified to not support YANG configuration. Continue? [Y/N]: ::: Y

--- a/annet/rulebook/texts/huawei.order
+++ b/annet/rulebook/texts/huawei.order
@@ -7,6 +7,10 @@
 
 
 # Сначала сплитим порты и размечаем ресурсы
+
+license
+
+# Сначала сплитим порты и размечаем ресурсы
 port split mode
 port split dimension
 port split refresh
@@ -19,6 +23,10 @@ port mode 200GE
 #clock
 #sysname
 #info-center
+
+# на vpn-instance Meth есть много ссылок отовсюду, так что создадим как можно раньше
+
+undo dcn
 
 # на vpn-instance Meth есть много ссылок отовсюду, так что создадим как можно раньше
 ip vpn-instance */[Mm][Ee][Tt]h.*/
@@ -36,9 +44,20 @@ ip vpn-instance */[Mm][Ee][Tt]h.*/
 # в таком случае нужно расскомментить эту строчку, но она не позволяет снести plist целиком
 # сначала мы добавляем stub-правило в рулсет чтобы оно не позволяло prefix-list'у "пропасть"
 # индекс референсится в логике патчинга префикс-листа huawei.misc.prefix_list
+
+rsa local-key-pair create
+#ecc
+
+# из-за того, что Huawei не позволяет иметь в одном prefix-list 2 одинаковых правила,
+# нужно сначала удалить все несовпадающие, а затем заполнить их заново
+# в таком случае нужно расскомментить эту строчку, но она не позволяет снести plist целиком
+# сначала мы добавляем stub-правило в рулсет чтобы оно не позволяло prefix-list'у "пропасть"
+# индекс референсится в логике патчинга префикс-листа huawei.misc.prefix_list
 ip */(ip|ipv6)/-prefix * index 99999999
 undo ip */(ip|ipv6)/-prefix * index *   %order_reverse
 ip */(ip|ipv6)/-prefix
+
+xpl as-path-list
 xpl
 
 ip as-path-filter
@@ -68,9 +87,22 @@ ntp
 #stp enable
 #stp region-configuration
 
+stp region-configuration
+    instance ~
+    active region-configuration
+
+erps ring
+#stp mode
+#stp bpdu-protection
+#stp enable
+
 acl port-pool
 acl ip-pool
 acl ipv6-pool
+
+acl
+
+system tcam acl$
 acl ~
     undo rule * description %order_reverse
     undo rule ~ %order_reverse
@@ -80,6 +112,10 @@ acl ~
 system tcam
 
 undo system tcam acl template * all %order_reverse
+
+system tcam acl template *
+
+system tcam acl template * all
 undo system tcam acl template * %order_reverse
 undo system tcam acl$ %order_reverse
 
@@ -92,18 +128,30 @@ port-wred
 
 dhcp
 
+*/igmp.?snooping/ enable
+
+*/igmp.?snooping/
+
 vlan reserved
 vlan batch
 vlan
+    */igmp.?snooping/ enable
+    */igmp.?snooping/
+    undo */igmp.?snooping/ enable %order_reverse
 vlan pool
+
+undo */igmp.?snooping/ enable %order_reverse
 
 hwtacacs-server
 hwtacacs server
+
+radius-server template *
 radius-server
 
 aaa
     undo local-user policy security-enhance
     undo user-password complexity-check
+    local-aaa-user user-name complexity-check disable
 
     undo user-group %order_reverse
     undo task-group %order_reverse
@@ -119,6 +167,8 @@ aaa
     user-group
 
     #pin removal order to ensure that local-user will be deleted last
+    domain default
+        radius-server *
     undo local-user * ftp-directory %order_reverse
     undo local-user * privilege %order_reverse
     undo local-user * level %order_reverse
@@ -127,8 +177,14 @@ aaa
 
 domain
 
+undo radius-server template * %order_reverse
+
 user-interface
 drop-profile
+
+# SR глобально -> MPLS -> IS-IS -> IS-IS и SID на интерфейсах
+
+ipv6
 
 # SR глобально -> MPLS -> IS-IS -> IS-IS и SID на интерфейсах
 segment-routing
@@ -143,6 +199,8 @@ mpls
     mpls te cspf preferred-igp
 
 mpls ldp
+    mtu-signalling
+    ipv4-family
 mpls ldp remote-peer *
 
 explicit-path
@@ -169,11 +227,29 @@ bridge-domain *
 # Должно идти перед interface, т.к. на уровне interface идет ссылка на diffserv domain
 diffserv domain *
 
+lldp enable
+
+# Включение dot1x должно происходить перед interface
+# так как там используются дополнительные настройки dot1x per interface
+
+dot1x enable
+
+# Отключение lnp должно идти перед interface
+
+lnp disable
+
+# Удаляем существующие Vbdif перед созданием новых
+
+    ip-dscp-inbound ~
+
+# удалять eth-trunk можно только после того, как вычистим member interfaces
 undo interface */Vbdif\d+/ %order_reverse
 undo interface */.*[.]\d+/ %order_reverse
 
 interface */Vbdif\d+/
 interface */Eth-Trunk\d+/
+
+bfd
 interface */LoopBack\d+/
 interface */Tunnel.*/
     tunnel-protocol
@@ -188,7 +264,12 @@ interface *
     undo portswitch
     undo ip address * * sub  %order_reverse
     undo ip address * *  %order_reverse
+    undo ip address unnumbered  %order_reverse
+    undo ip binding vpn-instance * %order_reverse
     portswitch  %order_reverse
+    undo dot1x max-user *
+    undo dot1x guest-vlan *
+    undo dot1x mac-bypass
     ip binding
     ipv6 enable
     ipv6 nd ra prefix
@@ -197,15 +278,21 @@ interface *
     ip address * * sub
     dhcpv6
     isis enable
+    isis ipv6 enable
     isis
     undo isis *
     undo isis enable  %order_reverse
+    undo isis ipv6 enable  %order_reverse
     mpls
     mpls ldp
     mpls ldp transport-address interface
     mpls rsvp-te
     mpls rsvp-te bfd
     port link-type
+    stp disable
+    stp edged-port
+    erps ring
+    undo erps ring
     port trunk pvid
     port trunk allow-pass
     undo port trunk allow-pass vlan all
@@ -233,6 +320,17 @@ interface *
 # Нужно чтобы subif'ы портов шли после конфигурации самих портов, иначе свитч ругнется на то что порт l2
 interface */\S+\.\d+/
 
+undo erps ring
+
+# Добавляем порт в monitor-link group после создания интерфейсов
+# Удаляем порт из monitor-link group до удаления интерфейсов
+
+monitor-link group *
+    port * downlink *
+    undo port * downlink * %order_reverse
+
+# Должен быть после interface потому что в нем ссылается на diffserv domain
+
 undo diffserv domain * 	%order_reverse
 
 # маршруты идут после интерфейсов
@@ -255,14 +353,24 @@ bgp
     maximum load-balancing
     # [NOCDEV-2043] Тут только декларируем пиров и группы
     # поскольку на них есть ссылки из family блоков
+    undo group * listen external
     group
     peer * as-number *
+    peer * fake-as * prepend-global-as
     peer * local-as *
+    peer * group *
+    vpn-instance ~
+        group
+        peer * as-number *
+        peer * fake-as * prepend-global-as
+        peer * group *
+        peer * ~
     ipv[46]-family|link-state-family unicast|l2vpn-family evpn
         undo undo maximum load-balancing %order_reverse
         maximum load-balancing
         group
         peer * as-number *
+        peer * fake-as * prepend-global-as
         peer * enable
         peer * ~
     l2vpn-ad-family
@@ -270,11 +378,18 @@ bgp
         peer * ~
     # [NOCDEV-2043] Остальное в глобальном блоке делаем тут
     undo peer * description %order_reverse
+    undo peer * group * %order_reverse
+    undo peer * * * * %order_reverse
     undo peer * * * %order_reverse
     undo peer * * %order_reverse
     undo peer * %order_reverse
     undo group * %order_reverse
     peer * ~
+
+
+# Вырубаем bfd после bgp, но до vpn
+    peer * capability-advertise graceful-restart
+    peer * graceful-restart timer restart
 
 
 # Вырубаем bfd после bgp, но до vpn
@@ -370,6 +485,18 @@ undo vlan batch %order_reverse
 undo observe-port %order_reverse
 
 # Должны быть после interface потому что в нем ссылается traffic-policy
+# И именно в данном порядке
+# policy ссылаются на behavior и classifier, они на acl'и
+
+undo bridge-domain %order_reverse
+
+# l2 интерфейсы можем добавлять только после удаления vlan
+
+interface */\S+\.\d+/ mode l2
+
+# Должны быть после interface потому что в нем ссылается traffic-policy
+# Должны быть после удаления интерфейсов, в противном случае получим ошибку:
+# нельзя удалить полиси которая применена на интерфейсе
 # И именно в данном порядке
 # policy ссылаются на behavior и classifier, они на acl'и
 undo qos group          %order_reverse

--- a/annet/rulebook/texts/huawei.rul
+++ b/annet/rulebook/texts/huawei.rul
@@ -58,6 +58,12 @@ ntp ~
 dns snooping ttl delay-time
 dns ~
 
+mpls-in-udp6
+    ~
+
+mpls-in-udp
+    ~
+
 bfd *
     ~
 
@@ -89,6 +95,8 @@ system tcam acl template *
 system tcam acl
 
 vlan reserved ~
+
+igmp-snooping send-query source-address
 
 vlan batch  %diff_logic=annet.rulebook.huawei.vlandb.vlan_diff %logic=annet.rulebook.huawei.vlandb.multi
 
@@ -167,6 +175,7 @@ traffic classifier *        %logic=annet.rulebook.huawei.misc.classifier
 traffic behavior *
     remark 8021p
     remark dscp
+    car
     car *
 
 traffic policy *
@@ -204,6 +213,18 @@ hwtacacs-server template *
 hwtacacs server template *
     hwtacacs server shared-key
     hwtacacs server source-ip
+
+dot1x timer tx-period
+
+mac-access-profile name *
+    mac-authen timer reauthenticate-period
+    ~ %global
+
+dot1x-access-profile name *
+    dot1x retry
+    ~ %global
+
+radius-server ip-address * shared-key
 
 !radius-server template default
 
@@ -275,6 +296,10 @@ interface */Tunnel.+/
     mpls te path metric-type
     mpls te path
     mpls te tunnel-id
+
+evpn
+    mac-duplication
+        ~
 
 interface *                             %logic=annet.rulebook.huawei.iface.permanent
     %if hw.Quidway:
@@ -374,7 +399,19 @@ route-policy * (?:permit|deny) node * %logic=annet.rulebook.huawei.misc.rp_node
 xpl ~
     ~              %rewrite %global
 
+bgp yang-mode enable
+
 bgp path-attribute attr-set *
+
+bgp path-attribute wide-community *
+
+bgp path-attribute large-community *
+
+bgp path-attribute ipv6-ext-community *
+
+bgp path-attribute ext-community *
+
+bgp path-attribute community *
 bgp path-attribute *
 
 bgp %logic=annet.rulebook.huawei.bgp.undo_commit
@@ -423,6 +460,8 @@ bgp %logic=annet.rulebook.huawei.bgp.undo_commit
 
 
 ip community-filter ~
+
+isis purge-source-trace ~
 ospf *
     stub-router     %logic=annet.rulebook.huawei.misc.undo_redo
     area *
@@ -431,6 +470,9 @@ ospf *
 isis *
     set-overload *
 
+    ipv6 enable *
+    import-route direct *
+    set-overload
 error-down auto-recovery cause link-flap
 
 configuration file auto-save backup-to-server server
@@ -474,6 +516,10 @@ snmp-agent protocol source-interface %logic=annet.rulebook.huawei.misc.undo_redo
 %else:
 snmp-agent protocol source-interface *
 %endif
+
+stp vlan 1 to 4094 priority \d+
+
+stp disable
 snmp-agent ~
 ifindex constant
 
@@ -491,6 +537,7 @@ cpu-defend-policy * global
 cpu-defend-policy
 slot *
     cpu-defend-policy
+    load-balance hash-arithmetic
 
 user-interface con 0
     set authentication password cipher

--- a/annet/rulebook/texts/juniper.rul
+++ b/annet/rulebook/texts/juniper.rul
@@ -23,6 +23,7 @@ system
             match
         file messages
             match
+            archive        %diff_logic=annet.rulebook.juniper.misc.syslog_archive_diff
 
 routing-options
     autonomous-system *
@@ -53,6 +54,9 @@ chassis
 protocols
     isis
         overload
+        interface *
+            level 2      %diff_logic=annet.rulebook.juniper.misc.level2_interface_diff
+                ~
     mpls
         path *
             *           %ordered

--- a/annet/rulebook/texts/nexus.order
+++ b/annet/rulebook/texts/nexus.order
@@ -11,9 +11,14 @@ service
 interface breakout
 
 no password strength-check
+
+role *
+    rule
 username
 tacacs-server
 aaa
+
+no tacacs-server %order_reverse
 
 ip access-list
 ipv6 access-list

--- a/annet/rulebook/texts/routeros.order
+++ b/annet/rulebook/texts/routeros.order
@@ -24,8 +24,10 @@ interface
         remove %order_reverse
         add
         port %split
+            remove
             add
         vlan %split
+            remove
             add
     vlan
         add
@@ -45,6 +47,7 @@ interface
         remove
         add
         member %split
+            remove
             add
 
 routing
@@ -53,13 +56,17 @@ routing
     table %split
         remove
     table %split
+        remove
         add
     rule %split
+        remove
         add
     filter
         rule
             add
     bgp
+        instance
+            add
         template
             set
             add
@@ -81,6 +88,7 @@ ip
         static
             add
     dhcp-server %split
+        remove
         add
         network
             remove

--- a/tests/annet/test_patch/huawei_bfd_empty_block.yaml
+++ b/tests/annet/test_patch/huawei_bfd_empty_block.yaml
@@ -8,8 +8,8 @@
     lldp enable
   patch: |
     system-view
+    lldp enable
     bfd
       quit
-    lldp enable
     q
     save

--- a/tests/annet/test_patch/huawei_multi.yaml
+++ b/tests/annet/test_patch/huawei_multi.yaml
@@ -32,6 +32,9 @@ diff: |
     - instance 2 vlan 1 2 3 to 4
 patch: |
   system-view
+  stp region-configuration
+    undo instance 2
+    quit
   vlan batch 543 to 599 635 2542 to 2599 2635 2999
   vlan 542
     description nalivka
@@ -53,8 +56,5 @@ patch: |
     eth-trunk 0
     quit
   undo vlan batch 1999
-  stp region-configuration
-    undo instance 2
-    quit
   q
   save

--- a/tests/annet/test_patch/huawei_xpl.yaml
+++ b/tests/annet/test_patch/huawei_xpl.yaml
@@ -255,14 +255,14 @@
       origin '123'
   patch: |+
     system-view
+    xpl as-path-list XXX_AS_FILTERS
+      origin '123'
+      end-list
     xpl route-filter XXX
       if as-path in XXX_AS_FILTERS then
         apply local-preference 10
       endif
       end-filter
-    xpl as-path-list XXX_AS_FILTERS
-      origin '123'
-      end-list
     q
     save
 - vendor: Huawei

--- a/tests/annet/test_patch/juniper_isis_level2.yaml
+++ b/tests/annet/test_patch/juniper_isis_level2.yaml
@@ -1,0 +1,83 @@
+# `level 2` under an isis interface is declared as a block, but the box may return it
+# inlined when there is a single term. level2_interface_diff expands the inlined form
+# into a block, so the two compare equal instead of producing an endless diff.
+
+# inlined on the box, block in the config, same contents -> nothing to do
+- vendor: juniper
+  before: |-
+    protocols {
+        isis {
+            interface ae0.0 {
+                level 2 metric 20;
+            }
+        }
+    }
+  after: |-
+    protocols {
+        isis {
+            interface ae0.0 {
+                level 2 {
+                    metric 20;
+                }
+            }
+        }
+    }
+  patch: |
+
+# same shapes, but the metric really did change -> a patch, not a no-op
+- vendor: juniper
+  before: |-
+    protocols {
+        isis {
+            interface ae0.0 {
+                level 2 metric 20;
+            }
+        }
+    }
+  after: |-
+    protocols {
+        isis {
+            interface ae0.0 {
+                level 2 {
+                    metric 30;
+                }
+            }
+        }
+    }
+  patch: |
+    configure exclusive
+    delete protocols isis interface ae0.0 level 2 metric 20
+    set protocols isis interface ae0.0 level 2 metric 30
+    commit
+    exit
+
+# more than one term, so the box returns a block too -> ordinary diff, helper stays out
+- vendor: juniper
+  before: |-
+    protocols {
+        isis {
+            interface ae0.0 {
+                level 2 {
+                    metric 20;
+                    post-convergence-lfa;
+                }
+            }
+        }
+    }
+  after: |-
+    protocols {
+        isis {
+            interface ae0.0 {
+                level 2 {
+                    metric 30;
+                    post-convergence-lfa;
+                }
+            }
+        }
+    }
+  patch: |
+    configure exclusive
+    delete protocols isis interface ae0.0 level 2 metric 20
+    set protocols isis interface ae0.0 level 2 metric 30
+    commit
+    exit

--- a/tests/annet/test_patch/juniper_syslog_archive.yaml
+++ b/tests/annet/test_patch/juniper_syslog_archive.yaml
@@ -1,0 +1,86 @@
+# `archive` is declared as a block, but the box may return it inlined on one line.
+# syslog_archive_diff collapses the declared block to match, so the two forms compare
+# equal instead of producing an endless diff.
+
+# inlined on the box, block in the config, same contents -> nothing to do
+- vendor: juniper
+  before: |-
+    system {
+        syslog {
+            file messages {
+                archive size 10m files 10 world-readable;
+            }
+        }
+    }
+  after: |-
+    system {
+        syslog {
+            file messages {
+                archive {
+                    size 10m;
+                    files 10;
+                    world-readable;
+                }
+            }
+        }
+    }
+  patch: |
+
+# same shapes, but a value really did change -> a patch, not a no-op
+- vendor: juniper
+  before: |-
+    system {
+        syslog {
+            file messages {
+                archive size 10m files 10 world-readable;
+            }
+        }
+    }
+  after: |-
+    system {
+        syslog {
+            file messages {
+                archive {
+                    size 20m;
+                    files 10;
+                    world-readable;
+                }
+            }
+        }
+    }
+  patch: |
+    configure exclusive
+    set system syslog file messages archive size 20m files 10 world-readable
+    commit
+    exit
+
+# both sides already blocks -> the helper must not disturb the ordinary diff
+- vendor: juniper
+  before: |-
+    system {
+        syslog {
+            file messages {
+                archive {
+                    size 10m;
+                    files 10;
+                }
+            }
+        }
+    }
+  after: |-
+    system {
+        syslog {
+            file messages {
+                archive {
+                    size 10m;
+                    files 20;
+                }
+            }
+        }
+    }
+  patch: |
+    configure exclusive
+    delete system syslog file messages archive files 10
+    set system syslog file messages archive files 20
+    commit
+    exit


### PR DESCRIPTION
Adds rules for huawei, cisco, aruba and juniper, deploy dialogs for huawei and cisco, and ordering rules for huawei, cisco, nexus and routeros.

Three huawei commands had no ordering rule at all, so their position in the emitted patch was incidental; giving them one changes three expected patches, updated here. No existing rule is modified.