### PR TITLE
fix: keep block order when rows match different rules

### DIFF
--- a/annet/annlib/patching.py
+++ b/annet/annlib/patching.py
@@ -616,7 +616,7 @@ def _filter_rows_by_rulebook_selector(
 def make_pre(diff: Diff, _parent_match: dict[str, Any] | None = None) -> dict[str, Any]:
     pre: dict[str, Any] = odict()
     reversals: defaultdict[str, set[str]] = defaultdict(set)
-    for op, row, children, match in diff:
+    for position, (op, row, children, match) in enumerate(diff):
         if _parent_match and _parent_match["attrs"]["multiline"]:
             # Если родительское правило было мультилайном, то все внутренности станут его контентом.
             # Это значит, что к ним будет принудительно применяться common.default() и фейковое
@@ -647,6 +647,7 @@ def make_pre(diff: Diff, _parent_match: dict[str, Any] | None = None) -> dict[st
                 "rule": match["rule"],
                 "attrs": match["attrs"],
                 "items": odict(),
+                "positions": {},
             }
         if key not in pre[raw_rule]["items"]:
             pre[raw_rule]["items"][key] = {
@@ -656,6 +657,7 @@ def make_pre(diff: Diff, _parent_match: dict[str, Any] | None = None) -> dict[st
                 Op.AFFECTED: [],
                 Op.UNCHANGED: [],
             }
+            pre[raw_rule]["positions"][key] = position
 
         pre[raw_rule]["items"][key][op].append(
             {
@@ -699,6 +701,7 @@ class _Pre(TypedDict):
     rule: str
     attrs: _PreAttrs
     items: odict[tuple[str, ...], dict[OpType, list[_DiffItem]]]
+    positions: dict[tuple[str, ...], int]
 
 
 class _PatchRow(TypedDict):
@@ -710,41 +713,73 @@ class _PatchRow(TypedDict):
     sort_key: tuple[Any, ...]
 
 
+def _iterate_over_pre(
+    pre: odict[str, _Pre],
+) -> Iterable[tuple[_Pre, tuple[str, ...], dict[OpType, list[_DiffItem]]]]:
+    groups = [
+        (content["positions"][key], content, key, diff)
+        for content in pre.values()
+        for key, diff in content["items"].items()
+    ]
+    for _, content, key, diff in sorted(groups):
+        yield content, key, diff
+
+
 def _iterate_over_patch(
     pre: odict[str, _Pre],
     hw: HardwareView,
     do_commit: bool,
     add_comments: bool,
 ) -> Iterable[_PatchRow]:
-    for raw_rule, content in pre.items():
-        for key, diff in content["items"].items():
-            rule_pre = content.copy()
-            attrs = copy.deepcopy(rule_pre["attrs"])
-            iterable = attrs["logic"](
-                rule=attrs,
-                key=key,
-                diff=diff,
-                hw=hw,
-                rule_pre=rule_pre,
-                root_pre=pre,
-            )
-            for direct, row, sub_pre in iterable:
-                if direct is None:
-                    continue
+    for content, key, diff in _iterate_over_pre(pre):
+        rule_pre = content.copy()
+        attrs = copy.deepcopy(rule_pre["attrs"])
+        iterable = attrs["logic"](
+            rule=attrs,
+            key=key,
+            diff=diff,
+            hw=hw,
+            rule_pre=rule_pre,
+            root_pre=pre,
+        )
+        for direct, row, sub_pre in iterable:
+            if direct is None:
+                continue
 
-                if add_comments:
-                    comments = " ".join(attrs["comment"])
-                    for macro, m_value in _comment_macros.items():
-                        comments = comments.replace(macro, m_value)
-                    if comments:
-                        row = f"{row} {comments}"
+            if add_comments:
+                comments = " ".join(attrs["comment"])
+                for macro, m_value in _comment_macros.items():
+                    comments = comments.replace(macro, m_value)
+                if comments:
+                    row = f"{row} {comments}"
 
-                if not do_commit and attrs.get("force_commit", False):
-                    # if do_commit is false skip patch that couldn't be applied without commit
-                    continue
+            if not do_commit and attrs.get("force_commit", False):
+                # if do_commit is false skip patch that couldn't be applied without commit
+                continue
 
-                if sub_pre is None:
-                    # leaf -> emit itself
+            if sub_pre is None:
+                # leaf -> emit itself
+                yield _PatchRow(
+                    row=(row,),
+                    keys=(key,),
+                    attrs=attrs.copy(),
+                    direct=direct,
+                    rules=(content["rule"],),
+                    sort_key=(),
+                )
+
+            else:
+                # block
+                children = list(
+                    _iterate_over_patch(
+                        sub_pre,
+                        hw=hw,
+                        add_comments=add_comments,
+                        do_commit=do_commit,
+                    )
+                )
+                if not children:
+                    # block, no children -> emit itself
                     yield _PatchRow(
                         row=(row,),
                         keys=(key,),
@@ -753,37 +788,16 @@ def _iterate_over_patch(
                         rules=(content["rule"],),
                         sort_key=(),
                     )
-
-                else:
-                    # block
-                    children = list(
-                        _iterate_over_patch(
-                            sub_pre,
-                            hw=hw,
-                            add_comments=add_comments,
-                            do_commit=do_commit,
-                        )
+                for sub_row in children:
+                    # block, has children -> emit only children
+                    yield _PatchRow(
+                        row=(row, *sub_row["row"]),
+                        keys=(key, *sub_row["keys"]),
+                        attrs=sub_row["attrs"],
+                        direct=sub_row["direct"],
+                        rules=(content["rule"], *sub_row["rules"]),
+                        sort_key=(),
                     )
-                    if not children:
-                        # block, no children -> emit itself
-                        yield _PatchRow(
-                            row=(row,),
-                            keys=(key,),
-                            attrs=attrs.copy(),
-                            direct=direct,
-                            rules=(content["rule"],),
-                            sort_key=(),
-                        )
-                    for sub_row in children:
-                        # block, has children -> emit only children
-                        yield _PatchRow(
-                            row=(row, *sub_row["row"]),
-                            keys=(key, *sub_row["keys"]),
-                            attrs=sub_row["attrs"],
-                            direct=sub_row["direct"],
-                            rules=(content["rule"], *sub_row["rules"]),
-                            sort_key=(),
-                        )
 
 
 def sort_patch_rows(orderer: Orderer, patch_rows: list[_PatchRow]) -> None:

--- a/tests/annet/test_patch/huawei_bgp_peers_group_merge.yaml
+++ b/tests/annet/test_patch/huawei_bgp_peers_group_merge.yaml
@@ -62,13 +62,13 @@ patch: |
   bgp 64203.10
     ipv6-family vpn-instance Vpn1
       undo peer SPINE_D1 as-number
-      undo peer SPINE_D2 as-number
-      undo peer SPINE_D3 as-number
-      undo peer SPINE_D4 as-number
       undo peer fe80::c1:d1 group SPINE_D1
       undo peer fe80::c1:d2 group SPINE_D2
+      undo peer SPINE_D2 as-number
       undo peer fe80::c1:d3 group SPINE_D3
       undo peer fe80::c1:d4 group SPINE_D4
+      undo peer SPINE_D3 as-number
+      undo peer SPINE_D4 as-number
       undo group SPINE_D1
       undo group SPINE_D2
       undo group SPINE_D3

--- a/tests/annet/test_patching.py
+++ b/tests/annet/test_patching.py
@@ -5,11 +5,13 @@ from textwrap import dedent
 import pytest
 
 from annet.annlib.rbparser import syntax
-from annet.patching import PatchTree, make_diff
+from annet.patching import PatchTree, make_diff, make_patch, make_pre
 from annet.rulebook.common import default, default_diff, ordered_diff
 from annet.rulebook.patching import _make_reverse, compile_patching_text
 from annet.types import Op
 from annet.vendors.tabparser import CommonFormatter
+
+from .. import make_hw_stub
 
 
 @pytest.fixture
@@ -123,6 +125,50 @@ def test_diff_keeps_block_order_with_mixed_diff_logic():
         (Op.ADDED, "60 remark GRE"),
         (Op.ADDED, "70 permit gre any any"),
         (Op.ADDED, "230 deny ip any any log"),
+    ]
+
+
+def test_patch_keeps_block_order_when_rows_match_different_rules(ann_connectors):
+    """The patch must follow the config, not the rulebook rule that matched each row - #638"""
+    rb_text = dedent("""
+        ip access-list ~
+            ?/(\\d+)/ remark ~   %diff_logic=tests.annet.test_patching.custom_diff_logic
+            ~
+    """).strip()
+    rb = {"patching": compile_patching_text(rb_text, "cisco"), "ordering": {}}
+    hw = make_hw_stub("cisco")
+
+    old = odict([("ip access-list extended TEST", odict())])
+    new = odict(
+        [
+            (
+                "ip access-list extended TEST",
+                odict(
+                    (row, odict())
+                    for row in [
+                        "10 remark SSH",
+                        "20 permit tcp any any eq 22",
+                        "30 remark GRE",
+                        "40 permit gre any any",
+                        "50 remark DENY",
+                        "60 deny ip any any log",
+                    ]
+                ),
+            )
+        ]
+    )
+
+    diff = make_diff(old, new, rb, [])
+    patch = make_patch(pre=make_pre(diff), rb=rb, hw=hw, add_comments=False)
+    # the remarks are matched by their own rule and the rest by the plain one,
+    # yet the acl is written out in the order it was generated in
+    assert list(patch.asdict()["ip access-list extended TEST"]) == [
+        "10 remark SSH",
+        "20 permit tcp any any eq 22",
+        "30 remark GRE",
+        "40 permit gre any any",
+        "50 remark DENY",
+        "60 deny ip any any log",
     ]
 
 


### PR DESCRIPTION
The previous fix (#640) kept the order in the diff, but the patch is built from the diff in a second pass that regrouped the rows again. make_pre() buckets a block's rows by the rulebook rule that matched them, and _iterate_over_patch() walked those buckets rule by rule, emitting all rows of one rule, then all rows of the next. A block whose rows are partly matched by a separate rule came out regrouped - for an acl with a `?/(.*)/remark ~` rule all the remarks ended up at the end, no matter what the generator produced. %diff_logic is not what triggers this: an ordinary child rule regroups the block exactly the same way.

Nothing downstream restores the order here: every one of those patch rows gets the same sort key, so sort_patch_rows() leaves them in the order they came in.

Remember for each (rule, key) group where it stood in the block and walk the groups in that order instead of in rulebook order. The order rulebook still wins wherever it has an opinion - this only decides the cases where it has none.

The huawei_bgp_peers_group_merge sample changes because of that: inside `ipv6-family vpn-instance Vpn1` the `undo peer * as-number` and `undo peer * group *` rows all match the same `peer *` entry of huawei.order at the same index, so their relative order was never rulebook-driven. The new output is the one this sample expected before #467 (`%split` blocks in order rulebooks) incidentally changed it.

Fixes #638