### PR TITLE
fix: keep block order when printing the diff

### DIFF
--- a/annet/annlib/diff.py
+++ b/annet/annlib/diff.py
@@ -5,6 +5,7 @@ from typing import Any
 import colorama
 
 from ..types import Diff, DiffItem, Op, OpType
+from .patching import iterate_over_pre
 
 
 # NOCDEV-1720
@@ -115,16 +116,14 @@ def gen_pre_as_diff(
     ops = [(order, op) for op, order in ops_order.items()]
     ops.sort()
 
-    for raw_rule, content in pre.items():
-        items = content["items"].items()
-        for _, diff in items:  # pylint: disable=redefined-outer-name
-            if show_rules and not raw_rule == "__MULTILINE_BODY__":
-                line = "# %s%s\n" % (indent * _level, raw_rule)
-                yield colorize_line_with_color(line, colorama.Fore.BLACK, no_color)
+    for raw_rule, _content, _key, diff in iterate_over_pre(pre):  # pylint: disable=redefined-outer-name
+        if show_rules and not raw_rule == "__MULTILINE_BODY__":
+            line = "# %s%s\n" % (indent * _level, raw_rule)
+            yield colorize_line_with_color(line, colorama.Fore.BLACK, no_color)
 
-            for op, rows in [(op, diff[op]) for (_, op) in ops]:
-                for item in rows:
-                    line = "%s%s %s\n" % (ops_sign[op], indent * _level, item["row"])
-                    yield colorize_line_with_color(line, ops_color[op], no_color)
-                    if len(item["children"]) != 0:
-                        yield from gen_pre_as_diff(item["children"], show_rules, indent, no_color, _level + 1)
+        for op, rows in [(op, diff[op]) for (_, op) in ops]:
+            for item in rows:
+                line = "%s%s %s\n" % (ops_sign[op], indent * _level, item["row"])
+                yield colorize_line_with_color(line, ops_color[op], no_color)
+                if len(item["children"]) != 0:
+                    yield from gen_pre_as_diff(item["children"], show_rules, indent, no_color, _level + 1)

--- a/annet/annlib/patching.py
+++ b/annet/annlib/patching.py
@@ -713,16 +713,24 @@ class _PatchRow(TypedDict):
     sort_key: tuple[Any, ...]
 
 
-def _iterate_over_pre(
-    pre: odict[str, _Pre],
-) -> Iterable[tuple[_Pre, tuple[str, ...], dict[OpType, list[_DiffItem]]]]:
+def iterate_over_pre(
+    pre: Mapping[str, _Pre],
+) -> Iterable[tuple[str, _Pre, tuple[str, ...], dict[OpType, list[_DiffItem]]]]:
+    """
+    Walk a pre in the order the rows had in the config, not in rulebook order.
+
+    A block's rows are bucketed by the rulebook rule that matched them, so walking
+    the buckets as they lie would emit all rows of one rule, then all rows of the
+    next. Every (rule, key) group remembers where it stood in the block, and the
+    positions are unique - they are the index of the row that opened the group.
+    """
     groups = [
-        (content["positions"][key], content, key, diff)
-        for content in pre.values()
+        (content["positions"][key], raw_rule, content, key, diff)
+        for raw_rule, content in pre.items()
         for key, diff in content["items"].items()
     ]
-    for _, content, key, diff in sorted(groups):
-        yield content, key, diff
+    for _, raw_rule, content, key, diff in sorted(groups, key=operator.itemgetter(0)):
+        yield raw_rule, content, key, diff
 
 
 def _iterate_over_patch(
@@ -731,7 +739,7 @@ def _iterate_over_patch(
     do_commit: bool,
     add_comments: bool,
 ) -> Iterable[_PatchRow]:
-    for content, key, diff in _iterate_over_pre(pre):
+    for _, content, key, diff in iterate_over_pre(pre):
         rule_pre = content.copy()
         attrs = copy.deepcopy(rule_pre["attrs"])
         iterable = attrs["logic"](

--- a/tests/annet/test_diff.py
+++ b/tests/annet/test_diff.py
@@ -1,8 +1,11 @@
 import io
 import re
+from collections import OrderedDict as odict
+from textwrap import dedent
 
 from annet import patching
 from annet.diff import diff_cmp, diff_ops, gen_pre_as_diff, resort_diff
+from annet.rulebook.patching import compile_patching_text
 from annet.types import Diff, DiffItem
 
 
@@ -270,3 +273,35 @@ def test_diff_sorting() -> None:
         diff_sorted_expected = buf.getvalue()
 
     assert diff_sorted_actual == diff_sorted_expected
+
+
+def test_diff_keeps_block_order_when_rows_match_different_rules() -> None:
+    """The printed diff must follow the config, not the rulebook rule that matched each row - #638"""
+    rb_text = dedent("""
+        ip access-list ~
+            ?/(\\d+)/ permit ~
+            ?/(\\d+)/ deny ~
+            ?/(\\d+)/ remark ~
+    """).strip()
+    rb = {"patching": compile_patching_text(rb_text, "cisco"), "ordering": {}}
+    block = "ip access-list extended TEST"
+    rows = [
+        "10 deny ip host 0.0.0.0 any",
+        "20 remark SSH",
+        "30 permit tcp any any eq 22",
+        "40 remark GRE",
+        "50 permit gre any any",
+        "60 deny ip any any log",
+    ]
+
+    old = odict([(block, odict())])
+    new = odict([(block, odict((row, odict()) for row in rows))])
+    diff = patching.make_diff(old, new, rb, [])
+
+    # the same way annet.diff.gen_sort_diff() renders it
+    pd = patching.make_pre(resort_diff(diff))
+    printed = "".join(gen_pre_as_diff(pd, False, "  ", True)).splitlines()
+
+    # each kind of acl entry is matched by its own rule, yet the acl is printed
+    # in the order it was generated in
+    assert printed == ["  " + block] + ["+   " + row for row in rows]


### PR DESCRIPTION
The previous fix (#643) made the patch follow the config, but the diff is printed through a second pass that regroups the rows again. `annet diff` does not render the diff tree: gen_sort_diff() pushes it back through make_pre() and prints it with gen_pre_as_diff(), which walked the buckets rule by rule - all rows of one rulebook rule, then all rows of the next - exactly the walk _iterate_over_patch() did before #643. An acl whose rows are matched by a `permit`, a `deny` and a `remark` rule came out of the printer grouped by kind, no matter what the generator produced, while the patch built from the same diff was in the right order.

Fixes #638