### PR TITLE
fix: split Huawei DHCP DNS list removal into separate commands

### DIFF
--- a/annet/rulebook/huawei/misc.py
+++ b/annet/rulebook/huawei/misc.py
@@ -181,6 +181,16 @@ def netstream_undo(rule: dict[str, Any], key: tuple[str, ...], diff: common.Diff
     yield from common.default(rule, key, diff)
 
 
+def undo_dhcp_server_dns_list(
+    rule: dict[str, Any], key: tuple[str, ...], diff: common.DiffDict, **_: Any
+) -> common.LogicResult:
+    if diff[Op.REMOVED]:
+        for dns_server in key[0].split():
+            yield False, rule["reverse"].format(dns_server), None
+    else:
+        yield from common.default(rule, key, diff)
+
+
 def old_snmp_iface_trap_undo(
     rule: dict[str, Any], key: tuple[str, ...], diff: common.DiffDict, hw: HardwareView, **_: Any
 ) -> common.LogicResult:

--- a/annet/rulebook/texts/huawei.rul
+++ b/annet/rulebook/texts/huawei.rul
@@ -329,6 +329,7 @@ interface *                             %logic=annet.rulebook.huawei.iface.perma
     ipv6 neighbor *                     %diff_logic=annet.rulebook.huawei.iface.binding_change
     ipv6 ~                              %diff_logic=annet.rulebook.huawei.iface.binding_change
     dhcpv6 ~
+    dhcp server dns-list ~              %logic=annet.rulebook.huawei.misc.undo_dhcp_server_dns_list
     port link-type
     port trunk pvid vlan
     port trunk allow-pass vlan %logic=annet.rulebook.huawei.vlandb.multi_all

--- a/tests/annet/test_patch/huawei_dhcp_server_dns_list.yaml
+++ b/tests/annet/test_patch/huawei_dhcp_server_dns_list.yaml
@@ -1,0 +1,31 @@
+- vendor: Huawei
+  before: |
+    interface Vlanif333
+      dhcp server dns-list 1.1.1.1 2.2.2.2
+  after: |
+    interface Vlanif333
+  patch: |
+    system-view
+    interface Vlanif333
+      undo dhcp server dns-list 1.1.1.1
+      undo dhcp server dns-list 2.2.2.2
+      quit
+    q
+    save
+
+- vendor: Huawei
+  before: |
+    interface Vlanif333
+      dhcp server dns-list 1.1.1.1 2.2.2.2
+  after: |
+    interface Vlanif333
+      dhcp server dns-list 2.2.2.2 3.3.3.3
+  patch: |
+    system-view
+    interface Vlanif333
+      undo dhcp server dns-list 1.1.1.1
+      undo dhcp server dns-list 2.2.2.2
+      dhcp server dns-list 2.2.2.2 3.3.3.3
+      quit
+    q
+    save


### PR DESCRIPTION
Fix Huawei patch generation for removing multiple DNS servers configured with `dhcp server dns-list`.

Huawei does not accept a single `undo` command containing multiple DNS addresses.

Before:

```
interface Vlanif333
  undo dhcp server dns-list 1.1.1.1 2.2.2.2
```

After:

```
interface Vlanif333
  undo dhcp server dns-list 1.1.1.1
  undo dhcp server dns-list 2.2.2.2
```