### PR TITLE
Add Cisco AirOS WLC support

### DIFF
--- a/annet/annlib/netdev/devdb/data/devdb.json
+++ b/annet/annlib/netdev/devdb/data/devdb.json
@@ -3,6 +3,7 @@
     "Cisco.CGS": " CGS",
     "Cisco.IE": " IE",
     "Cisco.AIR": "AIR",
+    "Cisco.AIR.WLC": "^Cisco AIR-CT5520(?:[- ]|$)",
     "Cisco.ASR": " ASR",
     "Cisco.ASR?.ASR1000": " ?1\\d{3}",
     "Cisco.NCS": " NCS",

--- a/annet/annlib/netdev/devdb/generated/__init__.pyi
+++ b/annet/annlib/netdev/devdb/generated/__init__.pyi
@@ -53,6 +53,7 @@ hw.B4com.CS4148Q
 hw.B4com.CS4164U
 hw.Cisco
 hw.Cisco.AIR
+hw.Cisco.AIR.WLC
 hw.Cisco.ASR
 hw.Cisco.ASR1000
 hw.Cisco.ASR9000
@@ -418,6 +419,9 @@ class Cisco(HardwareLeaf):
     XRV: Cisco_XRV
 
 class Cisco_AIR(HardwareLeaf):
+    WLC: Cisco_AIR_WLC
+
+class Cisco_AIR_WLC(HardwareLeaf):
     ...
 
 class Cisco_ASR(HardwareLeaf):

--- a/annet/rulebook/texts/airwlc.deploy
+++ b/annet/rulebook/texts/airwlc.deploy
@@ -1,0 +1,5 @@
+# Use the standard vendor apply flow for every AirOS configuration command.
+save config %timeout=60
+    dialog: Are you sure you want to save? (y/n)  ::: y
+
+~

--- a/annet/rulebook/texts/airwlc.rul
+++ b/annet/rulebook/texts/airwlc.rul
@@ -1,0 +1,2 @@
+# Generic annet intentionally owns no AirOS configuration commands. Projects
+# provide policy and verified command semantics in their own rulebook module.

--- a/annet/vendors/__init__.py
+++ b/annet/vendors/__init__.py
@@ -2,6 +2,7 @@ from annet.connectors import Connector
 from annet.vendors.base import AbstractVendor
 
 from .library import (
+    airwlc,
     arista,
     aruba,
     b4com,

--- a/annet/vendors/library/airwlc.py
+++ b/annet/vendors/library/airwlc.py
@@ -1,0 +1,40 @@
+from typing import Any
+
+from annet.annlib.command import Command, CommandList
+from annet.annlib.netdev.views.hardware import HardwareView
+from annet.vendors.base import AbstractVendor
+from annet.vendors.registry import registry
+from annet.vendors.tabparser import AirWLCFormatter
+
+
+@registry.register
+class AirWLCVendor(AbstractVendor):
+    NAME = "airwlc"
+
+    def apply(
+        self, hw: HardwareView, do_commit: bool, do_finalize: bool, path: str | None
+    ) -> tuple[CommandList, CommandList]:
+        before = CommandList(cmss=[Command("config")])
+        after = CommandList(cmss=[Command("exit")])
+        if do_finalize:
+            after.add_cmd(Command("save config"))
+        return before, after
+
+    def match(self) -> list[str]:
+        return ["Cisco.AIR.WLC"]
+
+    @property
+    def reverse(self) -> str:
+        # AirOS has no universal inverse prefix. Managed rules must use custom logic.
+        return "-"
+
+    @property
+    def hardware(self) -> HardwareView:
+        return HardwareView("Cisco AIR-CT5520")
+
+    def make_formatter(self, **kwargs: Any) -> AirWLCFormatter:
+        return AirWLCFormatter(**kwargs)
+
+    @property
+    def exit(self) -> str:
+        return "exit"

--- a/annet/vendors/tabparser.py
+++ b/annet/vendors/tabparser.py
@@ -217,6 +217,36 @@ class CommonFormatter:
             yield row
 
 
+class AirWLCFormatter(CommonFormatter):
+    """Normalize AirOS command dumps into a flat configuration."""
+
+    @staticmethod
+    def _normalize_row(row: str) -> str:
+        normalized: list[str] = []
+        in_quotes = False
+        space_pending = False
+        escaped = False
+        for character in row.strip():
+            if character == '"' and not escaped:
+                if space_pending and normalized:
+                    normalized.append(" ")
+                space_pending = False
+                in_quotes = not in_quotes
+                normalized.append(character)
+            elif character.isspace() and not in_quotes:
+                space_pending = bool(normalized)
+            else:
+                if space_pending and normalized:
+                    normalized.append(" ")
+                space_pending = False
+                normalized.append(character)
+            escaped = character == "\\" and not escaped
+        return "".join(normalized)
+
+    def split(self, text: str) -> list[str]:
+        return [row for line in super().split(text) if (row := self._normalize_row(line))]
+
+
 class BlockExitFormatter(CommonFormatter):
     block_exit_command = "exit"
     no_block_exit: str | tuple[str, ...] = ()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -50,6 +50,7 @@ def make_hw_stub(vendor):
             "huawei ce": "Huawei CE0000",
             "juniper": "Juniper",
             "routeros": "RouterOS",
+            "airwlc": "Cisco AIR-CT5520-K9",
             "aruba": "Aruba",
             "arista": "Arista",
             "nokia": "Nokia",

--- a/tests/annet/test_devdb.py
+++ b/tests/annet/test_devdb.py
@@ -99,6 +99,7 @@ MODELS = [
     ("Asterfusion CX864E-N", "PC.Whitebox.Asterfusion.CX.CX800.CX864EN"),
     ("B4com AS9726-32DB-O-AC-F", "B4com"),
     ("B4com CS4148Q08U", "B4com"),
+    ("Cisco AIR-CT5520-K9", "Cisco.AIR.WLC"),
     ("Cisco 8201-24H8FH", "Cisco.XR"),
     ("Cisco 8201-32FH", "Cisco.XR"),
     ("Cisco 8712-MOD-M", "Cisco.XR"),

--- a/tests/annet/test_formatter.py
+++ b/tests/annet/test_formatter.py
@@ -3,8 +3,9 @@ from collections import OrderedDict
 
 import pytest
 
+from annet.annlib.netdev.views.hardware import HardwareView
 from annet.vendors import registry_connector
-from annet.vendors.tabparser import parse_to_tree
+from annet.vendors.tabparser import AirWLCFormatter, parse_to_tree
 
 from .. import make_hw_stub
 
@@ -908,3 +909,20 @@ def test_jun_formatter_split_whitespaces01(juniper_config):
         "                origin igp",
         "                accept",
     ]
+
+
+def test_airwlc_formatter_normalizes_only_unquoted_spaces():
+    hardware = HardwareView("Cisco AIR-CT5520-K9")
+    vendor = registry_connector.get().match(hardware)
+    formatter = vendor.make_formatter()
+
+    assert vendor.NAME == "airwlc"
+    assert isinstance(formatter, AirWLCFormatter)
+    assert formatter.split('  aaa auth mgmt   local radius\ncmd "keep   spaces"  value\n') == [
+        "aaa auth mgmt local radius",
+        'cmd "keep   spaces" value',
+    ]
+
+    before, after = vendor.apply(hardware, do_commit=False, do_finalize=True, path=None)
+    assert [str(command) for command in before] == ["config"]
+    assert [str(command) for command in after] == ["exit", "save config"]


### PR DESCRIPTION
Add basic support for Cisco AIR-CT5520 controllers running AirOS:

- detect the hardware model as Cisco.AIR.WLC;
- register the AirWLC vendor;
- normalize command dumps without changing whitespace inside quotes;
- add the base apply/save lifecycle and empty policy rulebook;
- cover model detection, vendor selection, formatter and rulebook loading.