### PR TITLE
Fix file-diff when local rulebooks are used

### DIFF
--- a/annet/api/__init__.py
+++ b/annet/api/__init__.py
@@ -935,7 +935,10 @@ def guess_hw(config_text: str) -> tuple[HardwareView, float]:
     vendor_registry = registry_connector.get()
     for vendor in vendor_registry:
         hw = hw_provider.vendor_to_hw(vendor)
-        rb = rulebook.get_rulebook(hw)
+        try:
+            rb = rulebook.get_rulebook(hw)
+        except FileNotFoundError:
+            continue
         fmtr = vendor_registry[vendor].make_formatter()
 
         try:

--- a/annet/api/__init__.py
+++ b/annet/api/__init__.py
@@ -935,10 +935,7 @@ def guess_hw(config_text: str) -> tuple[HardwareView, float]:
     vendor_registry = registry_connector.get()
     for vendor in vendor_registry:
         hw = hw_provider.vendor_to_hw(vendor)
-        try:
-            rb = rulebook.get_rulebook(hw)
-        except FileNotFoundError:
-            continue
+        rb = rulebook.get_rulebook(hw)
         fmtr = vendor_registry[vendor].make_formatter()
 
         try:

--- a/annet/rulebook/__init__.py
+++ b/annet/rulebook/__init__.py
@@ -244,9 +244,7 @@ class DefaultRulebookProvider(RulebookProvider):
         except RULEBOOK_READ_EXCEPTIONS as err:
             fallback_path = f"{self.DEFAULT_RULEBOOK_MODULE}.{name}"
             if fallback_path == rulebook_path:
-                raise FileNotFoundError(
-                    f'Unable to find rulebook "{name}" in "{module}" module'
-                ) from err
+                raise FileNotFoundError(f'Unable to find rulebook "{name}" in "{module}" module') from err
             return self._get_raw_rulebook_text(fallback_path, extension)
 
     @staticmethod

--- a/annet/rulebook/__init__.py
+++ b/annet/rulebook/__init__.py
@@ -236,13 +236,18 @@ class DefaultRulebookProvider(RulebookProvider):
         return self._rulebook_text_cache[key]
 
     def _get_raw_rulebook_text(self, rulebook_path: str, extension: Extension) -> AnyRulebookText:
-        """Gets the raw rulebook text"""
+        """Gets the raw rulebook text, if local rulebook is not found, try to find it in upstream rulebooks"""
         self.check_rulebook_path(rulebook_path)
         module, name = rulebook_path.rsplit(".", 1)
         try:
             return resources.files(module).joinpath(f"{name}.{extension}").read_text(encoding="utf-8")
         except RULEBOOK_READ_EXCEPTIONS as err:
-            raise FileNotFoundError(f'Unable to find rulebook "{name}" in "{self.rulebook_module}" module') from err
+            fallback_path = f"{self.DEFAULT_RULEBOOK_MODULE}.{name}"
+            if fallback_path == rulebook_path:
+                raise FileNotFoundError(
+                    f'Unable to find rulebook "{name}" in "{module}" module'
+                ) from err
+            return self._get_raw_rulebook_text(fallback_path, extension)
 
     @staticmethod
     def _escape_mako(text: str) -> str:


### PR DESCRIPTION
If try to use file-diff with vendor auto-guessing (without explicit --hw option) while local rulebooks is exist, Annet would try to find all rulebooks in folder, and it cause an exception:

```
  File "/Users/anteron/annet-mws/.venv/lib/python3.12/site-packages/annet/rulebook/__init__.py", line 246, in _get_raw_rulebook_text
    raise FileNotFoundError(f'Unable to find rulebook "{name}" in "{self.rulebook_module}" module') from err
FileNotFoundError: Unable to find rulebook "arista" in "rulebooks.texts" module
```

Now I propose to search rulebooks in first of all in local rulebooks then in global