### PR TITLE
fix: reuse filter ACL for multiple devices

### DIFF
--- a/annet/cli_args.py
+++ b/annet/cli_args.py
@@ -362,6 +362,14 @@ class GenOptions(QueryOptions, GenSelectOptions, CacheOptions, ParallelOptions):
     strict_exit_code = opt_strict_exit_code
     fail_on_empty_config = opt_fail_on_empty_config
 
+    def stdin(self, **kwargs: str | None) -> dict[str, str | None]:
+        ret = super().stdin(**kwargs)
+        filter_acl = kwargs.get("filter_acl")
+        if filter_acl and filter_acl != "-" and not os.path.isdir(filter_acl):
+            with open(filter_acl) as filter_acl_file:
+                ret["filter_acl"] = filter_acl_file.read()
+        return ret
+
 
 class TransportOptions(ArgGroup):
     ask_pass = opt_ask_pass

--- a/annet/gen.py
+++ b/annet/gen.py
@@ -624,7 +624,7 @@ def build_filter_text(
     if args.filter_acl:
         assert stdin is not None
         filter_acl_text = stdin["filter_acl"]
-        if not filter_acl_text:
+        if filter_acl_text is None:
             if os.path.isdir(args.filter_acl):
                 filename = os.path.join(config, "%s.acl" % device.hostname)
             else:

--- a/tests/annet/test_filter_acl.py
+++ b/tests/annet/test_filter_acl.py
@@ -1,10 +1,16 @@
+import os
 import textwrap
+from unittest.mock import MagicMock
 
 import pytest
 
 import annet.annlib.filter_acl
 import annet.annlib.patching
+from annet.cli_args import GenOptions
+from annet.filtering import Filterer
+from annet.gen import build_filter_text
 from annet.rulebook.patching import compile_patching_text
+from annet.storage import Device
 from annet.vendors import registry_connector, tabparser
 
 
@@ -34,6 +40,29 @@ def test_filter_diff():
     -   foo bar
     """).strip()
     )
+
+
+def test_filter_acl_stream_is_reused():
+    filter_acl_text = "bgp *\n  address-family ~\n    balance *\n"
+    read_fd, write_fd = os.pipe()
+    os.write(write_fd, filter_acl_text.encode())
+    os.close(write_fd)
+
+    args = object.__new__(GenOptions)
+    args.filter_acl = f"/dev/fd/{read_fd}"
+    args.filter_ifaces = ""
+    args.filter_peers = ""
+    args.filter_policies = ""
+    stdin = args.stdin(filter_acl=args.filter_acl, config=None)
+
+    try:
+        first = build_filter_text(MagicMock(spec=Filterer), MagicMock(spec=Device), stdin, args, "running")
+        second = build_filter_text(MagicMock(spec=Filterer), MagicMock(spec=Device), stdin, args, "running")
+    finally:
+        os.close(read_fd)
+
+    assert first == filter_acl_text
+    assert second == filter_acl_text
 
 
 def test_ordered_and_filter_acl():


### PR DESCRIPTION
Fixes #652. --filter-acl streams are now read once and reused for all devices, while per-device ACL directories keep their existing behavior.