### PR TITLE
pass patchtree instead of text to `filter_patch` 

### DIFF
--- a/annet/annlib/filter_acl.py
+++ b/annet/annlib/filter_acl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import collections
+import copy
 import re
 from typing import Any, TypeAlias, overload
 
@@ -67,8 +68,22 @@ def filter_diff(acl: Acl, fmtr: tabparser.CommonFormatter, input_config: InputCo
     return config
 
 
-def filter_patch(acl: Acl, fmtr: tabparser.CommonFormatter, text: str) -> str:
-    return filter_config(acl, fmtr, text)
+def filter_patch(acl: Acl, patch: patching.PatchTree) -> patching.PatchTree:
+    filtered = patching.PatchTree()
+    for source_item in patch.itms:
+        match, children_acl = patching.match_row_to_acl(source_item.row, acl)
+        if match is None or match["is_reverse"] and all(match["attrs"]["cant_delete"]):
+            continue
+
+        item = copy.deepcopy(source_item)
+        if item.child:
+            assert children_acl is not None
+            filtered_child = filter_patch(children_acl, item.child)
+            if not filtered_child:
+                continue
+            item.child = filtered_child
+        filtered.itms.append(item)
+    return filtered
 
 
 # NOCDEV-6378 filter_acl cannot be applied to a Juniper/Nokia patch as-is

--- a/tests/annet/test_filter_acl.py
+++ b/tests/annet/test_filter_acl.py
@@ -1,3 +1,4 @@
+import copy
 import textwrap
 
 import pytest
@@ -6,6 +7,79 @@ import annet.annlib.filter_acl
 import annet.annlib.patching
 from annet.rulebook.patching import compile_patching_text
 from annet.vendors import registry_connector, tabparser
+
+
+def test_filter_patch_preserves_patch_tree_metadata_and_empty_children():
+    patch = annet.annlib.patching.PatchTree()
+    patch.add("service users", {"origin": "first"}, (2, "first"))
+    patch.add("service users", {"origin": "second"}, (1, "second"))
+    patch.add_block("empty-block", context={"origin": "empty"}, sort_key=(3, "empty"))
+
+    kept_children = patch.add_block("interface Ethernet1", context={"origin": "kept"}, sort_key=(4, "kept"))
+    kept_children.add("description users", {"origin": "description"}, (4, "description"))
+    kept_children.add("name legacy", {"origin": "name"}, (4, "name"))
+
+    dropped_children = patch.add_block("interface Ethernet2", context={"origin": "dropped"}, sort_key=(5, "dropped"))
+    dropped_children.add("name legacy", {"origin": "name"}, (5, "name"))
+
+    original = copy.deepcopy(patch.to_json())
+    acl = annet.annlib.filter_acl.make_acl("service *\nempty-block\ninterface *\n description *", "huawei")
+
+    filtered = annet.annlib.filter_acl.filter_patch(acl, patch)
+
+    assert patch.to_json() == original
+    assert filtered is not patch
+    assert [item.row for item in filtered.itms] == [
+        "service users",
+        "service users",
+        "empty-block",
+        "interface Ethernet1",
+    ]
+    assert [item.context for item in filtered.itms[:2]] == [{"origin": "first"}, {"origin": "second"}]
+    assert [item.sort_key for item in filtered.itms[:2]] == [(2, "first"), (1, "second")]
+    assert filtered.itms[0] is not patch.itms[0]
+    assert filtered.itms[0].child is None
+    assert filtered.itms[2].child is not None
+    assert not filtered.itms[2].child
+    assert filtered.itms[3].child is not None
+    assert [(item.row, item.context, item.sort_key) for item in filtered.itms[3].child.itms] == [
+        ("description users", {"origin": "description"}, (4, "description"))
+    ]
+
+
+def test_filter_patch_drops_reverse_cant_delete_parent_when_every_child_is_filtered():
+    patch = annet.annlib.patching.PatchTree()
+    children = patch.add_block("interface Ethernet1")
+    children.add("undo description legacy", {})
+    acl = annet.annlib.filter_acl.make_acl("interface *\n description * %cant_delete=1", "huawei")
+
+    assert not annet.annlib.filter_acl.filter_patch(acl, patch)
+
+
+@pytest.mark.parametrize(
+    "vendor, parent, acl_text, expected",
+    (
+        ("huawei", "vlan 10", "vlan *\n description *", "vlan 10\n  description users\n  quit"),
+        (
+            "cisco",
+            "interface Ethernet1",
+            "interface *\n description *",
+            "interface Ethernet1\n  description users\n  exit",
+        ),
+    ),
+)
+def test_filter_patch_keeps_formatter_closing_commands(vendor, parent, acl_text, expected):
+    patch = annet.annlib.patching.PatchTree()
+    children = patch.add_block(parent, context={}, sort_key=(0,))
+    children.add("description users", {}, (0,))
+
+    filtered = annet.annlib.filter_acl.filter_patch(
+        annet.annlib.filter_acl.make_acl(acl_text, vendor),
+        patch,
+    )
+
+    formatter = registry_connector.get()[vendor].make_formatter()
+    assert formatter.patch(filtered) == expected
 
 
 def test_filter_diff():


### PR DESCRIPTION
`filter_patch` was an alias for `filter_config`
Now it accepts a patchtree instead of text, and returns a patchtree as well.
This patchtree can be passed to `formatter.patch()` to get the proper patch text (with block exit commands, even if they are filtered out by ACL).
