### PR TITLE
Fix H3C VLAN range patching

### DIFF
--- a/annet/rulebook/h3c/vlandb.py
+++ b/annet/rulebook/h3c/vlandb.py
@@ -1,12 +1,12 @@
-from collections import OrderedDict as odict
 from collections.abc import Iterator
 from typing import Any, cast
 
 from annet.annlib.lib import huawei_collapse_vlandb as collapse_vlandb
 from annet.annlib.lib import huawei_expand_vlandb as expand_vlandb
 from annet.annlib.types import Op
-from annet.rulebook import common
-from annet.rulebook.common import DiffItem
+
+
+_DEFAULT_VLAN_ID = 1
 
 
 # =====
@@ -28,38 +28,32 @@ def multi_all(
     yield from _process_vlandb(rule, key, diff, True, True, 10)
 
 
-def vlan_diff(
-    old: odict[str, Any], new: odict[str, Any], diff_pre: odict[str, Any], _pops: tuple[str, ...]
-) -> list[DiffItem]:
-    batch_new = set()  # vlan batch ... vlan ids
-    for row in new:
-        prefix, vlans = _parse_vlancfg(row)
-        if prefix == "vlan batch":
-            batch_new.update(vlans)
-    ret = []
-    for item in common.default_diff(old, new, diff_pre, _pops):
-        prefix, vlan_ids = _parse_vlancfg(item.row)
-        # If a VLAN was declared globally and still remains in the batch,
-        # the command "undo vlan ..." will attempt to completely remove it from the device
-        # as well as from the batch. However, using "undo vlan ... ; vlan batch ..." is not a solution,
-        # since to delete it, the CLI requires removing all VLAN interfaces and related elements first.
+def global_vlan(
+    rule: dict[str, Any], key: tuple[str, ...], diff: dict[str, list[dict[str, Any]]], **_: Any
+) -> Iterator[tuple[bool, str, Any]]:
+    """Patch global VLAN declarations by ID while preserving VLAN blocks."""
+    # Required callback arguments; this logic derives commands from diff alone.
+    del rule, key
+    for affected in diff[Op.AFFECTED]:
+        if affected["children"]:
+            yield (True, affected["row"], affected["children"])
 
-        if prefix == "vlan" and item.op == Op.REMOVED and batch_new.intersection(vlan_ids):
-            result_item = DiffItem(Op.AFFECTED, item.row, item.children, item.diff_pre)
-        # If a VLAN is declared both globally and in the batch,
-        # and the global declaration block has no additional options,
-        # we don’t include it — it would just hang there unnecessarily.
-        # This way, we preserve symmetry with the previous logic,
-        # and both invariants will produce an empty patch.
+    new, new_blocks = _parse_global_vlan_actions(diff[Op.ADDED])
+    old, old_blocks = _parse_global_vlan_actions(diff[Op.REMOVED])
 
-        elif prefix == "vlan" and batch_new.intersection(vlan_ids) and not item.children:
-            result_item = None
-        # We don’t touch "vlan batch" or anything else.
-        else:
-            result_item = item
-        if result_item:
-            ret.append(result_item)
-    return ret
+    for vlan_id in (old_blocks.keys() - new_blocks.keys()) & new:
+        yield (True, f"vlan {vlan_id}", old_blocks[vlan_id])
+
+    removed = old - new
+    added = (new - old) - new_blocks.keys()
+    # VLAN 1 is the system default and H3C does not allow it to be deleted.
+    for vlan_id in sorted(removed - {_DEFAULT_VLAN_ID}):
+        yield (False, f"undo vlan {vlan_id}", None)
+    for vlan_id in sorted(added):
+        yield (True, f"vlan {vlan_id}", None)
+
+    for vlan_id, block in new_blocks.items():
+        yield (True, f"vlan {vlan_id}", block)
 
 
 # =====
@@ -115,6 +109,19 @@ def _parse_vlancfg_actions(actions: list[dict[str, Any]]) -> tuple[str | None, s
     return (prefix, vlandb)
 
 
+def _parse_global_vlan_actions(actions: list[dict[str, Any]]) -> tuple[set[int], dict[int, Any]]:
+    vlan_ids: set[int] = set()
+    blocks: dict[int, Any] = {}
+    for action in actions:
+        prefix, row_ids = _parse_vlancfg(action["row"])
+        assert prefix == "vlan", action["row"]
+        if action["children"]:
+            assert len(row_ids) == 1, f"VLAN block must contain one VLAN ID: {action['row']}"
+            blocks[next(iter(row_ids))] = action["children"]
+        vlan_ids.update(row_ids)
+    return vlan_ids, blocks
+
+
 def _parse_vlancfg(row: str) -> tuple[str, set[int]]:
     parts = row.split()
     assert len(parts) > 0, row
@@ -125,13 +132,3 @@ def _parse_vlancfg(row: str) -> tuple[str, set[int]]:
     prefix = " ".join(parts[: index + 1])
     vlandb = expand_vlandb(" ".join(parts[index + 1 :]))
     return (prefix, vlandb)
-
-
-def _find_new_vlans(root_pre: dict[str, Any]) -> set[int]:
-    ret: set[int] = set()
-    for rule, pre in root_pre.items():
-        if not rule.startswith("vlan batch"):
-            continue
-        new = _parse_vlancfg_actions(pre["items"][tuple()][Op.ADDED])[1]
-        ret.update(new)
-    return ret

--- a/annet/rulebook/texts/h3c.order
+++ b/annet/rulebook/texts/h3c.order
@@ -2,8 +2,7 @@
 # This file defines the order in which the commands should be sent to the device.
 # - If the order of a command does not matter - it can be left out of this file entirely.
 # - If a command starts with undo and the %order_reverse parameter is set, the command is treated
-#   as a reverse one, but takes its place among the direct ones where specified (i.e. undo vlan batch
-#   will come after the interface blocks).
+#   as a reverse one, but takes its place among the direct ones where specified.
 
 sysname
 
@@ -379,7 +378,6 @@ undo drop-profile %order_reverse
 
 # vlans are removed after vlanif/subif
 undo vlan %order_reverse
-undo vlan batch %order_reverse
 undo observe-port %order_reverse
 
 #sflow may be attached to a subif/eth-trunk

--- a/annet/rulebook/texts/h3c.rul
+++ b/annet/rulebook/texts/h3c.rul
@@ -84,9 +84,7 @@ system tcam acl
 
 vlan reserved ~
 
-vlan batch  %diff_logic=annet.rulebook.h3c.vlandb.vlan_diff %logic=annet.rulebook.h3c.vlandb.multi
-
-vlan */\d+/ %diff_logic=annet.rulebook.h3c.vlandb.vlan_diff
+?/vlan [0-9]+(?: to [0-9]+)?$/ %logic=annet.rulebook.h3c.vlandb.global_vlan
     name
 
 vlan pool *

--- a/tests/annet/test_patch/h3c_vlandb_ranges.yaml
+++ b/tests/annet/test_patch/h3c_vlandb_ranges.yaml
@@ -1,0 +1,87 @@
+- name: remove only absent id from collapsed range
+  vendor: h3c
+  diff: |
+    vlan 1
+    - vlan 1000 to 1001
+    + vlan 1000
+  patch: |
+    system-view
+    undo vlan 1001
+    save force
+
+- name: add only new id to collapsed range
+  vendor: h3c
+  diff: |
+    vlan 1
+    - vlan 1000
+    + vlan 1000 to 1001
+  patch: |
+    system-view
+    vlan 1001
+      quit
+    save force
+
+- name: preserve individual vlan child behavior
+  vendor: h3c
+  diff: |
+    vlan 1000
+      - name OLD
+      + name SERVERS
+  patch: |
+    system-view
+    vlan 1000
+      name SERVERS
+      quit
+    save force
+
+- name: create range with individual commands
+  vendor: h3c
+  before: ""
+  after: |
+    vlan 1000 to 1002
+  patch: |
+    system-view
+    vlan 1000
+      quit
+    vlan 1001
+      quit
+    vlan 1002
+      quit
+    save force
+
+- name: reconcile mixed singleton and range rows
+  vendor: h3c
+  before: |
+    vlan 1
+    vlan 1000 to 1001
+    vlan 1003
+    vlan 1005 to 1006
+    vlan 2000
+  after: |
+    vlan 1
+    vlan 1000 to 1002
+    vlan 1005
+    vlan 2000 to 2001
+  patch: |
+    system-view
+    vlan 1002
+      quit
+    vlan 2001
+      quit
+    undo vlan 1003
+    undo vlan 1006
+    save force
+
+- name: never remove default vlan one
+  vendor: h3c
+  before: |
+    vlan 1
+    vlan 1000 to 1001
+    vlan 1003
+  after: ""
+  patch: |
+    system-view
+    undo vlan 1000
+    undo vlan 1001
+    undo vlan 1003
+    save force


### PR DESCRIPTION
## Summary

- Parse H3C `vlan <id>` and `vlan <start> to <end>` rows as one VLAN-ID set.
- Emit one add/remove command per changed VLAN.
- Never generate `undo vlan 1`.
- Remove unsupported Huawei-style `vlan batch` rules and ordering from H3C.

## Problem

For:

```text
vlan 1000 to 1001
→ vlan 1000
```

the old logic generated:

```
vlan 1000
```
This did not remove VLAN 1001.

It now generates:
```
undo vlan 1001
```
Creating:
```
vlan 1000 to 1002
```
now produces explicit commands:
```
vlan 1000
vlan 1001
vlan 1002
```
If the desired configuration omits all VLANs while the device has:
```
vlan 1
vlan 1000 to 1001
vlan 1003
```
the patch removes only:
```
undo vlan 1000
undo vlan 1001
undo vlan 1003
```
VLAN 1 is always preserved.

Verification

- 6 focused H3C VLAN regression tests passed.
- Full upstream suite: 1,551 tests passed.
- Ruff, Flake8, and Mypy passed.