### PR TITLE
Add range-aware VLAN patching for Arista

### DIFF
--- a/annet/rulebook/cisco/vlandb.py
+++ b/annet/rulebook/cisco/vlandb.py
@@ -1,14 +1,12 @@
-import re
 from collections.abc import Iterator
 from typing import Any
 
 from annet.annlib.lib import cisco_collapse_vlandb as collapse_vlandb
-from annet.annlib.lib import cisco_expand_vlandb as expand_vlandb
 from annet.annlib.netdev.views.hardware import HardwareView
 from annet.annlib.types import Op
+from annet.rulebook.generic import vlandb as generic_vlandb
 
 
-VLANDB_CHUNK = 15
 SWTRUNK_CHUNK = 5
 
 
@@ -16,35 +14,29 @@ SWTRUNK_CHUNK = 5
 def simple(
     rule: dict[str, Any], key: tuple[str, ...], diff: dict[str, list[dict[str, Any]]], hw: HardwareView, **_: Any
 ) -> Iterator[tuple[bool, str, Any]]:
-    yield from _process_vlandb(rule, key, diff, hw, False, VLANDB_CHUNK)
+    yield from generic_vlandb.simple(
+        rule,
+        key,
+        diff,
+        tiny_ranges=bool(hw.Cisco.Catalyst),
+        exclude_added_blocks=bool(hw.Cisco.Catalyst),
+    )
 
 
 def swtrunk(
     rule: dict[str, Any], key: tuple[str, ...], diff: dict[str, list[dict[str, Any]]], hw: HardwareView, **_: Any
-) -> Iterator[tuple[bool, str, Any]]:
-    yield from _process_vlandb(rule, key, diff, hw, True, SWTRUNK_CHUNK)
-
-
-# =====
-def _process_vlandb(
-    rule: dict[str, Any],
-    key: tuple[str, ...],
-    diff: dict[str, list[dict[str, Any]]],
-    hw: HardwareView,
-    explicit_changing: bool,
-    multi_chunk: int,
 ) -> Iterator[tuple[bool, str, Any]]:
     # pylint: disable=unused-argument
     for affected in diff[Op.AFFECTED]:
         # The contents of the vlan block have changed
         yield (True, affected["row"], affected["children"])
 
-    (prefix, new, new_blocks) = _parse_vlancfg_actions(diff[Op.ADDED])
-    (prefix2, old, old_blocks) = _parse_vlancfg_actions(diff[Op.REMOVED])
+    (prefix, new, _new_blocks) = generic_vlandb.parse_actions(diff[Op.ADDED])
+    (prefix2, old, _old_blocks) = generic_vlandb.parse_actions(diff[Op.REMOVED])
     if not prefix:
         prefix = prefix2
 
-    if explicit_changing and not new:
+    if not new:
         if diff[Op.ADDED] and not diff[Op.UNCHANGED]:
             # switchport trunk allowed vlan none
             yield (True, "%s none" % prefix, None)
@@ -54,68 +46,18 @@ def _process_vlandb(
             yield (False, "no %s" % prefix, None)
             return
 
-    for vlan_id in (set(old_blocks.keys()) - set(new_blocks)) & new:
-        # The contents of the vlan block were removed, but the vlan itself is still there
-        yield (True, "%s %s" % (prefix, vlan_id), old_blocks[vlan_id])
-
     removed = old.difference(new)
     added = new.difference(old)
-    if hw.Cisco.Catalyst:
-        # Catalysts do not list vlans in batch mode if they are represented as blocks
-        added -= new_blocks.keys()
-
     if removed:
         collapsed = collapse_vlandb(removed, bool(hw.Cisco.Catalyst))
-        for chunk in _chunked(collapsed, multi_chunk):
-            if explicit_changing:
-                yield (True, "%s%s%s" % (prefix, " remove ", ",".join(chunk)), None)
-            else:
-                yield (False, "no %s%s%s" % (prefix, " ", ",".join(chunk)), None)
+        for chunk in generic_vlandb.iter_chunks(collapsed, SWTRUNK_CHUNK):
+            yield (True, "%s%s%s" % (prefix, " remove ", ",".join(chunk)), None)
 
     if added:
         collapsed = collapse_vlandb(added, bool(hw.Cisco.Catalyst))
-        if explicit_changing and not old:
+        if not old:
             # by default all vlans are allowed
             # switchport trunk allowed vlan none
             yield (True, "%s none" % prefix, None)
-        for chunk in _chunked(collapsed, multi_chunk):
-            if explicit_changing:
-                yield (True, "%s%s%s" % (prefix, " add ", ",".join(chunk)), None)
-            else:
-                yield (True, "%s%s%s" % (prefix, " ", ",".join(chunk)), None)
-
-    if new_blocks:
-        for vlan_id, block in new_blocks.items():
-            yield (True, "%s %s" % (prefix, vlan_id), block)
-
-
-def _chunked(items: list[str], size: int) -> Iterator[list[str]]:
-    for offset in range(0, len(items), size):
-        yield items[offset : offset + size]
-
-
-def _parse_vlancfg_actions(actions: list[dict[str, Any]]) -> tuple[str | None, set[int], dict[int, Any]]:
-    prefix = None
-    vlandb: set[int] = set()
-    blocks: dict[int, Any] = {}
-    for action in actions:
-        (prefix, part) = _parse_vlancfg(action["row"])
-        if action["children"]:
-            assert len(part) == 1, "vlandb block must contain one and only one vlanid: %s" % action["row"]
-            blocks[list(part)[0]] = action["children"]
-        vlandb.update(part)
-    return (prefix, vlandb, blocks)
-
-
-def _parse_vlancfg(row: str) -> tuple[str, set[int]]:
-    # sometimes ciscos put spaces between vlan ranges, and sometimes they do not.
-    words = re.sub(r",\s+", ",", row).split()
-
-    if words[-1] == "none":
-        # switchport trunk allowed vlan none
-        return (" ".join(words[:-1]), set())
-    assert re.match(r"[\d,-]+$", words[-1]), "Unable to parse vlancfg row: %s" % row
-    prefix = " ".join(words[:-2] if words[-2] == "add" else words[:-1])
-    vlancfg = words[-1]
-    vlandb = expand_vlandb(vlancfg)
-    return (prefix, vlandb)
+        for chunk in generic_vlandb.iter_chunks(collapsed, SWTRUNK_CHUNK):
+            yield (True, "%s%s%s" % (prefix, " add ", ",".join(chunk)), None)

--- a/annet/rulebook/generic/vlandb.py
+++ b/annet/rulebook/generic/vlandb.py
@@ -1,0 +1,107 @@
+"""Shared patch logic for comma-separated VLAN databases with dash ranges."""
+
+import re
+from collections.abc import Iterator
+from typing import Any
+
+from annet.annlib.lib import cisco_collapse_vlandb, cisco_expand_vlandb
+from annet.annlib.types import Op
+
+
+VLANDB_CHUNK = 15
+
+
+def simple_ranges(
+    rule: dict[str, Any], key: tuple[str, ...], diff: dict[str, list[dict[str, Any]]], **_: Any
+) -> Iterator[tuple[bool, str, Any]]:
+    """Patch a VLAN database, collapsing adjacent pairs into ranges.
+
+    For example, ``1000,1001,1003`` becomes ``1000-1001,1003``.
+    """
+    yield from simple(rule, key, diff, tiny_ranges=True, exclude_added_blocks=False)
+
+
+def simple_no_tiny_ranges(
+    rule: dict[str, Any], key: tuple[str, ...], diff: dict[str, list[dict[str, Any]]], **_: Any
+) -> Iterator[tuple[bool, str, Any]]:
+    """Patch a VLAN database without folding two-ID runs inside larger lists.
+
+    For example, ``1000,1001,1003`` stays ``1000,1001,1003``, while
+    ``1000,1001,1002,1004`` becomes ``1000-1002,1004``.
+    """
+    yield from simple(rule, key, diff, tiny_ranges=False, exclude_added_blocks=False)
+
+
+def simple(
+    rule: dict[str, Any],
+    key: tuple[str, ...],
+    diff: dict[str, list[dict[str, Any]]],
+    *,
+    tiny_ranges: bool,
+    exclude_added_blocks: bool,
+) -> Iterator[tuple[bool, str, Any]]:
+    """Patch one ordinary VLAN database by comparing expanded VLAN IDs."""
+    # pylint: disable=unused-argument
+    for affected in diff[Op.AFFECTED]:
+        yield (True, affected["row"], affected["children"])
+
+    (prefix, new, new_blocks) = parse_actions(diff[Op.ADDED])
+    (prefix2, old, old_blocks) = parse_actions(diff[Op.REMOVED])
+    if not prefix:
+        prefix = prefix2
+
+    for vlan_id in (set(old_blocks.keys()) - set(new_blocks)) & new:
+        # The contents of the vlan block were removed, but the vlan itself is still there
+        yield (True, "%s %s" % (prefix, vlan_id), old_blocks[vlan_id])
+
+    removed = old.difference(new)
+    added = new.difference(old)
+    if exclude_added_blocks:
+        # Catalysts do not list vlans in batch mode if they are represented as blocks
+        added -= new_blocks.keys()
+
+    if removed:
+        collapsed = cisco_collapse_vlandb(removed, tiny_ranges)
+        for chunk in iter_chunks(collapsed, VLANDB_CHUNK):
+            yield (False, "no %s%s%s" % (prefix, " ", ",".join(chunk)), None)
+
+    if added:
+        collapsed = cisco_collapse_vlandb(added, tiny_ranges)
+        for chunk in iter_chunks(collapsed, VLANDB_CHUNK):
+            yield (True, "%s%s%s" % (prefix, " ", ",".join(chunk)), None)
+
+    if new_blocks:
+        for vlan_id, block in new_blocks.items():
+            yield (True, "%s %s" % (prefix, vlan_id), block)
+
+
+def iter_chunks(items: list[str], size: int) -> Iterator[list[str]]:
+    for offset in range(0, len(items), size):
+        yield items[offset : offset + size]
+
+
+def parse_actions(actions: list[dict[str, Any]]) -> tuple[str | None, set[int], dict[int, Any]]:
+    prefix = None
+    vlandb: set[int] = set()
+    blocks: dict[int, Any] = {}
+    for action in actions:
+        (prefix, part) = parse_row(action["row"])
+        if action["children"]:
+            assert len(part) == 1, "vlandb block must contain one and only one vlanid: %s" % action["row"]
+            blocks[list(part)[0]] = action["children"]
+        vlandb.update(part)
+    return (prefix, vlandb, blocks)
+
+
+def parse_row(row: str) -> tuple[str, set[int]]:
+    # sometimes ciscos put spaces between vlan ranges, and sometimes they do not.
+    words = re.sub(r",\s+", ",", row).split()
+
+    if words[-1] == "none":
+        # switchport trunk allowed vlan none
+        return (" ".join(words[:-1]), set())
+    assert re.match(r"[\d,-]+$", words[-1]), "Unable to parse vlancfg row: %s" % row
+    prefix = " ".join(words[:-2] if words[-2] == "add" else words[:-1])
+    vlancfg = words[-1]
+    vlandb = cisco_expand_vlandb(vlancfg)
+    return (prefix, vlandb)

--- a/annet/rulebook/texts/arista.rul
+++ b/annet/rulebook/texts/arista.rul
@@ -15,6 +15,10 @@ role *
     ~ %global
 
 
+?/vlan [0-9][0-9,-]*$/ %logic=annet.rulebook.generic.vlandb.simple_ranges
+    name
+
+
 vrf instance *
     ~ %global
 

--- a/annet/rulebook/texts/asterfusioncli.rul
+++ b/annet/rulebook/texts/asterfusioncli.rul
@@ -36,7 +36,7 @@ tacacs ~
 
 ip route ~
 
-vlan * %logic=annet.rulebook.cisco.vlandb.simple
+vlan * %logic=annet.rulebook.generic.vlandb.simple_no_tiny_ranges
     name *
     description *
     isolate enable

--- a/annet/rulebook/texts/iosxr.rul
+++ b/annet/rulebook/texts/iosxr.rul
@@ -21,9 +21,9 @@ ip community-list standard ~
 !vrf context management
 vrf context *
 
-vlan group * vlan-list %logic=annet.rulebook.cisco.vlandb.simple
+vlan group * vlan-list %logic=annet.rulebook.generic.vlandb.simple_no_tiny_ranges
 vlan */[^\d].*/
-vlan %logic=annet.rulebook.cisco.vlandb.simple
+vlan %logic=annet.rulebook.generic.vlandb.simple_no_tiny_ranges
     name
 
 ip ssh version 2 %logic=annet.rulebook.cisco.misc.ssh_key

--- a/annet/rulebook/texts/nexus.rul
+++ b/annet/rulebook/texts/nexus.rul
@@ -16,9 +16,9 @@ ip community-list standard ~
 !vrf context management
 vrf context *
 
-vlan group * vlan-list %logic=annet.rulebook.cisco.vlandb.simple
+vlan group * vlan-list %logic=annet.rulebook.generic.vlandb.simple_no_tiny_ranges
 vlan */[^\d].*/
-vlan %logic=annet.rulebook.cisco.vlandb.simple
+vlan %logic=annet.rulebook.generic.vlandb.simple_no_tiny_ranges
     name
 
 ip ssh version 2 %logic=annet.rulebook.cisco.misc.ssh_key

--- a/tests/annet/test_generic_vlandb.py
+++ b/tests/annet/test_generic_vlandb.py
@@ -1,0 +1,58 @@
+from collections import OrderedDict
+from typing import Any
+
+from annet.annlib.types import Op
+from annet.rulebook.generic import vlandb
+
+
+def _diff(
+    *,
+    added: tuple[tuple[str, OrderedDict[str, Any]], ...] = (),
+    removed: tuple[tuple[str, OrderedDict[str, Any]], ...] = (),
+    affected: tuple[tuple[str, OrderedDict[str, Any]], ...] = (),
+) -> dict[str, list[dict[str, Any]]]:
+    return {
+        Op.ADDED: [{"row": row, "children": children} for row, children in added],
+        Op.REMOVED: [{"row": row, "children": children} for row, children in removed],
+        Op.AFFECTED: [{"row": row, "children": children} for row, children in affected],
+        Op.MOVED: [],
+        Op.UNCHANGED: [],
+    }
+
+
+def test_simple_ranges_collapses_adjacent_pair():
+    diff = _diff(
+        added=(("vlan 1000", OrderedDict()), ("vlan 1001", OrderedDict())),
+    )
+
+    assert list(vlandb.simple_ranges({}, (), diff)) == [(True, "vlan 1000-1001", None)]
+
+
+def test_simple_no_tiny_ranges_splits_pair_inside_disjoint_list():
+    diff = _diff(
+        removed=(("vlan 1000", OrderedDict()), ("vlan 1001", OrderedDict()), ("vlan 1003", OrderedDict())),
+    )
+
+    assert list(vlandb.simple_no_tiny_ranges({}, (), diff)) == [(False, "no vlan 1000,1001,1003", None)]
+
+
+def test_simple_preserves_affected_vlan_children():
+    children = OrderedDict({"name SERVERS": OrderedDict()})
+    diff = _diff(affected=(("vlan 1000", children),))
+
+    assert list(vlandb.simple_ranges({}, (), diff)) == [(True, "vlan 1000", children)]
+
+
+def test_simple_can_exclude_new_vlan_blocks_from_plain_additions():
+    children = OrderedDict({"name SERVERS": OrderedDict()})
+    diff = _diff(added=(("vlan 1000", children),))
+
+    assert list(
+        vlandb.simple(
+            {},
+            (),
+            diff,
+            tiny_ranges=True,
+            exclude_added_blocks=True,
+        )
+    ) == [(True, "vlan 1000", children)]

--- a/tests/annet/test_patch/arista_vlandb.yaml
+++ b/tests/annet/test_patch/arista_vlandb.yaml
@@ -1,0 +1,49 @@
+- name: remove only absent id from collapsed range
+  vendor: arista
+  diff: |
+    - vlan 1000-1001,1003
+    + vlan 1000-1001
+  patch: |
+    conf s
+    no vlan 1003
+    commit
+    write memory
+
+- name: add only new id to collapsed range
+  vendor: arista
+  diff: |
+    - vlan 1000-1001
+    + vlan 1000-1002
+  patch: |
+    conf s
+    vlan 1002
+      exit
+    commit
+    write memory
+
+- name: collapse disjoint additions and removals
+  vendor: arista
+  diff: |
+    - vlan 10-11,20
+    + vlan 10,30-31,40
+  patch: |
+    conf s
+    no vlan 11,20
+    vlan 30-31,40
+      exit
+    commit
+    write memory
+
+- name: preserve individual vlan child behavior
+  vendor: arista
+  diff: |
+    vlan 1000
+      - name OLD
+      + name SERVERS
+  patch: |
+    conf s
+    vlan 1000
+      name SERVERS
+      exit
+    commit
+    write memory

--- a/tests/annet/test_rulebooks/test_rulebooks.py
+++ b/tests/annet/test_rulebooks/test_rulebooks.py
@@ -17,3 +17,23 @@ def test_rulebooks(vendor):
     """
     hw = make_hw_stub(vendor)
     rulebook.get_rulebook(hw)
+
+
+@pytest.mark.parametrize(
+    ("vendor", "rule_prefix", "expected_module", "expected_name"),
+    [
+        ("arista", "?/vlan ", "annet.rulebook.generic.vlandb", "simple_ranges"),
+        ("cisco", "vlan %logic", "annet.rulebook.cisco.vlandb", "simple"),
+        ("nexus", "vlan %logic", "annet.rulebook.generic.vlandb", "simple_no_tiny_ranges"),
+        # Cisco XR resolves through the Cisco hardware/rulebook alias at runtime.
+        ("iosxr", "vlan %logic", "annet.rulebook.cisco.vlandb", "simple"),
+        ("asterfusioncli", "vlan * %logic", "annet.rulebook.generic.vlandb", "simple_no_tiny_ranges"),
+    ],
+)
+def test_vlan_database_logic_has_explicit_owner(ann_connectors, vendor, rule_prefix, expected_module, expected_name):
+    rb = rulebook.get_rulebook(make_hw_stub(vendor))
+    matching = [rule for raw_rule, rule in rb["patching"]["local"].items() if raw_rule.startswith(rule_prefix)]
+
+    assert len(matching) == 1
+    logic = matching[0]["attrs"]["logic"]
+    assert (logic.__module__, logic.__name__) == (expected_module, expected_name)


### PR DESCRIPTION
## Summary

Arista EOS can render multiple VLAN IDs and ranges in a single `vlan` command. Patching those rows atomically can remove or recreate VLANs that did not actually change.

This change adds range-aware Arista VLAN patching so additions and removals are calculated from the expanded VLAN IDs. It moves the shared VLAN database parsing and patch logic from the Cisco rulebook into `annet.rulebook.generic.vlandb`, updates existing non-Cisco consumers to use the generic module, and keeps Cisco-specific trunk handling in `cisco.vlandb.swtrunk`.

Tests cover Arista range additions, removals, mixed changes, VLAN child updates, shared range-collapsing behavior, and rulebook ownership.

## Patch example

VLAN diff:

```diff
- vlan 1000-1001,1003
+ vlan 1000-1001
```

Old patch:

```text
conf s
no vlan 1000-1001,1003
vlan 1000-1001
commit
write memory
```

New patch:

```text
conf s
no vlan 1003
commit
write memory