### PR TITLE
fix: prevent diff resorting for ordered block

### DIFF
--- a/annet/annlib/diff.py
+++ b/annet/annlib/diff.py
@@ -83,8 +83,11 @@ def diff_sort_key(diff_line: DiffItem) -> tuple[int, int]:
 
 def resort_diff(diff: Diff) -> Diff:
     res = []
-    df = sorted(diff, key=diff_sort_key)
-    for line in df:
+    # MOVED signals that the config block is ordered
+    # so we do not reshuffle it to reflect intended order
+    if not any(Op.MOVED in x for x in diff):
+        diff = sorted(diff, key=diff_sort_key)
+    for line in diff:
         ln = line
         if len(line[2]) > 0:
             ln = (line[0], line[1], resort_diff(line[2]), line[3])


### PR DESCRIPTION
Currently output of annet diff reshuffles commands showing first what is ADDED and then REMOVED.
This logic does not allow to analyze the resulting changes in ordered blocks.

Sadly there is no proper way to find if the block ordered or not in resort_diff. So the next best thing that comes to mind is just check if there is MOVED item in the diff.

This change only affects the output of diff and does not change how patch generated/applied.

Example of the change in the output: https://pastebin.com/hub1wWGE

