### PR TITLE
Preserve the original file inventory parsing error

### DIFF
--- a/annet/adapters/file/provider.py
+++ b/annet/adapters/file/provider.py
@@ -182,7 +182,7 @@ class Devices:
                     try:
                         dev = Device(dev=DeviceStorage(**dev_params))
                     except Exception as e:
-                        raise Exception(f"unable to parse {dev!r} as Device") from e
+                        raise Exception("unable to parse inventory entry as Device") from e
 
                 devices.append(dev)
 

--- a/tests/annet/test_fs_storage.py
+++ b/tests/annet/test_fs_storage.py
@@ -1,6 +1,7 @@
 import platform
 import sys
 import tempfile
+
 import pytest
 
 from annet.adapters.file.provider import FS, Device, StorageOpts

--- a/tests/annet/test_fs_storage.py
+++ b/tests/annet/test_fs_storage.py
@@ -46,3 +46,13 @@ def test_inventory_interfaces(tmp_path):
     assert device.interfaces[0].name == "Ethernet1"
     assert device.interfaces[0].description == "Managed by Annet"
     assert storage.make_devices(["empty.example.test"])[0].interfaces == []
+
+
+def test_invalid_inventory_preserves_cause(tmp_path):
+    import pytest
+
+    path = tmp_path / "inventory.yml"
+    path.write_text("devices: [{fqdn: switch.example.test}]\n")
+    with pytest.raises(Exception, match="unable to parse inventory entry") as error:
+        FS(StorageOpts(path=str(path)))
+    assert "unknown vendor" in str(error.value.__cause__)

--- a/tests/annet/test_fs_storage.py
+++ b/tests/annet/test_fs_storage.py
@@ -1,6 +1,7 @@
 import platform
 import sys
 import tempfile
+import pytest
 
 from annet.adapters.file.provider import FS, Device, StorageOpts
 
@@ -49,8 +50,6 @@ def test_inventory_interfaces(tmp_path):
 
 
 def test_invalid_inventory_preserves_cause(tmp_path):
-    import pytest
-
     path = tmp_path / "inventory.yml"
     path.write_text("devices: [{fqdn: switch.example.test}]\n")
     with pytest.raises(Exception, match="unable to parse inventory entry") as error:


### PR DESCRIPTION
Avoid referencing an unassigned or stale device when parsing an inventory entry fails. Keep the original exception as the cause and cover malformed inventory with a regression test.