### PR TITLE
Add CLI command plugins via entry points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 /build
 venv
 .venv
+.DS_Store

--- a/annet/annet.py
+++ b/annet/annet.py
@@ -22,7 +22,12 @@ def main() -> int:
     hardware.hardware_connector.set(hardware.AnnetHardwareProvider)
     diff.file_differ_connector.set(diff.UnifiedFileDiffer)
 
-    parser.add_commands(parser.find_subcommands(cli.list_subcommands()))
+    parser.add_commands(
+        [
+            *parser.find_subcommands(cli.list_subcommands()),
+            *parser.find_entry_point_commands(),
+        ]
+    )
     try:
         return cast(int, parser.dispatch(pre_call=annet.init, add_help_command=True))
     except (generators.GeneratorError, annet.ExecError) as e:

--- a/annet/argparse.py
+++ b/annet/argparse.py
@@ -8,7 +8,8 @@ import os
 import sys
 from collections.abc import Callable, Iterable, Iterator
 from functools import lru_cache
-from typing import Any, ContextManager, Generic, TypeVar, cast, overload
+from importlib.metadata import entry_points
+from typing import Any, ContextManager, Generic, NamedTuple, TypeVar, cast, overload
 
 from annet.connectors import Connector
 
@@ -318,6 +319,11 @@ class _DispatcherConnector(Connector[ArgDispatcher]):
 dispatcher_connector = _DispatcherConnector()
 
 
+class Command(NamedTuple):
+    func: Callable[..., Any]
+    name: str
+
+
 class ArgParser(argparse.ArgumentParser):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         if "formatter_class" not in kwargs:
@@ -328,21 +334,36 @@ class ArgParser(argparse.ArgumentParser):
     def argv(self) -> list[str]:
         return sys.argv[1:]
 
-    def add_commands(self, commands: Iterable[Callable[..., Any]]) -> None:
+    def add_commands(self, commands: Iterable[Callable[..., Any] | Command]) -> None:
         subparsers = self.add_subparsers()
-        pending = list(commands)
+        names: dict[Callable[..., Any], list[str]] = {}
+        for command in commands:
+            func, name = command if isinstance(command, Command) else (command, _get_meta(command).cmd_name)
+            aliases = names.setdefault(func, [])
+            if name in aliases:
+                raise ValueError(f"conflicting subparser: {name}")
+            aliases.append(name)
+        pending = [Command(func, aliases[0]) for func, aliases in names.items()]
         failcount = 0
         while pending and failcount < len(pending):
-            func, pending = pending[0], pending[1:]
-            if not self.add_func(func, subparsers):
-                pending.append(func)
+            registration, pending = pending[0], pending[1:]
+            if not self.add_func(registration, subparsers, aliases=names[registration.func][1:]):
+                pending.append(registration)
                 failcount += 1
             else:
                 failcount = 0
         if failcount:
             raise RuntimeError("Failed to resolve subparsers")
 
-    def add_func(self, func: Callable[..., Any], sub: argparse._SubParsersAction[Any]) -> bool:
+    def add_func(
+        self,
+        func: Callable[..., Any] | Command,
+        sub: argparse._SubParsersAction[Any],
+        aliases: list[str] | None = None,
+    ) -> bool:
+        name = None
+        if isinstance(func, Command):
+            func, name = func
         meta = _get_meta(func)
         parent = meta.parent
         if parent:
@@ -354,7 +375,7 @@ class ArgParser(argparse.ArgumentParser):
             assert parent_meta.sub is not None
             sub = parent_meta.sub
 
-        sp = sub.add_parser(meta.cmd_name, help=func.__doc__)
+        sp = sub.add_parser(name if name is not None else meta.cmd_name, aliases=aliases or [], help=func.__doc__)
         sp.set_defaults(func=func)
         meta.parser = sp
 
@@ -403,6 +424,20 @@ class ArgParser(argparse.ArgumentParser):
         for var in variables.values():
             if callable(var) and hasattr(var, _ARGS_ATTR_NAME):
                 yield var
+
+    @staticmethod
+    def find_entry_point_commands() -> Iterator[Command]:
+        for entry_point in entry_points(group="annet.commands"):
+            func = entry_point.load()
+            if not callable(func) or not hasattr(func, _ARGS_ATTR_NAME):
+                raise TypeError(
+                    f"Command entry point {entry_point.name!r} ({entry_point.value}) "
+                    "must reference a function decorated with @subcommand"
+                )
+            meta = _get_meta(func)
+            if entry_point.name == "help" and meta.parent is None:
+                raise ValueError("Command name 'help' is reserved")
+            yield Command(func, entry_point.name)
 
     @classmethod
     def func_opts(cls, func: Callable[..., Any]) -> Iterator[Arg[Any] | type[ArgGroup]]:

--- a/docs/usage/cli.rst
+++ b/docs/usage/cli.rst
@@ -5,6 +5,81 @@ Almost all annet calls expect hosts identifiers, like ``ann gen HOST1 HOST2``.
 These host identifiers are resolved by the storage adapter. For example, NetBox adapter supports for globs: ``myhost tag:mytag site:mysite`` - will search
 for a host with name ``myhost`` or hosts with tag ``mytag`` or hosts with site ``mysite``.
 
+CLI command plugins
+*******************
+
+An installed Python package can add a top-level annet command through the
+``annet.commands`` entry point group. The entry point name becomes the command
+name, and its value must reference a callable decorated with
+``annet.argparse.subcommand``.
+
+For example, a separate ``annet-example`` package can declare this entry point in
+``pyproject.toml``:
+
+.. code-block:: toml
+
+    [build-system]
+    requires = ["setuptools>=61"]
+    build-backend = "setuptools.build_meta"
+
+    [project]
+    name = "annet-example"
+    version = "0.1.0"
+    dependencies = ["annet"]
+
+    [project.entry-points."annet.commands"]
+    hello = "annet_example.cli:hello"
+
+The exported function uses the same ``Arg`` and ``ArgGroup`` interface as a
+built-in command:
+
+.. code-block:: python
+
+    from annet.argparse import Arg, subcommand
+
+
+    @subcommand(Arg("--name", default="world", help="Name to greet"))
+    def hello(name: str) -> None:
+        """Print a greeting."""
+        print(f"Hello, {name}!")
+
+After installing the package in the same Python environment as annet, the
+command is available as:
+
+.. code-block:: bash
+
+    annet hello --name Alice
+
+The command prints ``Hello, Alice!``.
+
+Annet discovers command plugins whenever it builds the CLI. It imports every
+entry point in the ``annet.commands`` group at that time. Keep expensive or
+optional imports inside the command handler so they run only when the command
+is invoked. Entry point import errors are propagated.
+Duplicate command names are rejected by ``argparse``, and the top-level name
+``help`` is reserved by annet.
+
+Command discovery works for any separately installed package that publishes an
+``annet.commands`` entry point; it does not depend on an annet extra. An extra
+is only an installation shortcut. After ``annet-example`` is published and its
+compatibility is verified, annet can add the following entry to its existing
+``extras_require`` in ``setup.py``:
+
+.. code-block:: python
+
+    extras_require={
+        "example": ["annet-example"],
+    },
+
+Users could then install both packages with:
+
+.. code-block:: bash
+
+    pip install 'annet[example]'
+
+The ``example`` extra is an example of future packaging configuration and is not
+currently declared by annet.
+
 annet gen
 ******************
 

--- a/tests/annet/test_cli.py
+++ b/tests/annet/test_cli.py
@@ -77,8 +77,7 @@ def test_command_name_conflict(monkeypatch: pytest.MonkeyPatch, name: str) -> No
 
 def test_plugin_aliases_preserve_builtin_name(monkeypatch: pytest.MonkeyPatch) -> None:
     entry_points = [
-        EntryPoint(name=name, value=f"{__name__}:hello_command", group="annet.commands")
-        for name in ("hello", "greet")
+        EntryPoint(name=name, value=f"{__name__}:hello_command", group="annet.commands") for name in ("hello", "greet")
     ]
     monkeypatch.setattr("annet.argparse.entry_points", Mock(return_value=entry_points))
     original_name = _get_meta(hello_command).cmd_name

--- a/tests/annet/test_cli.py
+++ b/tests/annet/test_cli.py
@@ -1,0 +1,122 @@
+from argparse import ArgumentError
+from importlib.metadata import EntryPoint
+from unittest.mock import Mock
+
+import pytest
+
+from annet.argparse import Arg, ArgParser, _get_meta, subcommand
+
+
+@subcommand(Arg("--name", default="world"))
+def hello_command(name: str) -> str:
+    """Say hello."""
+    return f"Hello, {name}!"
+
+
+@subcommand(is_group=True)
+def example_group() -> None:
+    """Example commands."""
+
+
+@subcommand(parent=example_group)
+def example_group_child() -> str:
+    """Example child command."""
+    return "child result"
+
+
+def test_plugin_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    entry_point = EntryPoint(name="hello", value=f"{__name__}:hello_command", group="annet.commands")
+    discover = Mock(return_value=[entry_point])
+    monkeypatch.setattr("annet.argparse.entry_points", discover)
+    parser = ArgParser()
+    parser.add_commands(parser.find_entry_point_commands())
+    monkeypatch.setattr(parser, "argv", lambda: ["hello", "--name", "Alice"])
+
+    assert parser.dispatch() == "Hello, Alice!"
+    assert "hello" in parser.format_help()
+    assert "Say hello." in parser.format_help()
+    discover.assert_called_once_with(group="annet.commands")
+
+
+def test_no_plugins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("annet.argparse.entry_points", Mock(return_value=[]))
+
+    assert list(ArgParser.find_entry_point_commands()) == []
+
+
+@pytest.mark.parametrize("value", [object(), lambda: None])
+def test_invalid_plugin(monkeypatch: pytest.MonkeyPatch, value: object) -> None:
+    entry_point = Mock(value="plugin:hello")
+    entry_point.name = "hello"
+    entry_point.load.return_value = value
+    monkeypatch.setattr("annet.argparse.entry_points", Mock(return_value=[entry_point]))
+
+    with pytest.raises(TypeError, match="decorated with @subcommand"):
+        list(ArgParser.find_entry_point_commands())
+
+
+def test_plugin_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    entry_point = Mock()
+    entry_point.load.side_effect = ImportError("Missing plugin dependency")
+    monkeypatch.setattr("annet.argparse.entry_points", Mock(return_value=[entry_point]))
+
+    with pytest.raises(ImportError, match="Missing plugin dependency"):
+        list(ArgParser.find_entry_point_commands())
+
+
+@pytest.mark.parametrize("name", ["hello", "help"])
+def test_command_name_conflict(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
+    entry_point = EntryPoint(name=name, value=f"{__name__}:hello_command", group="annet.commands")
+    monkeypatch.setattr("annet.argparse.entry_points", Mock(return_value=[entry_point]))
+    parser = ArgParser()
+
+    with pytest.raises((ValueError, ArgumentError), match="reserved|conflicting subparser"):
+        commands = list(parser.find_entry_point_commands())
+        parser.add_commands([*commands, *commands])
+
+
+def test_plugin_aliases_preserve_builtin_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    entry_points = [
+        EntryPoint(name=name, value=f"{__name__}:hello_command", group="annet.commands")
+        for name in ("hello", "greet")
+    ]
+    monkeypatch.setattr("annet.argparse.entry_points", Mock(return_value=entry_points))
+    original_name = _get_meta(hello_command).cmd_name
+    parser = ArgParser()
+    parser.add_commands([hello_command, *parser.find_entry_point_commands()])
+
+    assert _get_meta(hello_command).cmd_name == original_name
+    for name in (original_name, "hello", "greet"):
+        monkeypatch.setattr(parser, "argv", Mock(return_value=[name]))
+        assert parser.dispatch() == "Hello, world!"
+
+
+def test_plugin_conflicts_with_builtin(monkeypatch: pytest.MonkeyPatch) -> None:
+    entry_point = EntryPoint(name="hello-command", value=f"{__name__}:hello_command", group="annet.commands")
+    monkeypatch.setattr("annet.argparse.entry_points", Mock(return_value=[entry_point]))
+    parser = ArgParser()
+
+    with pytest.raises((ValueError, ArgumentError), match="conflicting subparser"):
+        parser.add_commands([hello_command, *parser.find_entry_point_commands()])
+
+
+def test_group_aliases(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    entry_points = [
+        EntryPoint(name=name, value=f"{__name__}:example_group", group="annet.commands")
+        for name in ("example", "alias")
+    ]
+    monkeypatch.setattr("annet.argparse.entry_points", Mock(return_value=entry_points))
+    parser = ArgParser()
+    parser.add_commands([example_group_child, *parser.find_entry_point_commands()])
+
+    for name in ("example", "alias"):
+        monkeypatch.setattr(parser, "argv", Mock(return_value=[name, "child"]))
+        assert parser.dispatch() == "child result"
+        monkeypatch.setattr(parser, "argv", Mock(return_value=[name, "--help"]))
+        with pytest.raises(SystemExit) as error:
+            parser.dispatch()
+        assert error.value.code == 0
+        assert "Example child command." in capsys.readouterr().out
+        monkeypatch.setattr(parser, "argv", Mock(return_value=[name]))
+        parser.dispatch()
+        assert "Example child command." in capsys.readouterr().out


### PR DESCRIPTION
Add CLI commands from installed packages through the `annet.commands` entry point group, reusing the existing subcommand API with support for groups and aliases.

Document plugin registration and cover discovery, dispatch, aliases, and name conflicts.

